### PR TITLE
refactor: address code review findings from PR #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.1] - 2026-04-07
+
+### Changed
+
+- Replace all custom `list_reverse` implementations with `list.reverse` from stdlib (14 modules)
+- `bignum.encode_int` now uses list accumulator instead of O(n^2) string concatenation
+- `bignum.count_leading_char` renamed to `count_leading_zeros_str` and uses `char_value` for zero alias handling (e.g. Crockford O->0)
+- Shared `find_index` extracted into `bignum` module; Base58 Bitcoin/Flickr deduplicated
+- `z85.list_to_string` uses `string.join` instead of recursive concatenation
+- `crockford.string_char_at` and `nopadding.find_char_pos` use `let assert` for unreachable branches
+- `verify-readme.sh` uses `trap` cleanup and indentation-safe grep patterns
+- Example comments clarified to note they do not produce real Bitcoin addresses
+
+### Fixed
+
+- Base91 EOF decode now flushes one final byte (matching C reference implementation)
+- `urlsafe_nopadding.decode` now reports the earliest invalid character, not just `=`
+- Crockford case-insensitive test was a tautology (compared same input to itself)
+- README `8-to-5 bit` compound modifier hyphenation corrected to `8-to-5-bit`
+
+### Added
+
+- `base58check` middle-position `InvalidCharacter` test
+
 ## [0.2.0] - 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ yabase supports the following [multibase](https://github.com/multiformats/multib
 
 ### Bech32 / Bech32m (BIP 173, BIP 350)
 
-Byte-payload convenience API. Takes raw bytes, handles 8-to-5 bit conversion internally, and produces the checksummed Bech32 string. Does not validate SegWit address semantics (witness version, program length):
+Byte-payload convenience API. Takes raw bytes, handles 8-to-5-bit conversion internally, and produces the checksummed Bech32 string. Does not validate SegWit address semantics (witness version, program length):
 
 ```gleam
 import yabase/bech32

--- a/examples/bitcoin_base58check.gleam
+++ b/examples/bitcoin_base58check.gleam
@@ -1,14 +1,16 @@
-/// Bitcoin Base58Check address encoding.
+/// Bitcoin Base58Check encoding demo.
 ///
 /// Base58Check prepends a version byte and appends a 4-byte SHA-256d
-/// checksum. Version 0x00 = mainnet P2PKH, 0x05 = mainnet P2SH.
+/// checksum. Version 0x00 is used for mainnet P2PKH (with a 20-byte
+/// hash160 payload), 0x05 for P2SH. This example uses a short payload
+/// for brevity, so the output is not a real Bitcoin address.
 import gleam/bit_array
 import gleam/int
 import gleam/io
 import yabase/base58check
 
 pub fn main() {
-  // Encode a payload with version byte 0 (mainnet P2PKH)
+  // Encode a short payload with version byte 0
   let payload = <<0xab, 0xcd, 0xef, 0x01, 0x23>>
   let assert Ok(encoded) = base58check.encode(0, payload)
   io.println("Base58Check: " <> encoded)

--- a/examples/bitcoin_bech32.gleam
+++ b/examples/bitcoin_bech32.gleam
@@ -1,15 +1,16 @@
-/// Bech32/Bech32m encoding for Bitcoin addresses (BIP 173 / BIP 350).
+/// Bech32/Bech32m encoding demo (BIP 173 / BIP 350).
 ///
 /// yabase's bech32 module is a byte-payload convenience API: it takes
 /// raw bytes, converts to 5-bit groups internally, and appends the
-/// checksum. SegWit address semantics (witness version, program length)
-/// are left to the caller.
+/// checksum. This example encodes an arbitrary byte payload with HRP "bc"
+/// and does NOT construct a valid Bitcoin SegWit address (no witness
+/// version/program semantics are applied).
 import gleam/io
 import yabase/bech32
 import yabase/core/encoding.{Bech32 as Bech32V, Bech32m as Bech32mV}
 
 pub fn main() {
-  // Bech32 encode with HRP "bc" (Bitcoin mainnet)
+  // Bech32 encode with HRP "bc" (arbitrary payload, not a SegWit address)
   let data = <<0, 14, 20, 15, 7, 28, 0, 15, 7, 4>>
   let assert Ok(encoded) = bech32.encode(Bech32V, "bc", data)
   io.println("Bech32:  " <> encoded)

--- a/scripts/verify-readme.sh
+++ b/scripts/verify-readme.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+cleanup() {
+  rm -f src/yabase/readme_snippet_*_.gleam
+}
+trap cleanup EXIT
+
 # Extract each ```gleam block from README.md as a separate module.
 # Blocks containing "pub fn" are kept as-is (complete modules).
 # Bare expression blocks are wrapped in a function.
@@ -17,12 +22,12 @@ while IFS= read -r line; do
   if [[ "$line" == '```' ]] && $in_block; then
     in_block=false
     f="src/yabase/readme_snippet_${n}_.gleam"
-    if echo "$tmp" | grep -q "^pub fn \|^fn "; then
+    if echo "$tmp" | grep -Eq '^[[:space:]]*(pub )?fn '; then
       echo "$tmp" > "$f"
     else
       # Separate import lines from body
-      imports=$(echo "$tmp" | grep "^import " || true)
-      body=$(echo "$tmp" | grep -v "^import " || true)
+      imports=$(echo "$tmp" | grep -E '^[[:space:]]*import ' || true)
+      body=$(echo "$tmp" | grep -Ev '^[[:space:]]*import ' || true)
       {
         echo "$imports"
         echo "pub fn readme_${n}_() {"
@@ -38,11 +43,5 @@ while IFS= read -r line; do
   fi
 done < README.md
 
-result=0
-gleam build --warnings-as-errors 2>&1 || result=$?
-rm -f src/yabase/readme_snippet_*_.gleam
-if [ $result -ne 0 ]; then
-  echo "ERROR: README code snippets failed to compile (or have warnings)"
-  exit 1
-fi
+gleam build --warnings-as-errors 2>&1
 echo "README snippets OK"

--- a/src/yabase/adobe_ascii85.gleam
+++ b/src/yabase/adobe_ascii85.gleam
@@ -17,7 +17,7 @@ pub fn encode(data: BitArray) -> String {
   prefix
   <> {
     encode_groups(data, [])
-    |> list_reverse_str
+    |> list.reverse
     |> string.join("")
   }
   <> suffix
@@ -171,10 +171,10 @@ fn collect_group(
   pos: Int,
 ) -> Result(#(List(Int), Int, String), CodecError) {
   case count >= 5 {
-    True -> Ok(#(list_reverse(acc), count, input))
+    True -> Ok(#(list.reverse(acc), count, input))
     False ->
       case string.pop_grapheme(input) {
-        Error(Nil) -> Ok(#(list_reverse(acc), count, ""))
+        Error(Nil) -> Ok(#(list.reverse(acc), count, ""))
         // Skip whitespace inside groups
         Ok(#(" ", rest)) -> collect_group(rest, acc, count, pos + 1)
         Ok(#("\t", rest)) -> collect_group(rest, acc, count, pos + 1)
@@ -187,28 +187,6 @@ fn collect_group(
             Ok(v) -> collect_group(rest, [v, ..acc], count + 1, pos + 1)
           }
       }
-  }
-}
-
-fn list_reverse(l: List(Int)) -> List(Int) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(Int), acc: List(Int)) -> List(Int) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
-  }
-}
-
-fn list_reverse_str(l: List(String)) -> List(String) {
-  list_reverse_str_acc(l, [])
-}
-
-fn list_reverse_str_acc(l: List(String), acc: List(String)) -> List(String) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_str_acc(t, [h, ..acc])
   }
 }
 

--- a/src/yabase/ascii85.gleam
+++ b/src/yabase/ascii85.gleam
@@ -12,7 +12,7 @@ import yabase/core/encoding.{
 /// Encode a BitArray to Ascii85.
 pub fn encode(data: BitArray) -> String {
   encode_groups(data, [])
-  |> list_reverse_str
+  |> list.reverse
   |> string.join("")
 }
 
@@ -37,17 +37,6 @@ fn encode_groups(data: BitArray, acc: List(String)) -> List(String) {
         _ -> acc
       }
     }
-  }
-}
-
-fn list_reverse_str(l: List(String)) -> List(String) {
-  list_reverse_str_acc(l, [])
-}
-
-fn list_reverse_str_acc(l: List(String), acc: List(String)) -> List(String) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_str_acc(t, [h, ..acc])
   }
 }
 
@@ -158,27 +147,16 @@ fn collect_group(
   pos: Int,
 ) -> Result(#(List(Int), Int, String), CodecError) {
   case count >= 5 {
-    True -> Ok(#(list_reverse_int(acc), count, input))
+    True -> Ok(#(list.reverse(acc), count, input))
     False ->
       case string.pop_grapheme(input) {
-        Error(Nil) -> Ok(#(list_reverse_int(acc), count, ""))
+        Error(Nil) -> Ok(#(list.reverse(acc), count, ""))
         Ok(#(c, rest)) ->
           case char_to_ascii85_value(c) {
             Error(_) -> Error(InvalidCharacter(c, pos))
             Ok(v) -> collect_group(rest, [v, ..acc], count + 1, pos + 1)
           }
       }
-  }
-}
-
-fn list_reverse_int(l: List(Int)) -> List(Int) {
-  list_reverse_int_acc(l, [])
-}
-
-fn list_reverse_int_acc(l: List(Int), acc: List(Int)) -> List(Int) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_int_acc(t, [h, ..acc])
   }
 }
 

--- a/src/yabase/base16.gleam
+++ b/src/yabase/base16.gleam
@@ -1,13 +1,14 @@
 /// Base16 (hexadecimal) encoding and decoding.
 import gleam/bit_array
 import gleam/int
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
 
 /// Encode a BitArray to a lowercase hexadecimal string.
 pub fn encode(data: BitArray) -> String {
   encode_bytes(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
 }
 
@@ -74,16 +75,5 @@ fn hex_char_to_int(c: String) -> Result(Int, Nil) {
     "e" -> Ok(14)
     "f" -> Ok(15)
     _ -> Error(Nil)
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }

--- a/src/yabase/base2.gleam
+++ b/src/yabase/base2.gleam
@@ -1,12 +1,13 @@
 /// Base2 encoding (binary string representation).
 /// Each byte is represented as 8 characters of "0" and "1".
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
 
 /// Encode a BitArray to a binary string (e.g. <<0x41>> -> "01000001").
 pub fn encode(data: BitArray) -> String {
   encode_bytes(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
 }
 
@@ -14,7 +15,12 @@ fn encode_bytes(data: BitArray, acc: List(String)) -> List(String) {
   case data {
     <<byte:8, rest:bits>> ->
       encode_bytes(rest, [encode_byte(byte, 7, ""), ..acc])
-    _ -> acc
+    <<>> -> acc
+    _ ->
+      // Non-byte-aligned tail: should not happen with normal BitArray input.
+      // Encode remaining bits would require padding semantics not defined
+      // for Base2, so we treat this as unreachable.
+      acc
   }
 }
 
@@ -85,16 +91,5 @@ fn decode_byte(
             _ -> Error(InvalidCharacter(c, pos))
           }
       }
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }

--- a/src/yabase/base32/clockwork.gleam
+++ b/src/yabase/base32/clockwork.gleam
@@ -3,6 +3,7 @@
 /// Alphabet: 0123456789ABCDEFGHJKMNPQRSTVWXYZ
 /// Decoding: o/O->0, i/I/l/L->1
 import gleam/bit_array
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
 
@@ -11,7 +12,7 @@ const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 /// Encode a BitArray to Clockwork Base32 (no padding).
 pub fn encode(data: BitArray) -> String {
   encode_bits(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
 }
 
@@ -105,16 +106,5 @@ fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
     Error(_) -> ""
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }

--- a/src/yabase/base32/crockford.gleam
+++ b/src/yabase/base32/crockford.gleam
@@ -102,8 +102,6 @@ fn char_to_value(c: String) -> Result(Int, Nil) {
 }
 
 fn string_char_at(s: String, index: Int) -> String {
-  case string.drop_start(s, index) |> string.pop_grapheme {
-    Ok(#(c, _)) -> c
-    Error(_) -> ""
-  }
+  let assert Ok(#(c, _)) = string.drop_start(s, index) |> string.pop_grapheme
+  c
 }

--- a/src/yabase/base32/hex.gleam
+++ b/src/yabase/base32/hex.gleam
@@ -1,5 +1,6 @@
 /// Base32 Hex encoding (RFC 4648, extended hex alphabet).
 import gleam/bit_array
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
 
@@ -10,7 +11,7 @@ const pad = "="
 /// Encode a BitArray to Base32 Hex string with padding.
 pub fn encode(data: BitArray) -> String {
   encode_bits(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
   |> add_padding
 }
@@ -152,16 +153,5 @@ fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
     Error(_) -> ""
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }

--- a/src/yabase/base32/rfc4648.gleam
+++ b/src/yabase/base32/rfc4648.gleam
@@ -1,5 +1,6 @@
 /// Base32 encoding per RFC 4648.
 import gleam/bit_array
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
 
@@ -10,7 +11,7 @@ const pad = "="
 /// Encode a BitArray to a Base32 string with padding.
 pub fn encode(data: BitArray) -> String {
   encode_bits(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
   |> add_padding
 }
@@ -161,16 +162,5 @@ fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
     Error(_) -> ""
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }

--- a/src/yabase/base32/zbase32.gleam
+++ b/src/yabase/base32/zbase32.gleam
@@ -3,6 +3,7 @@
 /// Alphabet: ybndrfg8ejkmcpqxot1uwisza345h769
 /// No padding.
 import gleam/bit_array
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
 
@@ -11,7 +12,7 @@ const alphabet = "ybndrfg8ejkmcpqxot1uwisza345h769"
 /// Encode a BitArray to z-base-32 (no padding).
 pub fn encode(data: BitArray) -> String {
   encode_bits(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
 }
 
@@ -81,16 +82,5 @@ fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
     Error(_) -> ""
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }

--- a/src/yabase/base45.gleam
+++ b/src/yabase/base45.gleam
@@ -1,6 +1,7 @@
 /// Base45 encoding per RFC 9285.
 /// Alphabet: 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:
 import gleam/bit_array
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{
   type CodecError, InvalidCharacter, InvalidLength, Overflow,
@@ -11,7 +12,7 @@ const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:"
 /// Encode a BitArray to Base45.
 pub fn encode(data: BitArray) -> String {
   encode_pairs(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
 }
 
@@ -101,27 +102,16 @@ fn take_chars_acc(
   acc: List(String),
 ) -> #(Result(List(String), Nil), String) {
   case n {
-    0 -> #(Ok(list_reverse(acc)), input)
+    0 -> #(Ok(list.reverse(acc)), input)
     _ ->
       case string.pop_grapheme(input) {
         Error(Nil) ->
           case acc {
             [] -> #(Error(Nil), "")
-            _ -> #(Ok(list_reverse(acc)), "")
+            _ -> #(Ok(list.reverse(acc)), "")
           }
         Ok(#(c, rest)) -> take_chars_acc(rest, n - 1, [c, ..acc])
       }
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }
 

--- a/src/yabase/base58/bitcoin.gleam
+++ b/src/yabase/base58/bitcoin.gleam
@@ -1,6 +1,5 @@
 /// Base58 encoding (Bitcoin alphabet).
 /// Alphabet: 123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz
-import gleam/string
 import yabase/core/encoding.{type CodecError}
 import yabase/internal/bignum
 
@@ -17,16 +16,5 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
 }
 
 fn char_value(c: String) -> Result(Int, Nil) {
-  find_index(alphabet, c, 0)
-}
-
-fn find_index(haystack: String, needle: String, idx: Int) -> Result(Int, Nil) {
-  case string.pop_grapheme(haystack) {
-    Error(Nil) -> Error(Nil)
-    Ok(#(c, rest)) ->
-      case c == needle {
-        True -> Ok(idx)
-        False -> find_index(rest, needle, idx + 1)
-      }
-  }
+  bignum.find_index(alphabet, c, 0)
 }

--- a/src/yabase/base58/flickr.gleam
+++ b/src/yabase/base58/flickr.gleam
@@ -1,7 +1,6 @@
 /// Base58 encoding (Flickr alphabet).
 /// Alphabet: 123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ
 /// Same as Bitcoin but with swapped upper/lower case.
-import gleam/string
 import yabase/core/encoding.{type CodecError}
 import yabase/internal/bignum
 
@@ -18,16 +17,5 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
 }
 
 fn char_value(c: String) -> Result(Int, Nil) {
-  find_index(alphabet, c, 0)
-}
-
-fn find_index(haystack: String, needle: String, idx: Int) -> Result(Int, Nil) {
-  case string.pop_grapheme(haystack) {
-    Error(Nil) -> Error(Nil)
-    Ok(#(c, rest)) ->
-      case c == needle {
-        True -> Ok(idx)
-        False -> find_index(rest, needle, idx + 1)
-      }
-  }
+  bignum.find_index(alphabet, c, 0)
 }

--- a/src/yabase/base64/dq.gleam
+++ b/src/yabase/base64/dq.gleam
@@ -18,7 +18,7 @@ const dq_pad = "・"
 /// Encode a BitArray to Base64 DQ (hiragana).
 pub fn encode(data: BitArray) -> String {
   encode_chunks(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
 }
 
@@ -142,16 +142,5 @@ fn find_index(
         True -> Ok(idx)
         False -> find_index(rest, needle, idx + 1)
       }
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }

--- a/src/yabase/base64/nopadding.gleam
+++ b/src/yabase/base64/nopadding.gleam
@@ -30,13 +30,12 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
 }
 
 fn find_char_pos(input: String, target: String, pos: Int) -> Int {
-  case string.pop_grapheme(input) {
-    Error(Nil) -> pos
-    Ok(#(c, rest)) ->
-      case c == target {
-        True -> pos
-        False -> find_char_pos(rest, target, pos + 1)
-      }
+  // Caller guarantees string.contains(input, target) is true,
+  // so Error(Nil) is unreachable.
+  let assert Ok(#(c, rest)) = string.pop_grapheme(input)
+  case c == target {
+    True -> pos
+    False -> find_char_pos(rest, target, pos + 1)
   }
 }
 

--- a/src/yabase/base64/standard.gleam
+++ b/src/yabase/base64/standard.gleam
@@ -1,5 +1,6 @@
 /// Standard Base64 encoding per RFC 4648.
 import gleam/bit_array
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
 
@@ -10,7 +11,7 @@ const pad = "="
 /// Encode a BitArray to standard Base64 with padding.
 pub fn encode(data: BitArray) -> String {
   encode_chunks(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
 }
 
@@ -26,17 +27,6 @@ fn encode_chunks(data: BitArray, acc: List(String)) -> List(String) {
     ]
     <<a:6, b:2>> -> [char_at(a) <> char_at(b * 16) <> pad <> pad, ..acc]
     _ -> acc
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }
 

--- a/src/yabase/base64/urlsafe.gleam
+++ b/src/yabase/base64/urlsafe.gleam
@@ -1,6 +1,7 @@
 /// URL-safe Base64 encoding (RFC 4648 section 5).
 /// Uses - instead of + and _ instead of /.
 import gleam/bit_array
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
 
@@ -11,7 +12,7 @@ const pad = "="
 /// Encode a BitArray to URL-safe Base64 with padding.
 pub fn encode(data: BitArray) -> String {
   encode_chunks(data, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
 }
 
@@ -130,17 +131,6 @@ fn char_at(index: Int) -> String {
   case string.drop_start(alphabet, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
     Error(_) -> ""
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }
 

--- a/src/yabase/base64/urlsafe_nopadding.gleam
+++ b/src/yabase/base64/urlsafe_nopadding.gleam
@@ -14,9 +14,10 @@ pub fn encode(data: BitArray) -> String {
 /// Length % 4 must be 0, 2, or 3 (never 1).
 /// Padding characters (=) are rejected.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
-  case string.contains(input, "=") {
-    True -> Error(InvalidCharacter("=", find_char_pos(input, "=", 0)))
-    False -> {
+  // Scan for the first invalid character (including "=") and report it
+  case find_first_invalid(input, 0) {
+    Ok(#(c, pos)) -> Error(InvalidCharacter(c, pos))
+    Error(Nil) -> {
       let len = string.length(input)
       case len % 4 {
         1 -> Error(InvalidLength(len))
@@ -29,14 +30,74 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
   }
 }
 
-fn find_char_pos(input: String, target: String, pos: Int) -> Int {
+fn find_first_invalid(input: String, pos: Int) -> Result(#(String, Int), Nil) {
   case string.pop_grapheme(input) {
-    Error(Nil) -> pos
+    Error(Nil) -> Error(Nil)
     Ok(#(c, rest)) ->
-      case c == target {
-        True -> pos
-        False -> find_char_pos(rest, target, pos + 1)
+      case is_urlsafe_base64_char(c) {
+        True -> find_first_invalid(rest, pos + 1)
+        False -> Ok(#(c, pos))
       }
+  }
+}
+
+fn is_urlsafe_base64_char(c: String) -> Bool {
+  case c {
+    "A"
+    | "B"
+    | "C"
+    | "D"
+    | "E"
+    | "F"
+    | "G"
+    | "H"
+    | "I"
+    | "J"
+    | "K"
+    | "L"
+    | "M"
+    | "N"
+    | "O"
+    | "P"
+    | "Q"
+    | "R"
+    | "S"
+    | "T"
+    | "U"
+    | "V"
+    | "W"
+    | "X"
+    | "Y"
+    | "Z" -> True
+    "a"
+    | "b"
+    | "c"
+    | "d"
+    | "e"
+    | "f"
+    | "g"
+    | "h"
+    | "i"
+    | "j"
+    | "k"
+    | "l"
+    | "m"
+    | "n"
+    | "o"
+    | "p"
+    | "q"
+    | "r"
+    | "s"
+    | "t"
+    | "u"
+    | "v"
+    | "w"
+    | "x"
+    | "y"
+    | "z" -> True
+    "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" -> True
+    "-" | "_" -> True
+    _ -> False
   }
 }
 

--- a/src/yabase/base91.gleam
+++ b/src/yabase/base91.gleam
@@ -6,6 +6,7 @@
 /// Uses Erlang bitwise operations via BitArray patterns to match
 /// the C reference implementation's unsigned integer semantics.
 import gleam/bit_array
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter}
 
@@ -14,7 +15,7 @@ const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789
 /// Encode a BitArray to Base91.
 pub fn encode(data: BitArray) -> String {
   encode_loop(data, 0, 0, [])
-  |> list_reverse
+  |> list.reverse
   |> string.join("")
 }
 
@@ -86,13 +87,13 @@ fn decode_loop(
     [] -> {
       let final_acc = case val != -1 {
         True -> {
+          // Flush one final byte from remaining bits (matches C reference)
           let combined = bor(queue, bsl(val, nbits))
-          let combined_nbits = nbits + 7
-          extract_bytes_from_queue(combined, combined_nbits, acc)
+          [band(combined, 255), ..acc]
         }
         False -> acc
       }
-      Ok(list_to_bit_array(list_reverse(final_acc), <<>>))
+      Ok(list_to_bit_array(list.reverse(final_acc), <<>>))
     }
     [c, ..rest] ->
       case char_index(c) {
@@ -172,17 +173,6 @@ fn find_in_graphemes(
         True -> Ok(idx)
         False -> find_in_graphemes(rest, needle, idx + 1)
       }
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }
 

--- a/src/yabase/bech32.gleam
+++ b/src/yabase/bech32.gleam
@@ -107,7 +107,7 @@ fn encode_variant(
               let all_values = list_append(data_values, checksum)
               let encoded_data =
                 values_to_chars(all_values, [])
-                |> list_reverse
+                |> list.reverse
                 |> string.join("")
               let result = lower_hrp <> "1" <> encoded_data
               // BIP 173: total length must not exceed 90
@@ -212,7 +212,7 @@ fn chars_to_values(
   pos: Int,
 ) -> Result(List(Int), CodecError) {
   case string.pop_grapheme(input) {
-    Error(Nil) -> Ok(list_reverse(acc))
+    Error(Nil) -> Ok(list.reverse(acc))
     Ok(#(c, rest)) ->
       case char_to_value(c) {
         Error(_) -> Error(InvalidCharacter(c, pos))
@@ -300,11 +300,11 @@ fn bytes_to_5bit_groups(data: BitArray) -> List(Int) {
 fn convert_bits(data: BitArray, acc: List(Int)) -> List(Int) {
   case data {
     <<group:5, rest:bits>> -> convert_bits(rest, [group, ..acc])
-    <<remaining:4>> -> list_reverse([remaining * 2, ..acc])
-    <<remaining:3>> -> list_reverse([remaining * 4, ..acc])
-    <<remaining:2>> -> list_reverse([remaining * 8, ..acc])
-    <<remaining:1>> -> list_reverse([remaining * 16, ..acc])
-    _ -> list_reverse(acc)
+    <<remaining:4>> -> list.reverse([remaining * 2, ..acc])
+    <<remaining:3>> -> list.reverse([remaining * 4, ..acc])
+    <<remaining:2>> -> list.reverse([remaining * 8, ..acc])
+    <<remaining:1>> -> list.reverse([remaining * 16, ..acc])
+    _ -> list.reverse(acc)
   }
 }
 
@@ -367,7 +367,7 @@ fn groups_to_bit_array(groups: List(Int), acc: BitArray) -> BitArray {
 fn extract_bytes(bits: BitArray, acc: List(Int)) -> List(Int) {
   case bits {
     <<byte:8, rest:bits>> -> extract_bytes(rest, [byte, ..acc])
-    _ -> list_reverse(acc)
+    _ -> list.reverse(acc)
   }
 }
 
@@ -423,17 +423,6 @@ fn list_to_bit_array(bytes: List(Int), acc: BitArray) -> BitArray {
   case bytes {
     [] -> acc
     [b, ..rest] -> list_to_bit_array(rest, bit_array.append(acc, <<b:int>>))
-  }
-}
-
-fn list_reverse(l: List(a)) -> List(a) {
-  list_reverse_acc(l, [])
-}
-
-fn list_reverse_acc(l: List(a), acc: List(a)) -> List(a) {
-  case l {
-    [] -> acc
-    [h, ..t] -> list_reverse_acc(t, [h, ..acc])
   }
 }
 

--- a/src/yabase/internal/bignum.gleam
+++ b/src/yabase/internal/bignum.gleam
@@ -34,10 +34,20 @@ pub fn count_leading_zeros(data: BitArray, count: Int) -> Int {
   }
 }
 
-/// Count leading occurrences of a specific character in a string.
-pub fn count_leading_char(input: String, char: String, count: Int) -> Int {
+/// Count leading zero-valued characters in a string.
+/// Uses the provided char_value function to check if a character maps to 0,
+/// so zero aliases (e.g. Crockford O->0) are correctly counted.
+pub fn count_leading_zeros_str(
+  input: String,
+  char_value: fn(String) -> Result(Int, Nil),
+  count: Int,
+) -> Int {
   case string.pop_grapheme(input) {
-    Ok(#(c, rest)) if c == char -> count_leading_char(rest, char, count + 1)
+    Ok(#(c, rest)) ->
+      case char_value(c) {
+        Ok(0) -> count_leading_zeros_str(rest, char_value, count + 1)
+        _ -> count
+      }
     _ -> count
   }
 }
@@ -51,13 +61,18 @@ pub fn list_to_bit_array(bytes: List(Int), acc: BitArray) -> BitArray {
 }
 
 /// Encode a big integer in the given radix using the given alphabet string.
-pub fn encode_int(num: Int, radix: Int, alphabet: String, acc: String) -> String {
+pub fn encode_int(
+  num: Int,
+  radix: Int,
+  alphabet: String,
+  acc: List(String),
+) -> List(String) {
   case num {
     0 -> acc
     _ -> {
       let remainder = num % radix
       let char = string_char_at(alphabet, remainder)
-      encode_int(num / radix, radix, alphabet, char <> acc)
+      encode_int(num / radix, radix, alphabet, [char, ..acc])
     }
   }
 }
@@ -93,7 +108,8 @@ pub fn encode(data: BitArray, radix: Int, alphabet: String) -> String {
       case num {
         0 -> string.repeat(zero_char, lz)
         _ ->
-          string.repeat(zero_char, lz) <> encode_int(num, radix, alphabet, "")
+          string.repeat(zero_char, lz)
+          <> string.join(encode_int(num, radix, alphabet, []), "")
       }
     }
   }
@@ -104,13 +120,13 @@ pub fn encode(data: BitArray, radix: Int, alphabet: String) -> String {
 pub fn decode(
   input: String,
   radix: Int,
-  zero_char: String,
+  _zero_char: String,
   char_value: fn(String) -> Result(Int, Nil),
 ) -> Result(BitArray, CodecError) {
   case input {
     "" -> Ok(<<>>)
     _ -> {
-      let leading_zeros = count_leading_char(input, zero_char, 0)
+      let leading_zeros = count_leading_zeros_str(input, char_value, 0)
       case string_to_int(input, radix, char_value, 0, 0) {
         Error(e) -> Error(e)
         Ok(num) -> {
@@ -121,6 +137,22 @@ pub fn decode(
         }
       }
     }
+  }
+}
+
+/// Look up a character's index in an alphabet string.
+pub fn find_index(
+  haystack: String,
+  needle: String,
+  idx: Int,
+) -> Result(Int, Nil) {
+  case string.pop_grapheme(haystack) {
+    Error(Nil) -> Error(Nil)
+    Ok(#(c, rest)) ->
+      case c == needle {
+        True -> Ok(idx)
+        False -> find_index(rest, needle, idx + 1)
+      }
   }
 }
 

--- a/src/yabase/z85.gleam
+++ b/src/yabase/z85.gleam
@@ -2,6 +2,7 @@
 /// Alphabet: 0-9, a-z, A-Z, ., -, :, +, =, ^, !, /, *, ?, &, <, >, (, ), [, ], {, }, @, %, $, #
 /// Input length for encode MUST be a multiple of 4.
 import gleam/bit_array
+import gleam/list
 import gleam/string
 import yabase/core/encoding.{
   type CodecError, InvalidCharacter, InvalidLength, Overflow,
@@ -17,7 +18,7 @@ pub fn encode(data: BitArray) -> Result(String, CodecError) {
     0 ->
       Ok(
         encode_groups(data, [])
-        |> reverse_strings
+        |> list.reverse
         |> string.join(""),
       )
     _ -> Error(InvalidLength(len))
@@ -46,10 +47,7 @@ fn encode_u32(n: Int, count: Int, acc: List(String)) -> List(String) {
 }
 
 fn list_to_string(chars: List(String)) -> String {
-  case chars {
-    [] -> ""
-    [c, ..rest] -> c <> list_to_string(rest)
-  }
+  string.join(chars, "")
 }
 
 /// Decode a Z85 string to a BitArray.
@@ -94,7 +92,7 @@ fn take_n(
   acc: List(String),
 ) -> Result(#(List(String), String), Nil) {
   case n {
-    0 -> Ok(#(reverse_strings(acc), input))
+    0 -> Ok(#(list.reverse(acc), input))
     _ ->
       case string.pop_grapheme(input) {
         Error(Nil) ->
@@ -104,17 +102,6 @@ fn take_n(
           }
         Ok(#(c, rest)) -> take_n(rest, n - 1, [c, ..acc])
       }
-  }
-}
-
-fn reverse_strings(l: List(String)) -> List(String) {
-  reverse_strings_acc(l, [])
-}
-
-fn reverse_strings_acc(l: List(String), acc: List(String)) -> List(String) {
-  case l {
-    [] -> acc
-    [h, ..t] -> reverse_strings_acc(t, [h, ..acc])
   }
 }
 

--- a/test/base32_test.gleam
+++ b/test/base32_test.gleam
@@ -274,7 +274,7 @@ pub fn crockford_decode_i_l_as_one_test() {
 }
 
 pub fn crockford_decode_case_insensitive_test() {
-  assert crockford.decode("21") == crockford.decode("21")
+  assert crockford.decode("2a") == crockford.decode("2A")
   assert crockford.decode("zz") == crockford.decode("ZZ")
 }
 

--- a/test/base58check_test.gleam
+++ b/test/base58check_test.gleam
@@ -128,6 +128,10 @@ pub fn decode_invalid_char_lowercase_l_test() {
   assert base58check.decode("l") == Error(InvalidCharacter("l", 0))
 }
 
+pub fn decode_invalid_char_middle_test() {
+  assert base58check.decode("111O1111") == Error(InvalidCharacter("O", 3))
+}
+
 // === Cross-reference: bitcoinjs/bs58check fixtures ===
 // Source: https://github.com/bitcoinjs/bs58check
 


### PR DESCRIPTION
## Summary

- Replace all 14 custom `list_reverse` implementations with `list.reverse` from stdlib across encoder modules
- Fix `bignum.encode_int` O(n^2) string concatenation by switching to list accumulator
- Fix `bignum.count_leading_char` to use `char_value` function so zero aliases (e.g. Crockford O->0) are correctly counted
- Extract shared `find_index` into `bignum` module, removing duplication from `bitcoin.gleam` / `flickr.gleam`
- Fix `base91` EOF decode branch to flush one final byte (matching C reference implementation)
- Fix `urlsafe_nopadding` decode to scan for and report the earliest invalid character, not just `=`
- Fix `crockford.string_char_at` and `nopadding.find_char_pos` to use `let assert` instead of silently returning fallback values
- Fix `z85.list_to_string` to use `string.join` instead of recursive concatenation
- Add `trap` cleanup and indentation-safe grep patterns to `verify-readme.sh`
- Clarify example comments to note they do not produce real Bitcoin addresses
- Fix crockford case-insensitive test tautology, add `base58check` middle-position `InvalidCharacter` test
- Fix README `8-to-5-bit` compound modifier hyphenation

## Test plan

- [x] `gleam test` passes all 567 tests
- [x] `just ci` passes (format, build, test, verify-examples, verify-readme)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Base91 decoding now correctly flushes final bytes at end-of-input
  * URL-safe Base64 decoding reports the earliest invalid character position
  * Fixed Crockford Base32 case-insensitivity test accuracy

* **Documentation**
  * Clarified example outputs do not generate real Bitcoin addresses
  * Updated README formatting in Bech32/Bech32m section

* **Tests**
  * Added Base58Check test for invalid character detection in middle of input

<!-- end of auto-generated comment: release notes by coderabbit.ai -->