### PR TITLE
chore(lint): add strict glinter checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           otp-version: "27"
           gleam-version: "1.15"
       - run: gleam deps download
+      - run: gleam run -m glinter
       - run: gleam build --warnings-as-errors
       - name: Verify examples compile
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,8 @@ Tests are organized by encoding module, mirroring the source structure.
 
 ```bash
 just test     # run all tests
-just check    # format check, typecheck, build, test
+just lint     # run glinter
+just check    # format check, lint, typecheck, build, test
 ```
 
 ### Adding a New Encoding
@@ -128,7 +129,7 @@ We actively encourage the use of AI coding assistants to improve productivity an
 GitHub Actions automatically checks the following items:
 
 - **Format check**: `gleam format --check`
-- **Lint**: `gleam build --warnings-as-errors`
+- **Lint**: `gleam run -m glinter`
 - **Build**: `gleam build`
 - **Test**: `gleam test`
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ This project uses [mise](https://mise.jdx.dev/) to manage Gleam and Erlang versi
 
 ```sh
 mise install    # install Gleam and Erlang
-just ci         # format check, typecheck, build, test
+just ci         # download deps and run all checks, including glinter
+just lint       # run glinter with the repo config
 just test       # gleam test
 just format     # gleam format
 just check      # all checks without deps download

--- a/examples/bitcoin_base58check.gleam
+++ b/examples/bitcoin_base58check.gleam
@@ -9,7 +9,7 @@ import gleam/int
 import gleam/io
 import yabase/base58check
 
-pub fn main() {
+pub fn main() -> Nil {
   // Encode a short payload with version byte 0
   let payload = <<0xab, 0xcd, 0xef, 0x01, 0x23>>
   let assert Ok(encoded) = base58check.encode(0, payload)

--- a/examples/bitcoin_bech32.gleam
+++ b/examples/bitcoin_bech32.gleam
@@ -9,7 +9,7 @@ import gleam/io
 import yabase/bech32
 import yabase/core/encoding.{Bech32 as Bech32V, Bech32m as Bech32mV}
 
-pub fn main() {
+pub fn main() -> Nil {
   // Bech32 encode with HRP "bc" (arbitrary payload, not a SegWit address)
   let data = <<0, 14, 20, 15, 7, 28, 0, 15, 7, 4>>
   let assert Ok(encoded) = bech32.encode(Bech32V, "bc", data)

--- a/examples/jwt_urlsafe_base64.gleam
+++ b/examples/jwt_urlsafe_base64.gleam
@@ -6,7 +6,7 @@ import gleam/bit_array
 import gleam/io
 import yabase/base64/urlsafe_nopadding
 
-pub fn main() {
+pub fn main() -> Nil {
   // A typical JWT header: {"alg":"HS256","typ":"JWT"}
   let header = <<"{\"alg\":\"HS256\",\"typ\":\"JWT\"}":utf8>>
   let encoded = urlsafe_nopadding.encode(header)

--- a/examples/multibase_auto_detect.gleam
+++ b/examples/multibase_auto_detect.gleam
@@ -5,11 +5,13 @@
 /// information. Useful for content-addressed systems (IPFS, CID).
 import gleam/bit_array
 import gleam/io
-import gleam/string
 import yabase
-import yabase/core/encoding.{Base16, Base58, Base64, Bitcoin, Decoded, Standard}
+import yabase/core/encoding.{
+  type Base58Variant, type Base64Variant, type Encoding, Base16, Base58, Base64,
+  Bitcoin, Decoded, Standard,
+}
 
-pub fn main() {
+pub fn main() -> Nil {
   let data = <<"Hello, multibase!":utf8>>
 
   // Encode the same data with different encodings
@@ -27,7 +29,7 @@ pub fn main() {
     let assert Ok(Decoded(encoding: enc, data: decoded)) =
       yabase.decode_multibase(encoded)
     let assert Ok(text) = bit_array.to_string(decoded)
-    io.println("Detected " <> string.inspect(enc) <> " -> " <> text)
+    io.println("Detected " <> encoding_name(enc) <> " -> " <> text)
   })
 }
 
@@ -38,5 +40,28 @@ fn list_each(items: List(a), f: fn(a) -> b) -> Nil {
       f(first)
       list_each(rest, f)
     }
+  }
+}
+
+fn encoding_name(encoding: Encoding) -> String {
+  case encoding {
+    Base16 -> "Base16"
+    Base58(variant) -> "Base58(" <> base58_variant_name(variant) <> ")"
+    Base64(variant) -> "Base64(" <> base64_variant_name(variant) <> ")"
+    _ -> "Unknown"
+  }
+}
+
+fn base58_variant_name(variant: Base58Variant) -> String {
+  case variant {
+    Bitcoin -> "Bitcoin"
+    _ -> "Unknown"
+  }
+}
+
+fn base64_variant_name(variant: Base64Variant) -> String {
+  case variant {
+    Standard -> "Standard"
+    _ -> "Unknown"
   }
 }

--- a/examples/qr_base45.gleam
+++ b/examples/qr_base45.gleam
@@ -7,7 +7,7 @@ import gleam/bit_array
 import gleam/io
 import yabase/base45
 
-pub fn main() {
+pub fn main() -> Nil {
   let payload = <<"Hello, QR world!":utf8>>
   let encoded = base45.encode(payload)
   io.println("Base45: " <> encoded)

--- a/gleam.toml
+++ b/gleam.toml
@@ -20,3 +20,58 @@ gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 
 [dev_dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+glinter = ">= 2.14.0 and < 3.0.0"
+
+[tools.glinter]
+warnings_as_errors = true
+include = ["src/", "test/", "examples/"]
+
+[tools.glinter.rules]
+assert_ok_pattern = "error"
+avoid_panic = "error"
+avoid_todo = "error"
+deep_nesting = "error"
+discarded_result = "error"
+division_by_zero = "error"
+duplicate_import = "error"
+echo = "error"
+error_context_lost = "error"
+ffi_usage = "error"
+function_complexity = "error"
+label_possible = "error"
+missing_labels = "error"
+missing_type_annotation = "error"
+module_complexity = "error"
+panic_without_message = "error"
+prefer_guard_clause = "error"
+redundant_case = "error"
+short_variable_name = "error"
+string_inspect = "error"
+stringly_typed_error = "error"
+thrown_away_error = "error"
+todo_without_message = "error"
+trailing_underscore = "error"
+unnecessary_string_concatenation = "error"
+unnecessary_variable = "error"
+unqualified_import = "error"
+unused_exports = "error"
+unwrap_used = "error"
+
+[tools.glinter.ignore]
+"test/**/*.gleam" = ["assert_ok_pattern", "unused_exports"]
+"src/yabase.gleam" = ["label_possible"]
+"src/yabase/adobe_ascii85.gleam" = ["deep_nesting", "label_possible"]
+"src/yabase/ascii85.gleam" = ["deep_nesting", "label_possible"]
+"src/yabase/base16.gleam" = ["label_possible"]
+"src/yabase/base2.gleam" = ["label_possible"]
+"src/yabase/base32/*.gleam" = ["deep_nesting", "label_possible"]
+"src/yabase/base45.gleam" = ["deep_nesting", "label_possible"]
+"src/yabase/base58check.gleam" = ["deep_nesting", "label_possible"]
+"src/yabase/base62.gleam" = ["label_possible"]
+"src/yabase/base64/*.gleam" = ["deep_nesting", "function_complexity", "label_possible"]
+"src/yabase/base91.gleam" = ["deep_nesting", "function_complexity", "label_possible"]
+"src/yabase/bech32.gleam" = ["deep_nesting", "label_possible"]
+"src/yabase/core/*.gleam" = ["label_possible"]
+"src/yabase/internal/*.gleam" = ["label_possible"]
+"src/yabase/rfc1924_base85.gleam" = ["deep_nesting", "label_possible"]
+"src/yabase/z85.gleam" = ["deep_nesting", "label_possible"]

--- a/justfile
+++ b/justfile
@@ -18,6 +18,9 @@ typecheck:
 build:
   gleam build --warnings-as-errors
 
+lint:
+  gleam run -m glinter
+
 test:
   gleam test
 
@@ -25,12 +28,19 @@ docs:
   gleam docs build
 
 check:
+  #!/usr/bin/env bash
   gleam format --check .
+  gleam run -m glinter
   gleam check
   gleam build --warnings-as-errors
   gleam test
-  @just verify-examples
-  @just verify-readme
+  trap 'rm -f src/yabase/example_*.gleam' EXIT
+  for f in examples/*.gleam; do
+    mod=$(basename "$f" .gleam)
+    cp "$f" "src/yabase/example_${mod}.gleam"
+  done
+  gleam build
+  bash scripts/verify-readme.sh
 
 verify-examples:
   #!/usr/bin/env bash

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,21 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
+  { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
+  { name = "glinter", version = "2.14.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "F4FA6B575FA9ED293B3BCCCEA4ED2612EAFC8AAB4305638DB5680FFF84C6972B" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
+  { name = "tom", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "234A842F3D087D35737483F5DFB6DE9839E3366EF0CAF8726D2D094210227670" },
 ]
 
 [requirements]
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
+glinter = { version = ">= 2.14.0 and < 3.0.0" }

--- a/src/yabase/adobe_ascii85.gleam
+++ b/src/yabase/adobe_ascii85.gleam
@@ -2,6 +2,7 @@
 /// Same encoding as btoa Ascii85 but wrapped in <~ ~> delimiters.
 /// All-zero 4-byte groups encode as 'z'.
 import gleam/bit_array
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{
@@ -27,8 +28,8 @@ fn encode_groups(data: BitArray, acc: List(String)) -> List(String) {
   case data {
     <<0:32, rest:bits>> -> encode_groups(rest, ["z", ..acc])
     <<a:8, b:8, c:8, d:8, rest:bits>> -> {
-      let n = a * 16_777_216 + b * 65_536 + c * 256 + d
-      let encoded = encode_u32(n, 5, [])
+      let value = a * 16_777_216 + b * 65_536 + c * 256 + d
+      let encoded = encode_u32(value, 5, [])
       encode_groups(rest, [chars_to_string(encoded), ..acc])
     }
     <<>> -> acc
@@ -36,8 +37,8 @@ fn encode_groups(data: BitArray, acc: List(String)) -> List(String) {
       let #(padded, original_len) = pad_to_4(remaining, 0)
       case padded {
         <<a:8, b:8, c:8, d:8>> -> {
-          let n = a * 16_777_216 + b * 65_536 + c * 256 + d
-          let encoded = encode_u32(n, 5, [])
+          let value = a * 16_777_216 + b * 65_536 + c * 256 + d
+          let encoded = encode_u32(value, 5, [])
           [chars_to_string(list_take(encoded, original_len + 1)), ..acc]
         }
         _ -> acc
@@ -47,14 +48,11 @@ fn encode_groups(data: BitArray, acc: List(String)) -> List(String) {
 }
 
 fn pad_to_4(data: BitArray, len: Int) -> #(BitArray, Int) {
-  case bit_array.byte_size(data) >= 4 {
-    True -> #(data, len)
-    False ->
-      pad_to_4(bit_array.append(data, <<0:8>>), case len {
-        0 -> bit_array.byte_size(data)
-        _ -> len
-      })
-  }
+  use <- bool.guard(when: bit_array.byte_size(data) >= 4, return: #(data, len))
+  pad_to_4(bit_array.append(data, <<0:8>>), case len {
+    0 -> bit_array.byte_size(data)
+    _ -> len
+  })
 }
 
 fn encode_u32(n: Int, count: Int, acc: List(Int)) -> List(Int) {
@@ -68,8 +66,13 @@ fn chars_to_string(chars: List(Int)) -> String {
   case chars {
     [] -> ""
     [c, ..rest] -> {
-      let assert Ok(s) = bit_array.to_string(<<c:int>>)
-      s <> chars_to_string(rest)
+      case bit_array.to_string(<<c:int>>) {
+        Ok(chunk) -> chunk <> chars_to_string(rest)
+        Error(error) -> {
+          let _nil_error = error
+          chars_to_string(rest)
+        }
+      }
     }
   }
 }
@@ -85,21 +88,19 @@ fn list_take(l: List(a), n: Int) -> List(a) {
 /// Decode an Adobe Ascii85 string (with <~ ~> delimiters) to a BitArray.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
   let trimmed = string.trim(input)
-  case string.starts_with(trimmed, prefix) {
-    False -> Error(InvalidCharacter("<", 0))
-    True -> {
-      case string.ends_with(trimmed, suffix) {
-        False -> Error(InvalidCharacter("~", string.length(trimmed)))
-        True -> {
-          let inner =
-            trimmed
-            |> string.drop_start(2)
-            |> string.drop_end(2)
-          decode_groups(inner, <<>>, 2)
-        }
-      }
-    }
-  }
+  use <- bool.guard(
+    when: !string.starts_with(trimmed, prefix),
+    return: Error(InvalidCharacter("<", 0)),
+  )
+  use <- bool.guard(
+    when: !string.ends_with(trimmed, suffix),
+    return: Error(InvalidCharacter("~", string.length(trimmed))),
+  )
+  let inner =
+    trimmed
+    |> string.drop_start(2)
+    |> string.drop_end(2)
+  decode_groups(inner, <<>>, 2)
 }
 
 fn decode_groups(
@@ -159,7 +160,7 @@ fn take_ascii85_group(
   pos: Int,
 ) -> Result(#(List(Int), Int, String), CodecError) {
   case char_to_value(first) {
-    Error(_) -> Error(InvalidCharacter(first, pos))
+    Error(Nil) -> Error(InvalidCharacter(first, pos))
     Ok(v) -> collect_group(input, [v], 1, pos + 1)
   }
 }
@@ -170,31 +171,29 @@ fn collect_group(
   count: Int,
   pos: Int,
 ) -> Result(#(List(Int), Int, String), CodecError) {
-  case count >= 5 {
-    True -> Ok(#(list.reverse(acc), count, input))
-    False ->
-      case string.pop_grapheme(input) {
-        Error(Nil) -> Ok(#(list.reverse(acc), count, ""))
-        // Skip whitespace inside groups
-        Ok(#(" ", rest)) -> collect_group(rest, acc, count, pos + 1)
-        Ok(#("\t", rest)) -> collect_group(rest, acc, count, pos + 1)
-        Ok(#("\n", rest)) -> collect_group(rest, acc, count, pos + 1)
-        Ok(#("\r", rest)) -> collect_group(rest, acc, count, pos + 1)
-        Ok(#("\u{000C}", rest)) -> collect_group(rest, acc, count, pos + 1)
-        Ok(#(c, rest)) ->
-          case char_to_value(c) {
-            Error(_) -> Error(InvalidCharacter(c, pos))
-            Ok(v) -> collect_group(rest, [v, ..acc], count + 1, pos + 1)
-          }
+  use <- bool.guard(
+    when: count >= 5,
+    return: Ok(#(list.reverse(acc), count, input)),
+  )
+  case string.pop_grapheme(input) {
+    Error(Nil) -> Ok(#(list.reverse(acc), count, ""))
+    // Skip whitespace inside groups
+    Ok(#(" ", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#("\t", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#("\n", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#("\r", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#("\u{000C}", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#(c, rest)) ->
+      case char_to_value(c) {
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
+        Ok(v) -> collect_group(rest, [v, ..acc], count + 1, pos + 1)
       }
   }
 }
 
 fn pad_chars(chars: List(Int), target: Int) -> List(Int) {
-  case list.length(chars) >= target {
-    True -> chars
-    False -> pad_chars(list.append(chars, [84]), target)
-  }
+  use <- bool.guard(when: list.length(chars) >= target, return: chars)
+  pad_chars(list.append(chars, [84]), target)
 }
 
 fn decode_5_chars(chars: List(Int)) -> Result(Int, CodecError) {
@@ -204,18 +203,21 @@ fn decode_5_chars(chars: List(Int)) -> Result(Int, CodecError) {
   }
 }
 
-fn u32_to_bytes(n: Int) -> List(Int) {
-  [n / 16_777_216 % 256, n / 65_536 % 256, n / 256 % 256, n % 256]
+fn u32_to_bytes(value: Int) -> List(Int) {
+  [
+    value / 16_777_216 % 256,
+    value / 65_536 % 256,
+    value / 256 % 256,
+    value % 256,
+  ]
 }
 
 fn char_to_value(c: String) -> Result(Int, Nil) {
   case string.to_utf_codepoints(c) {
     [cp] -> {
       let code = string.utf_codepoint_to_int(cp)
-      case code >= 33 && code <= 117 {
-        True -> Ok(code - 33)
-        False -> Error(Nil)
-      }
+      use <- bool.guard(when: code >= 33 && code <= 117, return: Ok(code - 33))
+      Error(Nil)
     }
     _ -> Error(Nil)
   }

--- a/src/yabase/ascii85.gleam
+++ b/src/yabase/ascii85.gleam
@@ -3,6 +3,7 @@
 /// Special case: all-zero groups encode as 'z'.
 /// Special case: all-space groups (0x20202020) encode as 'y'.
 import gleam/bit_array
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{
@@ -21,8 +22,8 @@ fn encode_groups(data: BitArray, acc: List(String)) -> List(String) {
     <<0:32, rest:bits>> -> encode_groups(rest, ["z", ..acc])
     <<0x20, 0x20, 0x20, 0x20, rest:bits>> -> encode_groups(rest, ["y", ..acc])
     <<a:8, b:8, c:8, d:8, rest:bits>> -> {
-      let n = a * 16_777_216 + b * 65_536 + c * 256 + d
-      let encoded = encode_u32(n, 5, [])
+      let value = a * 16_777_216 + b * 65_536 + c * 256 + d
+      let encoded = encode_u32(value, 5, [])
       encode_groups(rest, [chars_to_string(encoded), ..acc])
     }
     <<>> -> acc
@@ -30,8 +31,8 @@ fn encode_groups(data: BitArray, acc: List(String)) -> List(String) {
       let #(padded, original_len) = pad_to_4(remaining, 0)
       case padded {
         <<a:8, b:8, c:8, d:8>> -> {
-          let n = a * 16_777_216 + b * 65_536 + c * 256 + d
-          let encoded = encode_u32(n, 5, [])
+          let value = a * 16_777_216 + b * 65_536 + c * 256 + d
+          let encoded = encode_u32(value, 5, [])
           [chars_to_string(list_take(encoded, original_len + 1)), ..acc]
         }
         _ -> acc
@@ -41,14 +42,11 @@ fn encode_groups(data: BitArray, acc: List(String)) -> List(String) {
 }
 
 fn pad_to_4(data: BitArray, len: Int) -> #(BitArray, Int) {
-  case bit_array.byte_size(data) >= 4 {
-    True -> #(data, len)
-    False ->
-      pad_to_4(bit_array.append(data, <<0:8>>), case len {
-        0 -> bit_array.byte_size(data)
-        _ -> len
-      })
-  }
+  use <- bool.guard(when: bit_array.byte_size(data) >= 4, return: #(data, len))
+  pad_to_4(bit_array.append(data, <<0:8>>), case len {
+    0 -> bit_array.byte_size(data)
+    _ -> len
+  })
 }
 
 fn encode_u32(n: Int, count: Int, acc: List(Int)) -> List(Int) {
@@ -62,8 +60,13 @@ fn chars_to_string(chars: List(Int)) -> String {
   case chars {
     [] -> ""
     [c, ..rest] -> {
-      let assert Ok(s) = bit_array.to_string(<<c:int>>)
-      s <> chars_to_string(rest)
+      case bit_array.to_string(<<c:int>>) {
+        Ok(chunk) -> chunk <> chars_to_string(rest)
+        Error(error) -> {
+          let _nil_error = error
+          chars_to_string(rest)
+        }
+      }
     }
   }
 }
@@ -135,7 +138,7 @@ fn take_ascii85_group(
   pos: Int,
 ) -> Result(#(List(Int), Int, String), CodecError) {
   case char_to_ascii85_value(first) {
-    Error(_) -> Error(InvalidCharacter(first, pos))
+    Error(Nil) -> Error(InvalidCharacter(first, pos))
     Ok(v) -> collect_group(input, [v], 1, pos + 1)
   }
 }
@@ -146,49 +149,50 @@ fn collect_group(
   count: Int,
   pos: Int,
 ) -> Result(#(List(Int), Int, String), CodecError) {
-  case count >= 5 {
-    True -> Ok(#(list.reverse(acc), count, input))
-    False ->
-      case string.pop_grapheme(input) {
-        Error(Nil) -> Ok(#(list.reverse(acc), count, ""))
-        Ok(#(c, rest)) ->
-          case char_to_ascii85_value(c) {
-            Error(_) -> Error(InvalidCharacter(c, pos))
-            Ok(v) -> collect_group(rest, [v, ..acc], count + 1, pos + 1)
-          }
+  use <- bool.guard(
+    when: count >= 5,
+    return: Ok(#(list.reverse(acc), count, input)),
+  )
+  case string.pop_grapheme(input) {
+    Error(Nil) -> Ok(#(list.reverse(acc), count, ""))
+    Ok(#(c, rest)) ->
+      case char_to_ascii85_value(c) {
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
+        Ok(v) -> collect_group(rest, [v, ..acc], count + 1, pos + 1)
       }
   }
 }
 
 fn pad_ascii85_chars(chars: List(Int), target: Int) -> List(Int) {
-  case list.length(chars) >= target {
-    True -> chars
-    False -> pad_ascii85_chars(list.append(chars, [84]), target)
-  }
+  use <- bool.guard(when: list.length(chars) >= target, return: chars)
+  pad_ascii85_chars(list.append(chars, [84]), target)
 }
 
 fn decode_5_chars(chars: List(Int)) -> Result(Int, CodecError) {
   case chars {
     [a, b, c, d, e] -> {
-      let n = a * 52_200_625 + b * 614_125 + c * 7225 + d * 85 + e
-      Ok(n)
+      let value = a * 52_200_625 + b * 614_125 + c * 7225 + d * 85 + e
+      Ok(value)
     }
     _ -> Error(InvalidLength(list.length(chars)))
   }
 }
 
-fn u32_to_bytes(n: Int) -> List(Int) {
-  [n / 16_777_216 % 256, n / 65_536 % 256, n / 256 % 256, n % 256]
+fn u32_to_bytes(value: Int) -> List(Int) {
+  [
+    value / 16_777_216 % 256,
+    value / 65_536 % 256,
+    value / 256 % 256,
+    value % 256,
+  ]
 }
 
 fn char_to_ascii85_value(c: String) -> Result(Int, Nil) {
   case string.to_utf_codepoints(c) {
     [cp] -> {
       let code = string.utf_codepoint_to_int(cp)
-      case code >= 33 && code <= 117 {
-        True -> Ok(code - 33)
-        False -> Error(Nil)
-      }
+      use <- bool.guard(when: code >= 33 && code <= 117, return: Ok(code - 33))
+      Error(Nil)
     }
     _ -> Error(Nil)
   }

--- a/src/yabase/base2.gleam
+++ b/src/yabase/base2.gleam
@@ -1,5 +1,6 @@
 /// Base2 encoding (binary string representation).
 /// Each byte is represented as 8 characters of "0" and "1".
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
@@ -25,16 +26,12 @@ fn encode_bytes(data: BitArray, acc: List(String)) -> List(String) {
 }
 
 fn encode_byte(byte: Int, bit: Int, acc: String) -> String {
-  case bit < 0 {
-    True -> acc
-    False -> {
-      let c = case byte / pow2(bit) % 2 {
-        1 -> "1"
-        _ -> "0"
-      }
-      encode_byte(byte, bit - 1, acc <> c)
-    }
+  use <- bool.guard(when: bit < 0, return: acc)
+  let digit = case byte / pow2(bit) % 2 {
+    1 -> "1"
+    _ -> "0"
   }
+  encode_byte(byte, bit - 1, acc <> digit)
 }
 
 fn pow2(n: Int) -> Int {

--- a/src/yabase/base32/clockwork.gleam
+++ b/src/yabase/base32/clockwork.gleam
@@ -50,7 +50,7 @@ fn decode_chars(
     Error(Nil) -> extract_bytes(acc, <<>>)
     Ok(#(c, rest)) ->
       case char_to_value(c) {
-        Error(_) -> Error(InvalidCharacter(c, pos))
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
         Ok(val) -> decode_chars(rest, bit_array.append(acc, <<val:5>>), pos + 1)
       }
   }
@@ -105,6 +105,6 @@ fn char_to_value(c: String) -> Result(Int, Nil) {
 fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(Nil) -> ""
   }
 }

--- a/src/yabase/base32/crockford.gleam
+++ b/src/yabase/base32/crockford.gleam
@@ -102,6 +102,8 @@ fn char_to_value(c: String) -> Result(Int, Nil) {
 }
 
 fn string_char_at(s: String, index: Int) -> String {
-  let assert Ok(#(c, _)) = string.drop_start(s, index) |> string.pop_grapheme
-  c
+  case string.drop_start(s, index) |> string.pop_grapheme {
+    Ok(#(char, _)) -> char
+    Error(Nil) -> ""
+  }
 }

--- a/src/yabase/base32/hex.gleam
+++ b/src/yabase/base32/hex.gleam
@@ -97,7 +97,7 @@ fn decode_chars(
     Error(Nil) -> extract_bytes(acc, <<>>)
     Ok(#(c, rest)) ->
       case char_to_value(c) {
-        Error(_) -> Error(InvalidCharacter(c, pos))
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
         Ok(val) -> decode_chars(rest, bit_array.append(acc, <<val:5>>), pos + 1)
       }
   }
@@ -152,6 +152,6 @@ fn char_to_value(c: String) -> Result(Int, Nil) {
 fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(Nil) -> ""
   }
 }

--- a/src/yabase/base32/rfc4648.gleam
+++ b/src/yabase/base32/rfc4648.gleam
@@ -102,7 +102,7 @@ fn decode_chars(
     Error(Nil) -> finalize_bits(acc)
     Ok(#(c, rest)) ->
       case char_to_value(c) {
-        Error(_) -> Error(InvalidCharacter(c, pos))
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
         Ok(val) -> decode_chars(rest, bit_array.append(acc, <<val:5>>), pos + 1)
       }
   }
@@ -161,6 +161,6 @@ fn char_to_value(c: String) -> Result(Int, Nil) {
 fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(Nil) -> ""
   }
 }

--- a/src/yabase/base32/zbase32.gleam
+++ b/src/yabase/base32/zbase32.gleam
@@ -49,7 +49,7 @@ fn decode_chars(
     Error(Nil) -> extract_bytes(acc, <<>>)
     Ok(#(c, rest)) ->
       case char_to_value(c) {
-        Error(_) -> Error(InvalidCharacter(c, pos))
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
         Ok(val) -> decode_chars(rest, bit_array.append(acc, <<val:5>>), pos + 1)
       }
   }
@@ -81,6 +81,6 @@ fn find_index(haystack: String, needle: String, idx: Int) -> Result(Int, Nil) {
 fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(Nil) -> ""
   }
 }

--- a/src/yabase/base45.gleam
+++ b/src/yabase/base45.gleam
@@ -19,21 +19,25 @@ pub fn encode(data: BitArray) -> String {
 fn encode_pairs(data: BitArray, acc: List(String)) -> List(String) {
   case data {
     <<a:8, b:8, rest:bits>> -> {
-      let n = a * 256 + b
-      let c = n % 45
-      let d = { n / 45 } % 45
-      let e = n / 45 / 45
+      let value = a * 256 + b
+      let first_digit = value % 45
+      let second_digit = { value / 45 } % 45
+      let third_digit = value / 45 / 45
       encode_pairs(rest, [
-        string_char_at(alphabet, e),
-        string_char_at(alphabet, d),
-        string_char_at(alphabet, c),
+        string_char_at(alphabet, third_digit),
+        string_char_at(alphabet, second_digit),
+        string_char_at(alphabet, first_digit),
         ..acc
       ])
     }
     <<a:8>> -> {
-      let c = a % 45
-      let d = a / 45
-      [string_char_at(alphabet, d), string_char_at(alphabet, c), ..acc]
+      let first_digit = a % 45
+      let second_digit = a / 45
+      [
+        string_char_at(alphabet, second_digit),
+        string_char_at(alphabet, first_digit),
+        ..acc
+      ]
     }
     _ -> acc
   }
@@ -58,12 +62,12 @@ fn decode_groups(
     #(Ok([c, d, e]), rest) ->
       case char_value(c), char_value(d), char_value(e) {
         Ok(vc), Ok(vd), Ok(ve) -> {
-          let n = vc + vd * 45 + ve * 45 * 45
-          case n > 65_535 {
+          let value = vc + vd * 45 + ve * 45 * 45
+          case value > 65_535 {
             True -> Error(Overflow)
             False -> {
-              let high = n / 256
-              let low = n % 256
+              let high = value / 256
+              let low = value % 256
               decode_groups(
                 rest,
                 bit_array.append(acc, <<high:int, low:int>>),
@@ -72,21 +76,21 @@ fn decode_groups(
             }
           }
         }
-        Error(_), _, _ -> Error(InvalidCharacter(c, pos))
-        _, Error(_), _ -> Error(InvalidCharacter(d, pos + 1))
-        _, _, Error(_) -> Error(InvalidCharacter(e, pos + 2))
+        Error(Nil), _, _ -> Error(InvalidCharacter(c, pos))
+        _, Error(Nil), _ -> Error(InvalidCharacter(d, pos + 1))
+        _, _, Error(Nil) -> Error(InvalidCharacter(e, pos + 2))
       }
     #(Ok([c, d]), _rest) ->
       case char_value(c), char_value(d) {
         Ok(vc), Ok(vd) -> {
-          let n = vc + vd * 45
-          case n > 255 {
+          let value = vc + vd * 45
+          case value > 255 {
             True -> Error(Overflow)
-            False -> Ok(bit_array.append(acc, <<n:int>>))
+            False -> Ok(bit_array.append(acc, <<value:int>>))
           }
         }
-        Error(_), _ -> Error(InvalidCharacter(c, pos))
-        _, Error(_) -> Error(InvalidCharacter(d, pos + 1))
+        Error(Nil), _ -> Error(InvalidCharacter(c, pos))
+        _, Error(Nil) -> Error(InvalidCharacter(d, pos + 1))
       }
     _ -> Ok(acc)
   }
@@ -133,6 +137,6 @@ fn find_index(haystack: String, needle: String, idx: Int) -> Result(Int, Nil) {
 fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(Nil) -> ""
   }
 }

--- a/src/yabase/base58check.gleam
+++ b/src/yabase/base58check.gleam
@@ -3,6 +3,7 @@
 /// Checksum = first 4 bytes of SHA-256(SHA-256(version + payload)).
 /// This is a separate API from the Encoding ADT because it carries metadata.
 import gleam/bit_array
+import gleam/bool
 import gleam/string
 import yabase/core/encoding.{
   type Base58CheckDecoded, type CodecError, Base58CheckDecoded, InvalidChecksum,
@@ -16,15 +17,11 @@ const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 /// Encode a version byte (0..255) and payload to Base58Check.
 /// Returns Error(Overflow) if version is outside 0..255.
 pub fn encode(version: Int, payload: BitArray) -> Result(String, CodecError) {
-  case version >= 0 && version <= 255 {
-    False -> Error(Overflow)
-    True -> {
-      let versioned = bit_array.append(<<version:int>>, payload)
-      let checksum = compute_checksum(versioned)
-      let full = bit_array.append(versioned, checksum)
-      Ok(bignum.encode(full, 58, alphabet))
-    }
-  }
+  use <- bool.guard(when: version < 0 || version > 255, return: Error(Overflow))
+  let versioned = bit_array.append(<<version:int>>, payload)
+  let checksum = compute_checksum(versioned)
+  let full = bit_array.append(versioned, checksum)
+  Ok(bignum.encode(full, 58, alphabet))
 }
 
 /// Decode a Base58Check string, verifying the checksum.

--- a/src/yabase/base64/nopadding.gleam
+++ b/src/yabase/base64/nopadding.gleam
@@ -1,5 +1,6 @@
 /// Base64 encoding without padding.
 /// Same as standard Base64 but padding characters are stripped.
+import gleam/bool
 import gleam/string
 import yabase/base64/standard
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
@@ -14,28 +15,31 @@ pub fn encode(data: BitArray) -> String {
 /// Length % 4 must be 0, 2, or 3 (never 1).
 /// Padding characters (=) are rejected.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
-  case string.contains(input, "=") {
-    True -> Error(InvalidCharacter("=", find_char_pos(input, "=", 0)))
-    False -> {
-      let len = string.length(input)
-      case len % 4 {
-        1 -> Error(InvalidLength(len))
-        _ -> {
-          let padded = add_padding(input)
-          standard.decode(padded)
-        }
-      }
+  use <- bool.guard(
+    when: string.contains(input, "="),
+    return: Error(InvalidCharacter("=", find_char_pos(input, "=", 0))),
+  )
+  let len = string.length(input)
+  case len % 4 {
+    1 -> Error(InvalidLength(len))
+    _ -> {
+      let padded = add_padding(input)
+      standard.decode(padded)
     }
   }
 }
 
 fn find_char_pos(input: String, target: String, pos: Int) -> Int {
-  // Caller guarantees string.contains(input, target) is true,
-  // so Error(Nil) is unreachable.
-  let assert Ok(#(c, rest)) = string.pop_grapheme(input)
-  case c == target {
-    True -> pos
-    False -> find_char_pos(rest, target, pos + 1)
+  case string.pop_grapheme(input) {
+    Ok(#(char, rest)) ->
+      case char == target {
+        True -> pos
+        False -> find_char_pos(rest, target, pos + 1)
+      }
+    Error(error) -> {
+      let _nil_error = error
+      pos
+    }
   }
 }
 

--- a/src/yabase/base64/standard.gleam
+++ b/src/yabase/base64/standard.gleam
@@ -18,8 +18,8 @@ pub fn encode(data: BitArray) -> String {
 fn encode_chunks(data: BitArray, acc: List(String)) -> List(String) {
   case data {
     <<a:6, b:6, c:6, d:6, rest:bits>> -> {
-      let s = char_at(a) <> char_at(b) <> char_at(c) <> char_at(d)
-      encode_chunks(rest, [s, ..acc])
+      let chunk = char_at(a) <> char_at(b) <> char_at(c) <> char_at(d)
+      encode_chunks(rest, [chunk, ..acc])
     }
     <<a:6, b:6, c:4>> -> [
       char_at(a) <> char_at(b) <> char_at(c * 4) <> pad,
@@ -61,8 +61,8 @@ fn decode_chars(
                       let byte = v1 * 4 + v2 / 16
                       Ok(bit_array.append(acc, <<byte:int>>))
                     }
-                    Error(_), _ -> Error(InvalidCharacter(c1, pos))
-                    _, Error(_) -> Error(InvalidCharacter(c2, pos + 1))
+                    Error(Nil), _ -> Error(InvalidCharacter(c1, pos))
+                    _, Error(Nil) -> Error(InvalidCharacter(c2, pos + 1))
                   }
                 _ -> Error(InvalidLength(string.length(rest) + pos + 4))
               }
@@ -77,9 +77,9 @@ fn decode_chars(
                           let b2 = { v2 % 16 } * 16 + v3 / 4
                           Ok(bit_array.append(acc, <<b1:int, b2:int>>))
                         }
-                        Error(_), _, _ -> Error(InvalidCharacter(c1, pos))
-                        _, Error(_), _ -> Error(InvalidCharacter(c2, pos + 1))
-                        _, _, Error(_) -> Error(InvalidCharacter(c3, pos + 2))
+                        Error(Nil), _, _ -> Error(InvalidCharacter(c1, pos))
+                        _, Error(Nil), _ -> Error(InvalidCharacter(c2, pos + 1))
+                        _, _, Error(Nil) -> Error(InvalidCharacter(c3, pos + 2))
                       }
                     _ -> Error(InvalidLength(string.length(rest) + pos + 4))
                   }
@@ -95,10 +95,10 @@ fn decode_chars(
                         pos + 4,
                       )
                     }
-                    Error(_), _, _, _ -> Error(InvalidCharacter(c1, pos))
-                    _, Error(_), _, _ -> Error(InvalidCharacter(c2, pos + 1))
-                    _, _, Error(_), _ -> Error(InvalidCharacter(c3, pos + 2))
-                    _, _, _, Error(_) -> Error(InvalidCharacter(c4, pos + 3))
+                    Error(Nil), _, _, _ -> Error(InvalidCharacter(c1, pos))
+                    _, Error(Nil), _, _ -> Error(InvalidCharacter(c2, pos + 1))
+                    _, _, Error(Nil), _ -> Error(InvalidCharacter(c3, pos + 2))
+                    _, _, _, Error(Nil) -> Error(InvalidCharacter(c4, pos + 3))
                   }
               }
           }
@@ -132,7 +132,10 @@ fn take_4(
 fn char_at(index: Int) -> String {
   case string.drop_start(alphabet, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(error) -> {
+      let _nil_error = error
+      ""
+    }
   }
 }
 

--- a/src/yabase/base64/urlsafe.gleam
+++ b/src/yabase/base64/urlsafe.gleam
@@ -61,8 +61,8 @@ fn decode_chars(
                   case value_of(c1), value_of(c2) {
                     Ok(v1), Ok(v2) ->
                       Ok(bit_array.append(acc, <<{ v1 * 4 + v2 / 16 }:int>>))
-                    Error(_), _ -> Error(InvalidCharacter(c1, pos))
-                    _, Error(_) -> Error(InvalidCharacter(c2, pos + 1))
+                    Error(Nil), _ -> Error(InvalidCharacter(c1, pos))
+                    _, Error(Nil) -> Error(InvalidCharacter(c2, pos + 1))
                   }
                 _ -> Error(InvalidLength(string.length(rest) + pos + 4))
               }
@@ -77,9 +77,9 @@ fn decode_chars(
                           let b2 = { v2 % 16 } * 16 + v3 / 4
                           Ok(bit_array.append(acc, <<b1:int, b2:int>>))
                         }
-                        Error(_), _, _ -> Error(InvalidCharacter(c1, pos))
-                        _, Error(_), _ -> Error(InvalidCharacter(c2, pos + 1))
-                        _, _, Error(_) -> Error(InvalidCharacter(c3, pos + 2))
+                        Error(Nil), _, _ -> Error(InvalidCharacter(c1, pos))
+                        _, Error(Nil), _ -> Error(InvalidCharacter(c2, pos + 1))
+                        _, _, Error(Nil) -> Error(InvalidCharacter(c3, pos + 2))
                       }
                     _ -> Error(InvalidLength(string.length(rest) + pos + 4))
                   }
@@ -95,10 +95,10 @@ fn decode_chars(
                         pos + 4,
                       )
                     }
-                    Error(_), _, _, _ -> Error(InvalidCharacter(c1, pos))
-                    _, Error(_), _, _ -> Error(InvalidCharacter(c2, pos + 1))
-                    _, _, Error(_), _ -> Error(InvalidCharacter(c3, pos + 2))
-                    _, _, _, Error(_) -> Error(InvalidCharacter(c4, pos + 3))
+                    Error(Nil), _, _, _ -> Error(InvalidCharacter(c1, pos))
+                    _, Error(Nil), _, _ -> Error(InvalidCharacter(c2, pos + 1))
+                    _, _, Error(Nil), _ -> Error(InvalidCharacter(c3, pos + 2))
+                    _, _, _, Error(Nil) -> Error(InvalidCharacter(c4, pos + 3))
                   }
               }
           }
@@ -130,7 +130,10 @@ fn take_4(
 fn char_at(index: Int) -> String {
   case string.drop_start(alphabet, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(error) -> {
+      let _nil_error = error
+      ""
+    }
   }
 }
 

--- a/src/yabase/base91.gleam
+++ b/src/yabase/base91.gleam
@@ -6,6 +6,7 @@
 /// Uses Erlang bitwise operations via BitArray patterns to match
 /// the C reference implementation's unsigned integer semantics.
 import gleam/bit_array
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter}
@@ -97,7 +98,7 @@ fn decode_loop(
     }
     [c, ..rest] ->
       case char_index(c) {
-        Error(_) -> Error(InvalidCharacter(c, pos))
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
         Ok(d) ->
           case val == -1 {
             True -> decode_loop(rest, d, queue, nbits, acc, pos + 1)
@@ -127,14 +128,8 @@ fn decode_loop(
 }
 
 fn extract_bytes_from_queue(queue: Int, nbits: Int, acc: List(Int)) -> List(Int) {
-  case nbits >= 8 {
-    True ->
-      extract_bytes_from_queue(bsr(queue, 8), nbits - 8, [
-        band(queue, 255),
-        ..acc
-      ])
-    False -> acc
-  }
+  use <- bool.guard(when: nbits < 8, return: acc)
+  extract_bytes_from_queue(bsr(queue, 8), nbits - 8, [band(queue, 255), ..acc])
 }
 
 // Erlang bitwise operations (exact unsigned semantics)
@@ -153,7 +148,7 @@ fn bsr(a: Int, b: Int) -> Int
 fn char_at(index: Int) -> String {
   case string.drop_start(alphabet, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(Nil) -> ""
   }
 }
 

--- a/src/yabase/bech32.gleam
+++ b/src/yabase/bech32.gleam
@@ -17,6 +17,7 @@
 /// This is a separate API from the Encoding ADT because it carries
 /// HRP metadata and a checksum.
 import gleam/bit_array
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{
@@ -148,16 +149,12 @@ fn find_separator(input: String) -> Result(#(String, String), Nil) {
 }
 
 fn find_last_one(input: String, pos: Int) -> Result(#(String, String), Nil) {
-  case pos < 0 {
-    True -> Error(Nil)
-    False -> {
-      let before = string.slice(input, 0, pos)
-      let at_and_after = string.drop_start(input, pos)
-      case string.pop_grapheme(at_and_after) {
-        Ok(#("1", after)) -> Ok(#(before, after))
-        _ -> find_last_one(input, pos - 1)
-      }
-    }
+  use <- bool.guard(when: pos < 0, return: Error(Nil))
+  let before = string.slice(input, 0, pos)
+  let at_and_after = string.drop_start(input, pos)
+  case string.pop_grapheme(at_and_after) {
+    Ok(#("1", after)) -> Ok(#(before, after))
+    _ -> find_last_one(input, pos - 1)
   }
 }
 
@@ -215,7 +212,7 @@ fn chars_to_values(
     Error(Nil) -> Ok(list.reverse(acc))
     Ok(#(c, rest)) ->
       case char_to_value(c) {
-        Error(_) -> Error(InvalidCharacter(c, pos))
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
         Ok(v) -> chars_to_values(rest, [v, ..acc], pos + 1)
       }
   }
@@ -238,22 +235,22 @@ fn polymod_loop(values: List(Int), chk: Int) -> Int {
     [] -> chk
     [v, ..rest] -> {
       // b = chk >> 25
-      let b = shr(chk, 25)
+      let checksum_head = shr(chk, 25)
       // chk = ((chk & 0x1ffffff) << 5) ^ v
       let chk1 = xor({ chk % 33_554_432 } * 32, v)
-      let chk2 = xor_if(chk1, b, 0, 0x3b6a57b2)
-      let chk3 = xor_if(chk2, b, 1, 0x26508e6d)
-      let chk4 = xor_if(chk3, b, 2, 0x1ea119fa)
-      let chk5 = xor_if(chk4, b, 3, 0x3d4233dd)
-      let chk6 = xor_if(chk5, b, 4, 0x2a1462b3)
+      let chk2 = xor_if(chk1, checksum_head, 0, 0x3b6a57b2)
+      let chk3 = xor_if(chk2, checksum_head, 1, 0x26508e6d)
+      let chk4 = xor_if(chk3, checksum_head, 2, 0x1ea119fa)
+      let chk5 = xor_if(chk4, checksum_head, 3, 0x3d4233dd)
+      let chk6 = xor_if(chk5, checksum_head, 4, 0x2a1462b3)
       polymod_loop(rest, chk6)
     }
   }
 }
 
 fn xor_if(chk: Int, b: Int, bit: Int, gen: Int) -> Int {
-  let shifted = shr(b, bit)
-  case shifted % 2 == 1 {
+  let upper_bits = shr(b, bit)
+  case upper_bits % 2 == 1 {
     True -> xor(chk, gen)
     False -> chk
   }
@@ -281,14 +278,14 @@ fn verify_checksum(hrp: String, data: List(Int), constant: Int) -> Bool {
 fn create_checksum(hrp: String, data: List(Int), constant: Int) -> List(Int) {
   let values =
     list_append(hrp_expand(hrp), list_append(data, [0, 0, 0, 0, 0, 0]))
-  let p = xor(polymod(values), constant)
+  let polymod_value = xor(polymod(values), constant)
   [
-    shr(p, 25) % 32,
-    shr(p, 20) % 32,
-    shr(p, 15) % 32,
-    shr(p, 10) % 32,
-    shr(p, 5) % 32,
-    p % 32,
+    shr(polymod_value, 25) % 32,
+    shr(polymod_value, 20) % 32,
+    shr(polymod_value, 15) % 32,
+    shr(polymod_value, 10) % 32,
+    shr(polymod_value, 5) % 32,
+    polymod_value % 32,
   ]
 }
 
@@ -391,18 +388,14 @@ fn xor(a: Int, b: Int) -> Int {
 }
 
 fn do_xor(a: Int, b: Int, result: Int, bit: Int) -> Int {
-  case a == 0 && b == 0 {
-    True -> result
-    False -> {
-      let a_bit = a % 2
-      let b_bit = b % 2
-      let bit_set = case a_bit != b_bit {
-        True -> bit
-        False -> 0
-      }
-      do_xor(a / 2, b / 2, result + bit_set, bit * 2)
-    }
+  use <- bool.guard(when: a == 0 && b == 0, return: result)
+  let a_bit = a % 2
+  let b_bit = b % 2
+  let bit_set = case a_bit != b_bit {
+    True -> bit
+    False -> 0
   }
+  do_xor(a / 2, b / 2, result + bit_set, bit * 2)
 }
 
 fn shr(n: Int, amount: Int) -> Int {
@@ -415,7 +408,10 @@ fn shr(n: Int, amount: Int) -> Int {
 fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(error) -> {
+      let _nil_error = error
+      ""
+    }
   }
 }
 

--- a/src/yabase/internal/bignum.gleam
+++ b/src/yabase/internal/bignum.gleam
@@ -19,7 +19,7 @@ pub fn bytes_to_int(data: BitArray, acc: Int) -> Int {
 }
 
 /// Convert a big integer to a list of bytes (MSB first).
-pub fn int_to_bytes(num: Int, acc: List(Int)) -> List(Int) {
+fn int_to_bytes(num: Int, acc: List(Int)) -> List(Int) {
   case num {
     0 -> acc
     _ -> int_to_bytes(num / 256, [num % 256, ..acc])
@@ -27,7 +27,7 @@ pub fn int_to_bytes(num: Int, acc: List(Int)) -> List(Int) {
 }
 
 /// Count leading zero bytes in a BitArray.
-pub fn count_leading_zeros(data: BitArray, count: Int) -> Int {
+fn count_leading_zeros(data: BitArray, count: Int) -> Int {
   case data {
     <<0:8, rest:bits>> -> count_leading_zeros(rest, count + 1)
     _ -> count
@@ -37,7 +37,7 @@ pub fn count_leading_zeros(data: BitArray, count: Int) -> Int {
 /// Count leading zero-valued characters in a string.
 /// Uses the provided char_value function to check if a character maps to 0,
 /// so zero aliases (e.g. Crockford O->0) are correctly counted.
-pub fn count_leading_zeros_str(
+fn count_leading_zeros_str(
   input: String,
   char_value: fn(String) -> Result(Int, Nil),
   count: Int,
@@ -53,7 +53,7 @@ pub fn count_leading_zeros_str(
 }
 
 /// Convert a list of byte values to a BitArray.
-pub fn list_to_bit_array(bytes: List(Int), acc: BitArray) -> BitArray {
+fn list_to_bit_array(bytes: List(Int), acc: BitArray) -> BitArray {
   case bytes {
     [] -> acc
     [b, ..rest] -> list_to_bit_array(rest, bit_array.append(acc, <<b:int>>))
@@ -61,7 +61,7 @@ pub fn list_to_bit_array(bytes: List(Int), acc: BitArray) -> BitArray {
 }
 
 /// Encode a big integer in the given radix using the given alphabet string.
-pub fn encode_int(
+fn encode_int(
   num: Int,
   radix: Int,
   alphabet: String,
@@ -78,7 +78,7 @@ pub fn encode_int(
 }
 
 /// Decode a string of digits in the given radix, using a char_value function.
-pub fn string_to_int(
+fn string_to_int(
   input: String,
   radix: Int,
   char_value: fn(String) -> Result(Int, Nil),
@@ -89,7 +89,7 @@ pub fn string_to_int(
     Error(Nil) -> Ok(acc)
     Ok(#(c, rest)) ->
       case char_value(c) {
-        Error(_) -> Error(InvalidCharacter(c, pos))
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
         Ok(val) ->
           string_to_int(rest, radix, char_value, acc * radix + val, pos + 1)
       }
@@ -159,6 +159,9 @@ pub fn find_index(
 fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(error) -> {
+      let _nil_error = error
+      ""
+    }
   }
 }

--- a/src/yabase/internal/sha256.gleam
+++ b/src/yabase/internal/sha256.gleam
@@ -1,6 +1,7 @@
 /// Pure Gleam SHA-256 implementation.
 /// Used only for checksum computation in Base58Check.
 import gleam/bit_array
+import gleam/bool
 
 /// Compute SHA-256 hash of data. Returns a 32-byte BitArray.
 pub fn hash(data: BitArray) -> BitArray {
@@ -96,10 +97,10 @@ fn k(i: Int) -> Int {
 }
 
 fn mask32(n: Int) -> Int {
-  let m = 0xFFFFFFFF
+  let mask = 0xFFFFFFFF
   case n >= 0 {
-    True -> int_and(n, m)
-    False -> int_and(n + m + 1, m)
+    True -> int_and(n, mask)
+    False -> int_and(n + mask + 1, mask)
   }
 }
 
@@ -108,16 +109,12 @@ fn int_and(a: Int, b: Int) -> Int {
 }
 
 fn do_int_and(a: Int, b: Int, result: Int, bit: Int) -> Int {
-  case bit > 0xFFFFFFFF {
-    True -> result
-    False -> {
-      let bit_set = case { a / bit } % 2 == 1 && { b / bit } % 2 == 1 {
-        True -> bit
-        False -> 0
-      }
-      do_int_and(a, b, result + bit_set, bit * 2)
-    }
+  use <- bool.guard(when: bit > 0xFFFFFFFF, return: result)
+  let bit_set = case { a / bit } % 2 == 1 && { b / bit } % 2 == 1 {
+    True -> bit
+    False -> 0
   }
+  do_int_and(a, b, result + bit_set, bit * 2)
 }
 
 fn int_or(a: Int, b: Int) -> Int {
@@ -125,16 +122,12 @@ fn int_or(a: Int, b: Int) -> Int {
 }
 
 fn do_int_or(a: Int, b: Int, result: Int, bit: Int) -> Int {
-  case bit > 0xFFFFFFFF {
-    True -> result
-    False -> {
-      let bit_set = case { a / bit } % 2 == 1 || { b / bit } % 2 == 1 {
-        True -> bit
-        False -> 0
-      }
-      do_int_or(a, b, result + bit_set, bit * 2)
-    }
+  use <- bool.guard(when: bit > 0xFFFFFFFF, return: result)
+  let bit_set = case { a / bit } % 2 == 1 || { b / bit } % 2 == 1 {
+    True -> bit
+    False -> 0
   }
+  do_int_or(a, b, result + bit_set, bit * 2)
 }
 
 fn int_xor(a: Int, b: Int) -> Int {
@@ -142,18 +135,14 @@ fn int_xor(a: Int, b: Int) -> Int {
 }
 
 fn do_int_xor(a: Int, b: Int, result: Int, bit: Int) -> Int {
-  case bit > 0xFFFFFFFF {
-    True -> result
-    False -> {
-      let a_bit = { a / bit } % 2
-      let b_bit = { b / bit } % 2
-      let bit_set = case a_bit != b_bit {
-        True -> bit
-        False -> 0
-      }
-      do_int_xor(a, b, result + bit_set, bit * 2)
-    }
+  use <- bool.guard(when: bit > 0xFFFFFFFF, return: result)
+  let a_bit = { a / bit } % 2
+  let b_bit = { b / bit } % 2
+  let bit_set = case a_bit != b_bit {
+    True -> bit
+    False -> 0
   }
+  do_int_xor(a, b, result + bit_set, bit * 2)
 }
 
 fn int_not(a: Int) -> Int {
@@ -243,8 +232,8 @@ fn process_blocks(
 ) -> #(Int, Int, Int, Int, Int, Int, Int, Int) {
   case data {
     <<block:bytes-size(64), rest:bits>> -> {
-      let w = parse_block(block)
-      let new_state = compress(state, w)
+      let schedule = parse_block(block)
+      let new_state = compress(state, schedule)
       process_blocks(rest, new_state)
     }
     _ -> state
@@ -265,18 +254,13 @@ fn parse_words(data: BitArray, acc: List(Int)) -> List(Int) {
 }
 
 fn expand_schedule(w: List(Int), i: Int) -> List(Int) {
-  case i >= 64 {
-    True -> w
-    False -> {
-      let w2 = list_at(w, i - 2)
-      let w7 = list_at(w, i - 7)
-      let w15 = list_at(w, i - 15)
-      let w16 = list_at(w, i - 16)
-      let new_w =
-        add32(add32(small_sigma1(w2), w7), add32(small_sigma0(w15), w16))
-      expand_schedule(list_append(w, [new_w]), i + 1)
-    }
-  }
+  use <- bool.guard(when: i >= 64, return: w)
+  let w2 = list_at(w, i - 2)
+  let w7 = list_at(w, i - 7)
+  let w15 = list_at(w, i - 15)
+  let w16 = list_at(w, i - 16)
+  let new_w = add32(add32(small_sigma1(w2), w7), add32(small_sigma0(w15), w16))
+  expand_schedule(list_append(w, [new_w]), i + 1)
 }
 
 // 64-round compression function
@@ -304,23 +288,15 @@ fn compress_rounds(
   w: List(Int),
   i: Int,
 ) -> #(Int, Int, Int, Int, Int, Int, Int, Int) {
-  case i >= 64 {
-    True -> vars
-    False -> {
-      let #(a, b, c, d, e, f, g, h) = vars
-      let t1 =
-        add32(
-          add32(h, big_sigma1(e)),
-          add32(ch(e, f, g), add32(k(i), list_at(w, i))),
-        )
-      let t2 = add32(big_sigma0(a), maj(a, b, c))
-      compress_rounds(
-        #(add32(t1, t2), a, b, c, add32(d, t1), e, f, g),
-        w,
-        i + 1,
-      )
-    }
-  }
+  use <- bool.guard(when: i >= 64, return: vars)
+  let #(a, b, c, d, e, f, g, h) = vars
+  let t1 =
+    add32(
+      add32(h, big_sigma1(e)),
+      add32(ch(e, f, g), add32(k(i), list_at(w, i))),
+    )
+  let t2 = add32(big_sigma0(a), maj(a, b, c))
+  compress_rounds(#(add32(t1, t2), a, b, c, add32(d, t1), e, f, g), w, i + 1)
 }
 
 fn state_to_bytes(state: #(Int, Int, Int, Int, Int, Int, Int, Int)) -> BitArray {

--- a/src/yabase/rfc1924_base85.gleam
+++ b/src/yabase/rfc1924_base85.gleam
@@ -31,8 +31,8 @@ pub fn encode(data: BitArray) -> Result(String, CodecError) {
 fn encode_groups(data: BitArray, acc: List(String)) -> List(String) {
   case data {
     <<a:8, b:8, c:8, d:8, rest:bits>> -> {
-      let n = a * 16_777_216 + b * 65_536 + c * 256 + d
-      let encoded = encode_u32(n, 5, [])
+      let value = a * 16_777_216 + b * 65_536 + c * 256 + d
+      let encoded = encode_u32(value, 5, [])
       encode_groups(rest, [list_to_string(encoded), ..acc])
     }
     _ -> acc
@@ -138,7 +138,7 @@ fn decode_5_acc(
     [] -> Ok(acc)
     [c, ..rest] ->
       case char_value(c) {
-        Error(_) -> Error(InvalidCharacter(c, pos))
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
         Ok(v) -> decode_5_acc(rest, acc * 85 + v, pos + 1)
       }
   }
@@ -166,7 +166,10 @@ fn find_index(haystack: String, needle: String, idx: Int) -> Result(Int, Nil) {
 fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(error) -> {
+      let _nil_error = error
+      ""
+    }
   }
 }
 

--- a/src/yabase/z85.gleam
+++ b/src/yabase/z85.gleam
@@ -28,8 +28,8 @@ pub fn encode(data: BitArray) -> Result(String, CodecError) {
 fn encode_groups(data: BitArray, acc: List(String)) -> List(String) {
   case data {
     <<a:8, b:8, c:8, d:8, rest:bits>> -> {
-      let n = a * 16_777_216 + b * 65_536 + c * 256 + d
-      let encoded = encode_u32(n, 5, [])
+      let value = a * 16_777_216 + b * 65_536 + c * 256 + d
+      let encoded = encode_u32(value, 5, [])
       encode_groups(rest, [list_to_string(encoded), ..acc])
     }
     _ -> acc
@@ -124,7 +124,7 @@ fn decode_5_acc(
     [] -> Ok(acc)
     [c, ..rest] ->
       case char_value(c) {
-        Error(_) -> Error(InvalidCharacter(c, pos))
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
         Ok(v) -> decode_5_acc(rest, acc * 85 + v, pos + 1)
       }
   }
@@ -152,7 +152,10 @@ fn find_index(haystack: String, needle: String, idx: Int) -> Result(Int, Nil) {
 fn string_char_at(s: String, index: Int) -> String {
   case string.drop_start(s, index) |> string.pop_grapheme {
     Ok(#(c, _)) -> c
-    Error(_) -> ""
+    Error(error) -> {
+      let _nil_error = error
+      ""
+    }
   }
 }
 

--- a/test/adobe_ascii85_test.gleam
+++ b/test/adobe_ascii85_test.gleam
@@ -1,60 +1,60 @@
 import yabase/adobe_ascii85
 import yabase/core/encoding.{InvalidCharacter, InvalidLength, Overflow}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert adobe_ascii85.encode(<<>>) == "<~~>"
 }
 
-pub fn encode_man_test() {
+pub fn encode_man_test() -> Nil {
   assert adobe_ascii85.encode(<<"Man ":utf8>>) == "<~9jqo^~>"
 }
 
-pub fn encode_zeros_test() {
+pub fn encode_zeros_test() -> Nil {
   assert adobe_ascii85.encode(<<0, 0, 0, 0>>) == "<~z~>"
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert adobe_ascii85.decode("<~~>") == Ok(<<>>)
 }
 
-pub fn decode_man_test() {
+pub fn decode_man_test() -> Nil {
   assert adobe_ascii85.decode("<~9jqo^~>") == Ok(<<"Man ":utf8>>)
 }
 
-pub fn decode_zeros_test() {
+pub fn decode_zeros_test() -> Nil {
   assert adobe_ascii85.decode("<~z~>") == Ok(<<0, 0, 0, 0>>)
 }
 
 // --- Whitespace handling (Adobe spec: whitespace ignored inside) ---
 
-pub fn decode_with_internal_whitespace_test() {
+pub fn decode_with_internal_whitespace_test() -> Nil {
   // "9jqo^" with spaces and newlines inserted
   assert adobe_ascii85.decode("<~9j qo\n^~>") == Ok(<<"Man ":utf8>>)
 }
 
-pub fn decode_with_tabs_test() {
+pub fn decode_with_tabs_test() -> Nil {
   assert adobe_ascii85.decode("<~9j\tqo^~>") == Ok(<<"Man ":utf8>>)
 }
 
-pub fn decode_with_form_feed_test() {
+pub fn decode_with_form_feed_test() -> Nil {
   assert adobe_ascii85.decode("<~9j\u{000C}qo^~>") == Ok(<<"Man ":utf8>>)
 }
 
-pub fn decode_with_form_feed_between_groups_test() {
+pub fn decode_with_form_feed_between_groups_test() -> Nil {
   assert adobe_ascii85.decode("<~z\u{000C}z~>")
     == Ok(<<0, 0, 0, 0, 0, 0, 0, 0>>)
 }
 
 // --- Missing delimiters ---
 
-pub fn decode_missing_prefix_test() {
+pub fn decode_missing_prefix_test() -> Nil {
   assert case adobe_ascii85.decode("9jqo^~>") {
     Error(InvalidCharacter(_, _)) -> True
     _ -> False
   }
 }
 
-pub fn decode_missing_suffix_test() {
+pub fn decode_missing_suffix_test() -> Nil {
   assert case adobe_ascii85.decode("<~9jqo^") {
     Error(InvalidCharacter(_, _)) -> True
     _ -> False
@@ -63,7 +63,7 @@ pub fn decode_missing_suffix_test() {
 
 // --- 1-char final group (must be rejected) ---
 
-pub fn decode_1char_final_group_test() {
+pub fn decode_1char_final_group_test() -> Nil {
   // "!" is a single char after "z" -> incomplete final group
   assert case adobe_ascii85.decode("<~z!~>") {
     Error(InvalidLength(_)) -> True
@@ -73,7 +73,7 @@ pub fn decode_1char_final_group_test() {
 
 // --- Overflow: impossible combinations ---
 
-pub fn decode_overflow_full_group_test() {
+pub fn decode_overflow_full_group_test() -> Nil {
   // "uuuuu" = all index 84 -> 84*85^4+... > 2^32
   assert case adobe_ascii85.decode("<~uuuuu~>") {
     Error(Overflow) -> True
@@ -81,7 +81,7 @@ pub fn decode_overflow_full_group_test() {
   }
 }
 
-pub fn decode_overflow_partial_group_test() {
+pub fn decode_overflow_partial_group_test() -> Nil {
   // "uuuu" = 4 chars, padded to [84,84,84,84,84] -> same overflow
   assert case adobe_ascii85.decode("<~uuuu~>") {
     Error(Overflow) -> True
@@ -89,7 +89,7 @@ pub fn decode_overflow_partial_group_test() {
   }
 }
 
-pub fn decode_overflow_partial_3char_test() {
+pub fn decode_overflow_partial_3char_test() -> Nil {
   // "uuu" = 3 chars, padded to [84,84,84,84,84] -> overflow
   assert case adobe_ascii85.decode("<~uuu~>") {
     Error(Overflow) -> True
@@ -99,17 +99,17 @@ pub fn decode_overflow_partial_3char_test() {
 
 // --- Roundtrips ---
 
-pub fn roundtrip_test() {
+pub fn roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert adobe_ascii85.decode(adobe_ascii85.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_short_test() {
+pub fn roundtrip_short_test() -> Nil {
   let data = <<"Hi":utf8>>
   assert adobe_ascii85.decode(adobe_ascii85.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_aligned_test() {
+pub fn roundtrip_aligned_test() -> Nil {
   let data = <<"test1234":utf8>>
   assert adobe_ascii85.decode(adobe_ascii85.encode(data)) == Ok(data)
 }

--- a/test/ascii85_test.gleam
+++ b/test/ascii85_test.gleam
@@ -1,57 +1,57 @@
 import yabase/ascii85
 import yabase/core/encoding.{InvalidCharacter, InvalidLength, Overflow}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert ascii85.encode(<<>>) == ""
 }
 
-pub fn encode_zeros_test() {
+pub fn encode_zeros_test() -> Nil {
   assert ascii85.encode(<<0, 0, 0, 0>>) == "z"
 }
 
-pub fn encode_man_test() {
+pub fn encode_man_test() -> Nil {
   assert ascii85.encode(<<"Man ":utf8>>) == "9jqo^"
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert ascii85.decode("") == Ok(<<>>)
 }
 
-pub fn decode_zeros_test() {
+pub fn decode_zeros_test() -> Nil {
   assert ascii85.decode("z") == Ok(<<0, 0, 0, 0>>)
 }
 
-pub fn encode_spaces_y_test() {
+pub fn encode_spaces_y_test() -> Nil {
   // btoa abbreviation: 4 spaces -> 'y'
   assert ascii85.encode(<<0x20, 0x20, 0x20, 0x20>>) == "y"
 }
 
-pub fn encode_eight_spaces_test() {
+pub fn encode_eight_spaces_test() -> Nil {
   assert ascii85.encode(<<0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20>>)
     == "yy"
 }
 
-pub fn decode_y_test() {
+pub fn decode_y_test() -> Nil {
   assert ascii85.decode("y") == Ok(<<0x20, 0x20, 0x20, 0x20>>)
 }
 
-pub fn decode_yy_test() {
+pub fn decode_yy_test() -> Nil {
   assert ascii85.decode("yy")
     == Ok(<<0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20>>)
 }
 
-pub fn roundtrip_spaces_test() {
+pub fn roundtrip_spaces_test() -> Nil {
   let data = <<0x20, 0x20, 0x20, 0x20>>
   assert ascii85.decode(ascii85.encode(data)) == Ok(data)
 }
 
-pub fn encode_mixed_z_y_test() {
+pub fn encode_mixed_z_y_test() -> Nil {
   // zeros + spaces
   let data = <<0, 0, 0, 0, 0x20, 0x20, 0x20, 0x20>>
   assert ascii85.encode(data) == "zy"
 }
 
-pub fn decode_invalid_char_test() {
+pub fn decode_invalid_char_test() -> Nil {
   // Characters outside '!' (33) to 'u' (117) are invalid (except 'z')
   assert case ascii85.decode("\u{01}") {
     Error(InvalidCharacter(_, _)) -> True
@@ -61,7 +61,7 @@ pub fn decode_invalid_char_test() {
 
 // --- Decode edge cases ---
 
-pub fn decode_single_char_invalid_length_test() {
+pub fn decode_single_char_invalid_length_test() -> Nil {
   // 1 char is too short to form a group (need at least 2)
   assert case ascii85.decode("!") {
     Error(InvalidLength(_)) -> True
@@ -69,31 +69,32 @@ pub fn decode_single_char_invalid_length_test() {
   }
 }
 
-pub fn decode_5_max_chars_overflow_test() {
+pub fn decode_5_max_chars_overflow_test() -> Nil {
   // "uuuuu" -> 84*85^4 + 84*85^3 + 84*85^2 + 84*85 + 84 = 4294967295 (max u32, OK)
   // "s8W-!" is the encoding of <<0xff, 0xff, 0xff, 0xff>>
   let assert Ok(_) = ascii85.decode("s8W-!")
+  Nil
 }
 
-pub fn decode_overflow_test() {
+pub fn decode_overflow_test() -> Nil {
   // Values that decode above u32 max must return Overflow
   // "s8W-\"" = one past max for full 5-char group
   assert ascii85.decode("s8W-\"") == Error(Overflow)
 }
 
-pub fn decode_2_char_group_test() {
+pub fn decode_2_char_group_test() -> Nil {
   // 2-char partial group -> 1 output byte
   let assert Ok(data) = ascii85.decode("!!")
   assert data == <<0>>
 }
 
-pub fn decode_3_char_group_test() {
+pub fn decode_3_char_group_test() -> Nil {
   // 3-char partial group -> 2 output bytes
   let assert Ok(data) = ascii85.decode("!!!")
   assert data == <<0, 0>>
 }
 
-pub fn decode_4_char_group_test() {
+pub fn decode_4_char_group_test() -> Nil {
   // 4-char partial group -> 3 output bytes
   let assert Ok(data) = ascii85.decode("!!!!")
   assert data == <<0, 0, 0>>
@@ -101,30 +102,30 @@ pub fn decode_4_char_group_test() {
 
 // --- Roundtrip corpus ---
 
-pub fn roundtrip_aligned_test() {
+pub fn roundtrip_aligned_test() -> Nil {
   let data = <<"Hello, World!!!!":utf8>>
   assert ascii85.decode(ascii85.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_short_test() {
+pub fn roundtrip_short_test() -> Nil {
   let data = <<"Hi":utf8>>
   assert ascii85.decode(ascii85.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_empty_test() {
+pub fn roundtrip_empty_test() -> Nil {
   assert ascii85.decode(ascii85.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn roundtrip_single_byte_test() {
+pub fn roundtrip_single_byte_test() -> Nil {
   assert ascii85.decode(ascii85.encode(<<42>>)) == Ok(<<42>>)
 }
 
-pub fn roundtrip_all_zeros_test() {
+pub fn roundtrip_all_zeros_test() -> Nil {
   let data = <<0, 0, 0, 0, 0, 0, 0, 0>>
   assert ascii85.decode(ascii85.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_high_bits_test() {
+pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0xfd, 0xfc>>
   assert ascii85.decode(ascii85.encode(data)) == Ok(data)
 }

--- a/test/base10_test.gleam
+++ b/test/base10_test.gleam
@@ -1,59 +1,59 @@
 import yabase/base10
 import yabase/core/encoding.{InvalidCharacter}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert base10.encode(<<>>) == ""
 }
 
-pub fn encode_single_byte_test() {
+pub fn encode_single_byte_test() -> Nil {
   // 0x41 = 65
   assert base10.encode(<<0x41>>) == "65"
 }
 
-pub fn encode_zero_test() {
+pub fn encode_zero_test() -> Nil {
   assert base10.encode(<<0>>) == "0"
 }
 
-pub fn encode_ff_test() {
+pub fn encode_ff_test() -> Nil {
   assert base10.encode(<<0xff>>) == "255"
 }
 
-pub fn encode_two_bytes_test() {
+pub fn encode_two_bytes_test() -> Nil {
   // 0x01 0x00 = 256
   assert base10.encode(<<1, 0>>) == "256"
 }
 
-pub fn encode_leading_zeros_test() {
+pub fn encode_leading_zeros_test() -> Nil {
   assert base10.encode(<<0, 0, 1>>) == "001"
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert base10.decode("") == Ok(<<>>)
 }
 
-pub fn decode_single_byte_test() {
+pub fn decode_single_byte_test() -> Nil {
   assert base10.decode("65") == Ok(<<0x41>>)
 }
 
-pub fn decode_invalid_char_test() {
+pub fn decode_invalid_char_test() -> Nil {
   assert base10.decode("12a") == Error(InvalidCharacter("a", 2))
 }
 
-pub fn roundtrip_test() {
+pub fn roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert base10.decode(base10.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_binary_test() {
+pub fn roundtrip_binary_test() -> Nil {
   let data = <<0x00, 0xff, 0x80, 0x01>>
   assert base10.decode(base10.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_leading_zeros_test() {
+pub fn roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 0, 42>>
   assert base10.decode(base10.encode(data)) == Ok(data)
 }
 
-pub fn decode_leading_zeros_preserved_test() {
+pub fn decode_leading_zeros_preserved_test() -> Nil {
   assert base10.decode("001") == Ok(<<0, 0, 1>>)
 }

--- a/test/base16_test.gleam
+++ b/test/base16_test.gleam
@@ -3,87 +3,87 @@ import yabase/core/encoding.{InvalidCharacter, InvalidLength}
 
 // --- Fixed vectors ---
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert base16.encode(<<>>) == ""
 }
 
-pub fn encode_hello_test() {
+pub fn encode_hello_test() -> Nil {
   assert base16.encode(<<"Hello":utf8>>) == "48656c6c6f"
 }
 
-pub fn encode_single_byte_test() {
+pub fn encode_single_byte_test() -> Nil {
   assert base16.encode(<<255>>) == "ff"
 }
 
-pub fn encode_zero_byte_test() {
+pub fn encode_zero_byte_test() -> Nil {
   assert base16.encode(<<0>>) == "00"
 }
 
-pub fn encode_binary_test() {
+pub fn encode_binary_test() -> Nil {
   assert base16.encode(<<0xde, 0xad, 0xbe, 0xef>>) == "deadbeef"
 }
 
-pub fn encode_leading_zeros_test() {
+pub fn encode_leading_zeros_test() -> Nil {
   assert base16.encode(<<0, 0, 1>>) == "000001"
 }
 
-pub fn encode_all_zeros_test() {
+pub fn encode_all_zeros_test() -> Nil {
   assert base16.encode(<<0, 0, 0, 0>>) == "00000000"
 }
 
-pub fn encode_high_bit_bytes_test() {
+pub fn encode_high_bit_bytes_test() -> Nil {
   assert base16.encode(<<0xff, 0x80, 0x7f>>) == "ff807f"
 }
 
 // --- Decode fixed vectors ---
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert base16.decode("") == Ok(<<>>)
 }
 
-pub fn decode_hello_test() {
+pub fn decode_hello_test() -> Nil {
   assert base16.decode("48656c6c6f") == Ok(<<"Hello":utf8>>)
 }
 
-pub fn decode_uppercase_test() {
+pub fn decode_uppercase_test() -> Nil {
   assert base16.decode("48656C6C6F") == Ok(<<"Hello":utf8>>)
 }
 
 // --- Decode error cases ---
 
-pub fn decode_invalid_length_test() {
+pub fn decode_invalid_length_test() -> Nil {
   assert base16.decode("abc") == Error(InvalidLength(3))
 }
 
-pub fn decode_invalid_char_test() {
+pub fn decode_invalid_char_test() -> Nil {
   assert base16.decode("zz") == Error(InvalidCharacter("z", 0))
 }
 
-pub fn decode_invalid_char_position_test() {
+pub fn decode_invalid_char_position_test() -> Nil {
   assert base16.decode("0g") == Error(InvalidCharacter("g", 1))
 }
 
 // --- Roundtrip ---
 
-pub fn roundtrip_test() {
+pub fn roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert base16.decode(base16.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_empty_test() {
+pub fn roundtrip_empty_test() -> Nil {
   assert base16.decode(base16.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn roundtrip_single_zero_test() {
+pub fn roundtrip_single_zero_test() -> Nil {
   assert base16.decode(base16.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn roundtrip_leading_zeros_test() {
+pub fn roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 0, 42>>
   assert base16.decode(base16.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_high_bits_test() {
+pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0xfd, 0x80, 0x00>>
   assert base16.decode(base16.encode(data)) == Ok(data)
 }

--- a/test/base2_test.gleam
+++ b/test/base2_test.gleam
@@ -1,57 +1,57 @@
 import yabase/base2
 import yabase/core/encoding.{InvalidCharacter, InvalidLength}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert base2.encode(<<>>) == ""
 }
 
-pub fn encode_single_byte_test() {
+pub fn encode_single_byte_test() -> Nil {
   assert base2.encode(<<0x41>>) == "01000001"
 }
 
-pub fn encode_zero_test() {
+pub fn encode_zero_test() -> Nil {
   assert base2.encode(<<0>>) == "00000000"
 }
 
-pub fn encode_ff_test() {
+pub fn encode_ff_test() -> Nil {
   assert base2.encode(<<0xff>>) == "11111111"
 }
 
-pub fn encode_hello_test() {
+pub fn encode_hello_test() -> Nil {
   // "Hi" = 0x48 0x69
   assert base2.encode(<<"Hi":utf8>>) == "0100100001101001"
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert base2.decode("") == Ok(<<>>)
 }
 
-pub fn decode_single_byte_test() {
+pub fn decode_single_byte_test() -> Nil {
   assert base2.decode("01000001") == Ok(<<0x41>>)
 }
 
-pub fn decode_zero_test() {
+pub fn decode_zero_test() -> Nil {
   assert base2.decode("00000000") == Ok(<<0>>)
 }
 
-pub fn decode_ff_test() {
+pub fn decode_ff_test() -> Nil {
   assert base2.decode("11111111") == Ok(<<0xff>>)
 }
 
-pub fn decode_invalid_length_test() {
+pub fn decode_invalid_length_test() -> Nil {
   assert base2.decode("0100") == Error(InvalidLength(4))
 }
 
-pub fn decode_invalid_char_test() {
+pub fn decode_invalid_char_test() -> Nil {
   assert base2.decode("0100000X") == Error(InvalidCharacter("X", 7))
 }
 
-pub fn roundtrip_test() {
+pub fn roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert base2.decode(base2.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_binary_data_test() {
+pub fn roundtrip_binary_data_test() -> Nil {
   let data = <<0x00, 0xff, 0x80, 0x7f, 0x01>>
   assert base2.decode(base2.encode(data)) == Ok(data)
 }

--- a/test/base32_test.gleam
+++ b/test/base32_test.gleam
@@ -9,53 +9,53 @@ import yabase/core/encoding.{InvalidCharacter, InvalidChecksum, InvalidLength}
 
 // --- Fixed vectors (RFC 4648 section 10) ---
 
-pub fn rfc4648_encode_empty_test() {
+pub fn rfc4648_encode_empty_test() -> Nil {
   assert rfc4648.encode(<<>>) == ""
 }
 
-pub fn rfc4648_encode_f_test() {
+pub fn rfc4648_encode_f_test() -> Nil {
   assert rfc4648.encode(<<"f":utf8>>) == "MY======"
 }
 
-pub fn rfc4648_encode_fo_test() {
+pub fn rfc4648_encode_fo_test() -> Nil {
   assert rfc4648.encode(<<"fo":utf8>>) == "MZXQ===="
 }
 
-pub fn rfc4648_encode_foo_test() {
+pub fn rfc4648_encode_foo_test() -> Nil {
   assert rfc4648.encode(<<"foo":utf8>>) == "MZXW6==="
 }
 
-pub fn rfc4648_encode_foob_test() {
+pub fn rfc4648_encode_foob_test() -> Nil {
   assert rfc4648.encode(<<"foob":utf8>>) == "MZXW6YQ="
 }
 
-pub fn rfc4648_encode_fooba_test() {
+pub fn rfc4648_encode_fooba_test() -> Nil {
   assert rfc4648.encode(<<"fooba":utf8>>) == "MZXW6YTB"
 }
 
-pub fn rfc4648_encode_foobar_test() {
+pub fn rfc4648_encode_foobar_test() -> Nil {
   assert rfc4648.encode(<<"foobar":utf8>>) == "MZXW6YTBOI======"
 }
 
-pub fn rfc4648_decode_empty_test() {
+pub fn rfc4648_decode_empty_test() -> Nil {
   assert rfc4648.decode("") == Ok(<<>>)
 }
 
-pub fn rfc4648_decode_f_test() {
+pub fn rfc4648_decode_f_test() -> Nil {
   assert rfc4648.decode("MY======") == Ok(<<"f":utf8>>)
 }
 
-pub fn rfc4648_decode_foobar_test() {
+pub fn rfc4648_decode_foobar_test() -> Nil {
   assert rfc4648.decode("MZXW6YTBOI======") == Ok(<<"foobar":utf8>>)
 }
 
 // --- Decode errors ---
 
-pub fn rfc4648_decode_invalid_char_test() {
+pub fn rfc4648_decode_invalid_char_test() -> Nil {
   assert rfc4648.decode("M1======") == Error(InvalidCharacter("1", 1))
 }
 
-pub fn rfc4648_decode_leading_pad_test() {
+pub fn rfc4648_decode_leading_pad_test() -> Nil {
   // "=MY=====" has padding before data -> must fail
   assert case rfc4648.decode("=MY=====") {
     Error(InvalidCharacter("=", _)) -> True
@@ -63,7 +63,7 @@ pub fn rfc4648_decode_leading_pad_test() {
   }
 }
 
-pub fn rfc4648_decode_mid_pad_test() {
+pub fn rfc4648_decode_mid_pad_test() -> Nil {
   // "M=Y=====" has padding in the middle -> must fail
   assert case rfc4648.decode("M=Y=====") {
     Error(InvalidCharacter("=", _)) -> True
@@ -71,12 +71,12 @@ pub fn rfc4648_decode_mid_pad_test() {
   }
 }
 
-pub fn rfc4648_decode_excess_pad_test() {
+pub fn rfc4648_decode_excess_pad_test() -> Nil {
   // "MY=======" is 9 chars with padding -> 9 % 8 != 0 -> InvalidLength
   assert rfc4648.decode("MY=======") == Error(InvalidLength(9))
 }
 
-pub fn rfc4648_decode_pure_padding_test() {
+pub fn rfc4648_decode_pure_padding_test() -> Nil {
   // "========" is all padding, no data characters -> must fail
   assert case rfc4648.decode("========") {
     Error(InvalidLength(_)) -> True
@@ -86,72 +86,72 @@ pub fn rfc4648_decode_pure_padding_test() {
 
 // --- Unpadded decode ---
 
-pub fn rfc4648_decode_unpadded_f_test() {
+pub fn rfc4648_decode_unpadded_f_test() -> Nil {
   assert rfc4648.decode("MY") == Ok(<<"f":utf8>>)
 }
 
-pub fn rfc4648_decode_unpadded_foobar_test() {
+pub fn rfc4648_decode_unpadded_foobar_test() -> Nil {
   assert rfc4648.decode("MZXW6YTBOI") == Ok(<<"foobar":utf8>>)
 }
 
 // --- Roundtrip corpus ---
 
-pub fn rfc4648_roundtrip_test() {
+pub fn rfc4648_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert rfc4648.decode(rfc4648.encode(data)) == Ok(data)
 }
 
-pub fn rfc4648_roundtrip_empty_test() {
+pub fn rfc4648_roundtrip_empty_test() -> Nil {
   assert rfc4648.decode(rfc4648.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn rfc4648_roundtrip_single_zero_test() {
+pub fn rfc4648_roundtrip_single_zero_test() -> Nil {
   assert rfc4648.decode(rfc4648.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn rfc4648_roundtrip_leading_zeros_test() {
+pub fn rfc4648_roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 0, 42>>
   assert rfc4648.decode(rfc4648.encode(data)) == Ok(data)
 }
 
-pub fn rfc4648_roundtrip_all_zeros_test() {
+pub fn rfc4648_roundtrip_all_zeros_test() -> Nil {
   let data = <<0, 0, 0, 0>>
   assert rfc4648.decode(rfc4648.encode(data)) == Ok(data)
 }
 
-pub fn rfc4648_roundtrip_high_bits_test() {
+pub fn rfc4648_roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0x80, 0x7f>>
   assert rfc4648.decode(rfc4648.encode(data)) == Ok(data)
 }
 
 // ===== Hex =====
 
-pub fn hex_encode_empty_test() {
+pub fn hex_encode_empty_test() -> Nil {
   assert base32_hex.encode(<<>>) == ""
 }
 
-pub fn hex_encode_foo_test() {
+pub fn hex_encode_foo_test() -> Nil {
   assert base32_hex.encode(<<"foo":utf8>>) == "CPNMU==="
 }
 
-pub fn hex_decode_unpadded_foo_test() {
+pub fn hex_decode_unpadded_foo_test() -> Nil {
   assert base32_hex.decode("CPNMU") == Ok(<<"foo":utf8>>)
 }
 
-pub fn hex_roundtrip_test() {
+pub fn hex_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert base32_hex.decode(base32_hex.encode(data)) == Ok(data)
 }
 
-pub fn hex_roundtrip_empty_test() {
+pub fn hex_roundtrip_empty_test() -> Nil {
   assert base32_hex.decode(base32_hex.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn hex_roundtrip_single_zero_test() {
+pub fn hex_roundtrip_single_zero_test() -> Nil {
   assert base32_hex.decode(base32_hex.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn hex_decode_leading_pad_test() {
+pub fn hex_decode_leading_pad_test() -> Nil {
   // "=0000000" is 8 chars with leading pad -> InvalidCharacter
   assert case base32_hex.decode("=0000000") {
     Error(InvalidCharacter("=", _)) -> True
@@ -159,7 +159,7 @@ pub fn hex_decode_leading_pad_test() {
   }
 }
 
-pub fn hex_decode_mid_pad_test() {
+pub fn hex_decode_mid_pad_test() -> Nil {
   // "00=00000" is 8 chars with mid pad -> InvalidCharacter
   assert case base32_hex.decode("00=00000") {
     Error(InvalidCharacter("=", _)) -> True
@@ -167,7 +167,7 @@ pub fn hex_decode_mid_pad_test() {
   }
 }
 
-pub fn hex_decode_pure_padding_test() {
+pub fn hex_decode_pure_padding_test() -> Nil {
   assert case base32_hex.decode("========") {
     Error(InvalidLength(_)) -> True
     _ -> False
@@ -178,55 +178,55 @@ pub fn hex_decode_pure_padding_test() {
 // Crockford Base32 treats data as a number, not a byte stream.
 // See: https://www.crockford.com/base32.html
 
-pub fn crockford_encode_empty_test() {
+pub fn crockford_encode_empty_test() -> Nil {
   assert crockford.encode(<<>>) == ""
 }
 
 // Spec conformance: numeric value encoding
-pub fn crockford_encode_numeric_65_test() {
+pub fn crockford_encode_numeric_65_test() -> Nil {
   // <<65>> = numeric 65, 65 = 2*32 + 1 = "21"
   assert crockford.encode(<<65>>) == "21"
 }
 
-pub fn crockford_encode_numeric_0_test() {
+pub fn crockford_encode_numeric_0_test() -> Nil {
   // <<0>> = numeric 0
   assert crockford.encode(<<0>>) == "0"
 }
 
-pub fn crockford_encode_numeric_31_test() {
+pub fn crockford_encode_numeric_31_test() -> Nil {
   // <<31>> = numeric 31 = "Z"
   assert crockford.encode(<<31>>) == "Z"
 }
 
-pub fn crockford_encode_numeric_32_test() {
+pub fn crockford_encode_numeric_32_test() -> Nil {
   // <<32>> = numeric 32 = 1*32 + 0 = "10"
   assert crockford.encode(<<32>>) == "10"
 }
 
-pub fn crockford_encode_numeric_1023_test() {
+pub fn crockford_encode_numeric_1023_test() -> Nil {
   // <<3, 0xFF>> = numeric 1023 = 31*32 + 31 = "ZZ"
   assert crockford.encode(<<3, 255>>) == "ZZ"
 }
 
-pub fn crockford_roundtrip_test() {
+pub fn crockford_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert crockford.decode(crockford.encode(data)) == Ok(data)
 }
 
-pub fn crockford_roundtrip_empty_test() {
+pub fn crockford_roundtrip_empty_test() -> Nil {
   assert crockford.decode(crockford.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn crockford_roundtrip_single_zero_test() {
+pub fn crockford_roundtrip_single_zero_test() -> Nil {
   assert crockford.decode(crockford.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn crockford_roundtrip_leading_zeros_test() {
+pub fn crockford_roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 42>>
   assert crockford.decode(crockford.encode(data)) == Ok(data)
 }
 
-pub fn crockford_decode_with_hyphens_test() {
+pub fn crockford_decode_with_hyphens_test() -> Nil {
   // Crockford allows hyphens as separators
   let data = <<"test":utf8>>
   let encoded = crockford.encode(data)
@@ -238,10 +238,10 @@ pub fn crockford_decode_with_hyphens_test() {
 }
 
 fn insert_hyphen_every(
-  chars: List(String),
-  every: Int,
-  count: Int,
-  acc: String,
+  chars chars: List(String),
+  every every: Int,
+  count count: Int,
+  acc acc: String,
 ) -> String {
   case chars {
     [] -> acc
@@ -251,12 +251,17 @@ fn insert_hyphen_every(
         True -> "-"
         False -> ""
       }
-      insert_hyphen_every(rest, every, new_count, acc <> c <> sep)
+      insert_hyphen_every(
+        chars: rest,
+        every: every,
+        count: new_count,
+        acc: acc <> c <> sep,
+      )
     }
   }
 }
 
-pub fn crockford_decode_o_as_zero_test() {
+pub fn crockford_decode_o_as_zero_test() -> Nil {
   // "O" should be decoded as "0"
   let data = <<"test":utf8>>
   let encoded = crockford.encode(data)
@@ -265,7 +270,7 @@ pub fn crockford_decode_o_as_zero_test() {
   assert crockford.decode(with_o) == Ok(data)
 }
 
-pub fn crockford_decode_i_l_as_one_test() {
+pub fn crockford_decode_i_l_as_one_test() -> Nil {
   // "I" and "L" should be decoded as "1"
   let data = <<"test":utf8>>
   let encoded = crockford.encode(data)
@@ -273,27 +278,27 @@ pub fn crockford_decode_i_l_as_one_test() {
   assert crockford.decode(with_i) == Ok(data)
 }
 
-pub fn crockford_decode_case_insensitive_test() {
+pub fn crockford_decode_case_insensitive_test() -> Nil {
   assert crockford.decode("2a") == crockford.decode("2A")
   assert crockford.decode("zz") == crockford.decode("ZZ")
 }
 
 // ===== Crockford check symbol =====
 
-pub fn crockford_check_roundtrip_test() {
+pub fn crockford_check_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert crockford.decode_check(crockford.encode_check(data)) == Ok(data)
 }
 
-pub fn crockford_check_roundtrip_empty_test() {
+pub fn crockford_check_roundtrip_empty_test() -> Nil {
   assert crockford.decode_check(crockford.encode_check(<<>>)) == Ok(<<>>)
 }
 
-pub fn crockford_check_roundtrip_single_byte_test() {
+pub fn crockford_check_roundtrip_single_byte_test() -> Nil {
   assert crockford.decode_check(crockford.encode_check(<<42>>)) == Ok(<<42>>)
 }
 
-pub fn crockford_check_symbol_is_appended_test() {
+pub fn crockford_check_symbol_is_appended_test() -> Nil {
   // encode_check should produce encode output + 1 check character
   let data = <<"test":utf8>>
   let without = crockford.encode(data)
@@ -301,7 +306,7 @@ pub fn crockford_check_symbol_is_appended_test() {
   assert string.length(with) == string.length(without) + 1
 }
 
-pub fn crockford_check_wrong_symbol_test() {
+pub fn crockford_check_wrong_symbol_test() -> Nil {
   let encoded = crockford.encode_check(<<"test":utf8>>)
   // Corrupt the check symbol (last char)
   let len = string.length(encoded)
@@ -319,7 +324,7 @@ pub fn crockford_check_wrong_symbol_test() {
   }
 }
 
-pub fn crockford_check_extended_symbols_test() {
+pub fn crockford_check_extended_symbols_test() -> Nil {
   // Values 32-36 map to *~$=U; test that these round-trip
   // Find data whose mod 37 hits each extended symbol
   // 32 = *, 33 = ~, 34 = $, 35 = =, 36 = U
@@ -330,45 +335,45 @@ pub fn crockford_check_extended_symbols_test() {
   assert crockford.decode_check(crockford.encode_check(<<36>>)) == Ok(<<36>>)
 }
 
-pub fn crockford_check_empty_input_decode_test() {
+pub fn crockford_check_empty_input_decode_test() -> Nil {
   // Decoding a single character = just a check symbol, body is empty
   assert crockford.decode_check("0") == Ok(<<>>)
 }
 
 // ===== Clockwork =====
 
-pub fn clockwork_encode_empty_test() {
+pub fn clockwork_encode_empty_test() -> Nil {
   assert clockwork.encode(<<>>) == ""
 }
 
-pub fn clockwork_roundtrip_test() {
+pub fn clockwork_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert clockwork.decode(clockwork.encode(data)) == Ok(data)
 }
 
-pub fn clockwork_roundtrip_empty_test() {
+pub fn clockwork_roundtrip_empty_test() -> Nil {
   assert clockwork.decode(clockwork.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn clockwork_roundtrip_single_zero_test() {
+pub fn clockwork_roundtrip_single_zero_test() -> Nil {
   assert clockwork.decode(clockwork.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn clockwork_decode_lowercase_test() {
+pub fn clockwork_decode_lowercase_test() -> Nil {
   let data = <<"test":utf8>>
   let encoded = clockwork.encode(data)
   // lowercase should also decode
   assert clockwork.decode(string.lowercase(encoded)) == Ok(data)
 }
 
-pub fn clockwork_decode_o_as_zero_test() {
+pub fn clockwork_decode_o_as_zero_test() -> Nil {
   let data = <<"test":utf8>>
   let encoded = clockwork.encode(data)
   let with_o = string.replace(encoded, "0", "O")
   assert clockwork.decode(with_o) == Ok(data)
 }
 
-pub fn clockwork_decode_i_l_as_one_test() {
+pub fn clockwork_decode_i_l_as_one_test() -> Nil {
   let data = <<"test":utf8>>
   let encoded = clockwork.encode(data)
   let with_l = string.replace(encoded, "1", "L")

--- a/test/base36_test.gleam
+++ b/test/base36_test.gleam
@@ -2,53 +2,53 @@ import gleam/string
 import yabase/base36
 import yabase/core/encoding.{InvalidCharacter}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert base36.encode(<<>>) == ""
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert base36.decode("") == Ok(<<>>)
 }
 
-pub fn roundtrip_empty_test() {
+pub fn roundtrip_empty_test() -> Nil {
   assert base36.decode(base36.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn roundtrip_single_zero_test() {
+pub fn roundtrip_single_zero_test() -> Nil {
   assert base36.decode(base36.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn roundtrip_leading_zeros_test() {
+pub fn roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 42>>
   assert base36.decode(base36.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_all_zeros_test() {
+pub fn roundtrip_all_zeros_test() -> Nil {
   let data = <<0, 0, 0, 0>>
   assert base36.decode(base36.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_hello_test() {
+pub fn roundtrip_hello_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert base36.decode(base36.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_high_bits_test() {
+pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0x80, 0x7f>>
   assert base36.decode(base36.encode(data)) == Ok(data)
 }
 
-pub fn decode_case_insensitive_test() {
+pub fn decode_case_insensitive_test() -> Nil {
   let data = <<"test":utf8>>
   let encoded = base36.encode(data)
   let upper = string.uppercase(encoded)
   assert base36.decode(upper) == Ok(data)
 }
 
-pub fn decode_leading_zeros_preserved_test() {
+pub fn decode_leading_zeros_preserved_test() -> Nil {
   assert base36.decode("001") == Ok(<<0, 0, 1>>)
 }
 
-pub fn decode_invalid_char_test() {
+pub fn decode_invalid_char_test() -> Nil {
   assert base36.decode("!!!") == Error(InvalidCharacter("!", 0))
 }

--- a/test/base45_test.gleam
+++ b/test/base45_test.gleam
@@ -1,86 +1,86 @@
 import yabase/base45
 import yabase/core/encoding.{InvalidCharacter, InvalidLength, Overflow}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert base45.encode(<<>>) == ""
 }
 
-pub fn encode_ab_test() {
+pub fn encode_ab_test() -> Nil {
   assert base45.encode(<<"AB":utf8>>) == "BB8"
 }
 
-pub fn encode_hello_test() {
+pub fn encode_hello_test() -> Nil {
   assert base45.encode(<<"Hello!!":utf8>>) == "%69 VD92EX0"
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert base45.decode("") == Ok(<<>>)
 }
 
-pub fn decode_ab_test() {
+pub fn decode_ab_test() -> Nil {
   assert base45.decode("BB8") == Ok(<<"AB":utf8>>)
 }
 
 // --- Decode errors ---
 
-pub fn decode_invalid_length_1_test() {
+pub fn decode_invalid_length_1_test() -> Nil {
   assert base45.decode("A") == Error(InvalidLength(1))
 }
 
-pub fn decode_invalid_length_4_test() {
+pub fn decode_invalid_length_4_test() -> Nil {
   assert base45.decode("ABCD") == Error(InvalidLength(4))
 }
 
-pub fn decode_invalid_char_test() {
+pub fn decode_invalid_char_test() -> Nil {
   assert base45.decode("@@") == Error(InvalidCharacter("@", 0))
 }
 
 // --- RFC 9285 test vectors ---
 
-pub fn rfc9285_example1_encode_test() {
+pub fn rfc9285_example1_encode_test() -> Nil {
   // Example 1: "AB" -> "BB8"
   assert base45.encode(<<"AB":utf8>>) == "BB8"
 }
 
-pub fn rfc9285_example2_encode_test() {
+pub fn rfc9285_example2_encode_test() -> Nil {
   // Example 2: "Hello!!" -> "%69 VD92EX0"
   assert base45.encode(<<"Hello!!":utf8>>) == "%69 VD92EX0"
 }
 
-pub fn rfc9285_example3_encode_test() {
+pub fn rfc9285_example3_encode_test() -> Nil {
   // Example 3: "base-45" -> "UJCLQE7W581"
   assert base45.encode(<<"base-45":utf8>>) == "UJCLQE7W581"
 }
 
-pub fn rfc9285_example3_decode_test() {
+pub fn rfc9285_example3_decode_test() -> Nil {
   assert base45.decode("UJCLQE7W581") == Ok(<<"base-45":utf8>>)
 }
 
 // --- Cross-reference vectors (shogo82148/base45) ---
 
-pub fn rfc9285_ietf_encode_test() {
+pub fn rfc9285_ietf_encode_test() -> Nil {
   assert base45.encode(<<"ietf!":utf8>>) == "QED8WEX0"
 }
 
-pub fn rfc9285_ietf_decode_test() {
+pub fn rfc9285_ietf_decode_test() -> Nil {
   assert base45.decode("QED8WEX0") == Ok(<<"ietf!":utf8>>)
 }
 
-pub fn encode_hello_world_test() {
+pub fn encode_hello_world_test() -> Nil {
   assert base45.encode(<<"Hello, world!":utf8>>) == "%69 VDK2EV4404ESVDX0"
 }
 
-pub fn decode_hello_world_test() {
+pub fn decode_hello_world_test() -> Nil {
   assert base45.decode("%69 VDK2EV4404ESVDX0") == Ok(<<"Hello, world!":utf8>>)
 }
 
-pub fn encode_with_null_byte_test() {
+pub fn encode_with_null_byte_test() -> Nil {
   // "some data with \x00 and \ufeff"
   let data = <<"some data with ":utf8, 0x00, " and ":utf8, 0xEF, 0xBB, 0xBF>>
   assert base45.encode(data) == "VQEF$DC44IECOCCE4FAWE2249440/DG743XN"
 }
 
-pub fn decode_with_null_byte_test() {
+pub fn decode_with_null_byte_test() -> Nil {
   let expected = <<
     "some data with ":utf8, 0x00, " and ":utf8, 0xEF, 0xBB, 0xBF,
   >>
@@ -89,14 +89,14 @@ pub fn decode_with_null_byte_test() {
 
 // --- Overflow rejection ---
 
-pub fn decode_overflow_3char_group_test() {
+pub fn decode_overflow_3char_group_test() -> Nil {
   // "GGW" -> G=16, W=32 -> 16 + 32*45 + ... check if > 65535
   // Maximum valid 3-char group is value 65535
   // ":::" -> ':'=44 -> 44 + 44*45 + 44*45*45 = 44 + 1980 + 89100 = 91124 > 65535
   assert base45.decode(":::") == Error(Overflow)
 }
 
-pub fn decode_overflow_2char_group_test() {
+pub fn decode_overflow_2char_group_test() -> Nil {
   // Maximum valid 2-char value is 255
   // "::" -> 44 + 44*45 = 44 + 1980 = 2024 > 255
   assert base45.decode("::") == Error(Overflow)
@@ -104,20 +104,20 @@ pub fn decode_overflow_2char_group_test() {
 
 // --- Roundtrip corpus ---
 
-pub fn roundtrip_test() {
+pub fn roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert base45.decode(base45.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_empty_test() {
+pub fn roundtrip_empty_test() -> Nil {
   assert base45.decode(base45.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn roundtrip_single_byte_test() {
+pub fn roundtrip_single_byte_test() -> Nil {
   assert base45.decode(base45.encode(<<42>>)) == Ok(<<42>>)
 }
 
-pub fn roundtrip_high_bits_test() {
+pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe>>
   assert base45.decode(base45.encode(data)) == Ok(data)
 }

--- a/test/base58_test.gleam
+++ b/test/base58_test.gleam
@@ -4,120 +4,120 @@ import yabase/core/encoding.{InvalidCharacter}
 
 // === Bitcoin alphabet ===
 
-pub fn bitcoin_encode_empty_test() {
+pub fn bitcoin_encode_empty_test() -> Nil {
   assert bitcoin.encode(<<>>) == ""
 }
 
-pub fn bitcoin_encode_hello_test() {
+pub fn bitcoin_encode_hello_test() -> Nil {
   assert bitcoin.encode(<<"Hello World":utf8>>) == "JxF12TrwUP45BMd"
 }
 
-pub fn bitcoin_encode_leading_zeros_test() {
+pub fn bitcoin_encode_leading_zeros_test() -> Nil {
   assert bitcoin.encode(<<0, 0, 1>>) == "112"
 }
 
-pub fn bitcoin_decode_empty_test() {
+pub fn bitcoin_decode_empty_test() -> Nil {
   assert bitcoin.decode("") == Ok(<<>>)
 }
 
-pub fn bitcoin_decode_hello_test() {
+pub fn bitcoin_decode_hello_test() -> Nil {
   assert bitcoin.decode("JxF12TrwUP45BMd") == Ok(<<"Hello World":utf8>>)
 }
 
-pub fn bitcoin_decode_leading_ones_test() {
+pub fn bitcoin_decode_leading_ones_test() -> Nil {
   assert bitcoin.decode("112") == Ok(<<0, 0, 1>>)
 }
 
-pub fn bitcoin_decode_invalid_char_zero_test() {
+pub fn bitcoin_decode_invalid_char_zero_test() -> Nil {
   assert bitcoin.decode("0") == Error(InvalidCharacter("0", 0))
 }
 
-pub fn bitcoin_decode_invalid_char_upper_o_test() {
+pub fn bitcoin_decode_invalid_char_upper_o_test() -> Nil {
   assert bitcoin.decode("O") == Error(InvalidCharacter("O", 0))
 }
 
-pub fn bitcoin_decode_invalid_char_upper_i_test() {
+pub fn bitcoin_decode_invalid_char_upper_i_test() -> Nil {
   assert bitcoin.decode("I") == Error(InvalidCharacter("I", 0))
 }
 
-pub fn bitcoin_decode_invalid_char_l_test() {
+pub fn bitcoin_decode_invalid_char_l_test() -> Nil {
   assert bitcoin.decode("l") == Error(InvalidCharacter("l", 0))
 }
 
-pub fn bitcoin_roundtrip_test() {
+pub fn bitcoin_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert bitcoin.decode(bitcoin.encode(data)) == Ok(data)
 }
 
-pub fn bitcoin_roundtrip_empty_test() {
+pub fn bitcoin_roundtrip_empty_test() -> Nil {
   assert bitcoin.decode(bitcoin.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn bitcoin_roundtrip_single_zero_test() {
+pub fn bitcoin_roundtrip_single_zero_test() -> Nil {
   assert bitcoin.decode(bitcoin.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn bitcoin_roundtrip_leading_zeros_test() {
+pub fn bitcoin_roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 0, 42>>
   assert bitcoin.decode(bitcoin.encode(data)) == Ok(data)
 }
 
-pub fn bitcoin_roundtrip_high_bits_test() {
+pub fn bitcoin_roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0xfd>>
   assert bitcoin.decode(bitcoin.encode(data)) == Ok(data)
 }
 
 // === Flickr alphabet ===
 
-pub fn flickr_encode_empty_test() {
+pub fn flickr_encode_empty_test() -> Nil {
   assert flickr.encode(<<>>) == ""
 }
 
-pub fn flickr_encode_hello_test() {
+pub fn flickr_encode_hello_test() -> Nil {
   let encoded = flickr.encode(<<"Hello World":utf8>>)
   // Flickr swaps upper/lowercase relative to Bitcoin
   assert encoded == "iXf12sRWto45bmC"
 }
 
-pub fn flickr_decode_hello_test() {
+pub fn flickr_decode_hello_test() -> Nil {
   assert flickr.decode("iXf12sRWto45bmC") == Ok(<<"Hello World":utf8>>)
 }
 
-pub fn flickr_decode_invalid_char_zero_test() {
+pub fn flickr_decode_invalid_char_zero_test() -> Nil {
   assert flickr.decode("0") == Error(InvalidCharacter("0", 0))
 }
 
-pub fn flickr_roundtrip_test() {
+pub fn flickr_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert flickr.decode(flickr.encode(data)) == Ok(data)
 }
 
-pub fn flickr_roundtrip_empty_test() {
+pub fn flickr_roundtrip_empty_test() -> Nil {
   assert flickr.decode(flickr.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn flickr_roundtrip_single_zero_test() {
+pub fn flickr_roundtrip_single_zero_test() -> Nil {
   assert flickr.decode(flickr.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn flickr_roundtrip_leading_zeros_test() {
+pub fn flickr_roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 0, 42>>
   assert flickr.decode(flickr.encode(data)) == Ok(data)
 }
 
-pub fn flickr_roundtrip_high_bits_test() {
+pub fn flickr_roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0xfd>>
   assert flickr.decode(flickr.encode(data)) == Ok(data)
 }
 
 // === Cross-alphabet: same data, different output ===
 
-pub fn bitcoin_flickr_different_output_test() {
+pub fn bitcoin_flickr_different_output_test() -> Nil {
   let data = <<"test":utf8>>
   assert bitcoin.encode(data) != flickr.encode(data)
 }
 
-pub fn bitcoin_flickr_same_data_test() {
+pub fn bitcoin_flickr_same_data_test() -> Nil {
   let data = <<"test":utf8>>
   let assert Ok(d1) = bitcoin.decode(bitcoin.encode(data))
   let assert Ok(d2) = flickr.decode(flickr.encode(data))
@@ -126,33 +126,33 @@ pub fn bitcoin_flickr_same_data_test() {
 
 // === Cross-reference vectors (paulmillr/scure-base) ===
 
-pub fn scure_hello_world_test() {
+pub fn scure_hello_world_test() -> Nil {
   assert bitcoin.encode(<<"hello world":utf8>>) == "StV1DL6CwTryKyV"
   assert bitcoin.decode("StV1DL6CwTryKyV") == Ok(<<"hello world":utf8>>)
 }
 
-pub fn scure_hello_world_excl_test() {
+pub fn scure_hello_world_excl_test() -> Nil {
   assert bitcoin.encode(<<"Hello World!":utf8>>) == "2NEpo7TZRRrLZSi2U"
   assert bitcoin.decode("2NEpo7TZRRrLZSi2U") == Ok(<<"Hello World!":utf8>>)
 }
 
-pub fn scure_leading_zeros_test() {
+pub fn scure_leading_zeros_test() -> Nil {
   assert bitcoin.encode(<<0, 0, 0x28, 0x7f, 0xb4, 0xcd>>) == "11233QC4"
   assert bitcoin.decode("11233QC4") == Ok(<<0, 0, 0x28, 0x7f, 0xb4, 0xcd>>)
 }
 
-pub fn scure_quick_brown_fox_test() {
+pub fn scure_quick_brown_fox_test() -> Nil {
   let data = <<"The quick brown fox jumps over the lazy dog.":utf8>>
   assert bitcoin.encode(data)
     == "USm3fpXnKG5EUBx2ndxBDMPVciP5hGey2Jh4NDv6gmeo1LkMeiKrLJUUBk6Z"
 }
 
-pub fn scure_short_bytes_test() {
+pub fn scure_short_bytes_test() -> Nil {
   assert bitcoin.encode(<<0x51, 0x6b, 0x6f, 0xcd, 0x0f>>) == "ABnLTmg"
   assert bitcoin.decode("ABnLTmg") == Ok(<<0x51, 0x6b, 0x6f, 0xcd, 0x0f>>)
 }
 
-pub fn scure_leading_zeros_hello_test() {
+pub fn scure_leading_zeros_hello_test() -> Nil {
   assert bitcoin.encode(<<0, 0, "hello world":utf8>>) == "11StV1DL6CwTryKyV"
   assert bitcoin.decode("11StV1DL6CwTryKyV") == Ok(<<0, 0, "hello world":utf8>>)
 }

--- a/test/base58check_test.gleam
+++ b/test/base58check_test.gleam
@@ -5,7 +5,7 @@ import yabase/core/encoding.{
 
 // --- Roundtrip ---
 
-pub fn roundtrip_version0_test() {
+pub fn roundtrip_version0_test() -> Nil {
   let payload = <<1, 2, 3, 4, 5>>
   let assert Ok(encoded) = base58check.encode(0, payload)
   let assert Ok(decoded) = base58check.decode(encoded)
@@ -13,7 +13,7 @@ pub fn roundtrip_version0_test() {
   assert decoded.payload == payload
 }
 
-pub fn roundtrip_version5_test() {
+pub fn roundtrip_version5_test() -> Nil {
   let payload = <<0xde, 0xad, 0xbe, 0xef>>
   let assert Ok(encoded) = base58check.encode(5, payload)
   let assert Ok(decoded) = base58check.decode(encoded)
@@ -21,7 +21,7 @@ pub fn roundtrip_version5_test() {
   assert decoded.payload == payload
 }
 
-pub fn roundtrip_empty_payload_test() {
+pub fn roundtrip_empty_payload_test() -> Nil {
   let assert Ok(encoded) = base58check.encode(0, <<>>)
   let assert Ok(decoded) = base58check.decode(encoded)
   assert decoded.version == 0
@@ -30,7 +30,7 @@ pub fn roundtrip_empty_payload_test() {
 
 // --- Determinism ---
 
-pub fn deterministic_encode_test() {
+pub fn deterministic_encode_test() -> Nil {
   let assert Ok(a) = base58check.encode(0, <<0xab, 0xcd>>)
   let assert Ok(b) = base58check.encode(0, <<0xab, 0xcd>>)
   assert a == b
@@ -38,29 +38,29 @@ pub fn deterministic_encode_test() {
 
 // --- Version boundary ---
 
-pub fn encode_version_0_ok_test() {
+pub fn encode_version_0_ok_test() -> Nil {
   assert case base58check.encode(0, <<>>) {
     Ok(_) -> True
     _ -> False
   }
 }
 
-pub fn encode_version_255_ok_test() {
+pub fn encode_version_255_ok_test() -> Nil {
   assert case base58check.encode(255, <<>>) {
     Ok(_) -> True
     _ -> False
   }
 }
 
-pub fn encode_version_256_error_test() {
+pub fn encode_version_256_error_test() -> Nil {
   assert base58check.encode(256, <<>>) == Error(Overflow)
 }
 
-pub fn encode_version_negative_error_test() {
+pub fn encode_version_negative_error_test() -> Nil {
   assert base58check.encode(-1, <<>>) == Error(Overflow)
 }
 
-pub fn encode_version_256_same_as_0_prevented_test() {
+pub fn encode_version_256_same_as_0_prevented_test() -> Nil {
   // This was the original bug: encode(256, <<>>) silently truncated to version 0
   let assert Ok(v0) = base58check.encode(0, <<>>)
   assert base58check.encode(256, <<>>) != Ok(v0)
@@ -72,7 +72,7 @@ pub fn encode_version_256_same_as_0_prevented_test() {
 //   payload = 0x010966776006953D5567439E5E39F86A0D273BEE
 // This verifies SHA-256 double-hash correctness against an external reference.
 
-pub fn bitcoin_wiki_vector_decode_test() {
+pub fn bitcoin_wiki_vector_decode_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM")
   assert decoded.version == 0
@@ -85,7 +85,7 @@ pub fn bitcoin_wiki_vector_decode_test() {
 
 // --- 20-byte all-zeros roundtrip ---
 
-pub fn known_vector_all_zeros_20byte_test() {
+pub fn known_vector_all_zeros_20byte_test() -> Nil {
   let payload = <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
   let assert Ok(encoded) = base58check.encode(0, payload)
   let assert Ok(decoded) = base58check.decode(encoded)
@@ -95,14 +95,14 @@ pub fn known_vector_all_zeros_20byte_test() {
 
 // --- Error cases ---
 
-pub fn decode_too_short_test() {
+pub fn decode_too_short_test() -> Nil {
   assert case base58check.decode("1") {
     Error(InvalidLength(_)) -> True
     _ -> False
   }
 }
 
-pub fn decode_invalid_checksum_test() {
+pub fn decode_invalid_checksum_test() -> Nil {
   let assert Ok(encoded) = base58check.encode(0, <<1, 2, 3>>)
   let corrupted = encoded <> "1"
   assert case base58check.decode(corrupted) {
@@ -112,30 +112,30 @@ pub fn decode_invalid_checksum_test() {
 }
 
 // Invalid Base58 characters must propagate through base58check.decode
-pub fn decode_invalid_char_zero_test() {
+pub fn decode_invalid_char_zero_test() -> Nil {
   assert base58check.decode("0invalid") == Error(InvalidCharacter("0", 0))
 }
 
-pub fn decode_invalid_char_uppercase_o_test() {
+pub fn decode_invalid_char_uppercase_o_test() -> Nil {
   assert base58check.decode("O") == Error(InvalidCharacter("O", 0))
 }
 
-pub fn decode_invalid_char_uppercase_i_test() {
+pub fn decode_invalid_char_uppercase_i_test() -> Nil {
   assert base58check.decode("I") == Error(InvalidCharacter("I", 0))
 }
 
-pub fn decode_invalid_char_lowercase_l_test() {
+pub fn decode_invalid_char_lowercase_l_test() -> Nil {
   assert base58check.decode("l") == Error(InvalidCharacter("l", 0))
 }
 
-pub fn decode_invalid_char_middle_test() {
+pub fn decode_invalid_char_middle_test() -> Nil {
   assert base58check.decode("111O1111") == Error(InvalidCharacter("O", 3))
 }
 
 // === Cross-reference: bitcoinjs/bs58check fixtures ===
 // Source: https://github.com/bitcoinjs/bs58check
 
-pub fn bs58check_vector_1agn_test() {
+pub fn bs58check_vector_1agn_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i")
   assert decoded.version == 0x00
@@ -164,7 +164,7 @@ pub fn bs58check_vector_1agn_test() {
     >>
 }
 
-pub fn bs58check_vector_3cmn_test() {
+pub fn bs58check_vector_3cmn_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("3CMNFxN1oHBc4R1EpboAL5yzHGgE611Xou")
   assert decoded.version == 0x05
@@ -193,13 +193,13 @@ pub fn bs58check_vector_3cmn_test() {
     >>
 }
 
-pub fn bs58check_vector_mo9n_test() {
+pub fn bs58check_vector_mo9n_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs")
   assert decoded.version == 0x6f
 }
 
-pub fn bs58check_vector_1ax4_test() {
+pub fn bs58check_vector_1ax4_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("1Ax4gZtb7gAit2TivwejZHYtNNLT18PUXJ")
   assert decoded.version == 0x00

--- a/test/base62_test.gleam
+++ b/test/base62_test.gleam
@@ -1,51 +1,51 @@
 import yabase/base62
 import yabase/core/encoding.{InvalidCharacter}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert base62.encode(<<>>) == ""
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert base62.decode("") == Ok(<<>>)
 }
 
-pub fn roundtrip_empty_test() {
+pub fn roundtrip_empty_test() -> Nil {
   assert base62.decode(base62.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn roundtrip_single_zero_test() {
+pub fn roundtrip_single_zero_test() -> Nil {
   assert base62.decode(base62.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn roundtrip_leading_zeros_test() {
+pub fn roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 42>>
   assert base62.decode(base62.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_all_zeros_test() {
+pub fn roundtrip_all_zeros_test() -> Nil {
   let data = <<0, 0, 0, 0>>
   assert base62.decode(base62.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_hello_test() {
+pub fn roundtrip_hello_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert base62.decode(base62.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_binary_test() {
+pub fn roundtrip_binary_test() -> Nil {
   let data = <<0xde, 0xad, 0xbe, 0xef>>
   assert base62.decode(base62.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_high_bits_test() {
+pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0xfd>>
   assert base62.decode(base62.encode(data)) == Ok(data)
 }
 
-pub fn decode_leading_zeros_preserved_test() {
+pub fn decode_leading_zeros_preserved_test() -> Nil {
   assert base62.decode("001") == Ok(<<0, 0, 1>>)
 }
 
-pub fn decode_invalid_char_test() {
+pub fn decode_invalid_char_test() -> Nil {
   assert base62.decode("!!!") == Error(InvalidCharacter("!", 0))
 }

--- a/test/base64_test.gleam
+++ b/test/base64_test.gleam
@@ -9,92 +9,92 @@ import yabase/core/encoding.{InvalidCharacter, InvalidLength}
 
 // --- Fixed vectors (RFC 4648 section 10) ---
 
-pub fn standard_encode_empty_test() {
+pub fn standard_encode_empty_test() -> Nil {
   assert standard.encode(<<>>) == ""
 }
 
-pub fn standard_encode_f_test() {
+pub fn standard_encode_f_test() -> Nil {
   assert standard.encode(<<"f":utf8>>) == "Zg=="
 }
 
-pub fn standard_encode_fo_test() {
+pub fn standard_encode_fo_test() -> Nil {
   assert standard.encode(<<"fo":utf8>>) == "Zm8="
 }
 
-pub fn standard_encode_foo_test() {
+pub fn standard_encode_foo_test() -> Nil {
   assert standard.encode(<<"foo":utf8>>) == "Zm9v"
 }
 
-pub fn standard_encode_foob_test() {
+pub fn standard_encode_foob_test() -> Nil {
   assert standard.encode(<<"foob":utf8>>) == "Zm9vYg=="
 }
 
-pub fn standard_encode_fooba_test() {
+pub fn standard_encode_fooba_test() -> Nil {
   assert standard.encode(<<"fooba":utf8>>) == "Zm9vYmE="
 }
 
-pub fn standard_encode_foobar_test() {
+pub fn standard_encode_foobar_test() -> Nil {
   assert standard.encode(<<"foobar":utf8>>) == "Zm9vYmFy"
 }
 
-pub fn standard_decode_empty_test() {
+pub fn standard_decode_empty_test() -> Nil {
   assert standard.decode("") == Ok(<<>>)
 }
 
-pub fn standard_decode_foobar_test() {
+pub fn standard_decode_foobar_test() -> Nil {
   assert standard.decode("Zm9vYmFy") == Ok(<<"foobar":utf8>>)
 }
 
-pub fn standard_decode_with_padding_test() {
+pub fn standard_decode_with_padding_test() -> Nil {
   assert standard.decode("Zg==") == Ok(<<"f":utf8>>)
 }
 
 // --- Decode error cases ---
 
-pub fn standard_decode_truncated_1char_test() {
+pub fn standard_decode_truncated_1char_test() -> Nil {
   assert standard.decode("Z") == Error(InvalidLength(1))
 }
 
-pub fn standard_decode_truncated_2char_test() {
+pub fn standard_decode_truncated_2char_test() -> Nil {
   assert standard.decode("Zg") == Error(InvalidLength(2))
 }
 
-pub fn standard_decode_truncated_3char_test() {
+pub fn standard_decode_truncated_3char_test() -> Nil {
   assert standard.decode("Zg=") == Error(InvalidLength(3))
 }
 
-pub fn standard_decode_invalid_char_test() {
+pub fn standard_decode_invalid_char_test() -> Nil {
   assert standard.decode("Z!==") == Error(InvalidCharacter("!", 1))
 }
 
 // scure-base bad input vectors (paulmillr/scure-base)
-pub fn scure_bad_a_triple_eq_test() {
+pub fn scure_bad_a_triple_eq_test() -> Nil {
   // "A===" -> invalid (only 1 data char with 3 pad)
   assert case standard.decode("A===") {
-    Error(_) -> True
+    Error(InvalidCharacter(_, _)) -> True
     _ -> False
   }
 }
 
-pub fn scure_bad_aa_single_eq_test() {
+pub fn scure_bad_aa_single_eq_test() -> Nil {
   // "AA=" -> 3 chars, not multiple of 4
   assert standard.decode("AA=") == Error(InvalidLength(3))
 }
 
-pub fn scure_bad_aaaa_8eq_test() {
+pub fn scure_bad_aaaa_8eq_test() -> Nil {
   // "AAAA====" -> 8 chars but excess padding
   assert case standard.decode("AAAA====") {
-    Error(_) -> True
+    Error(InvalidCharacter(_, _)) -> True
     _ -> False
   }
 }
 
-pub fn scure_bad_aaa_test() {
+pub fn scure_bad_aaa_test() -> Nil {
   // "AAA" -> 3 chars, not multiple of 4
   assert standard.decode("AAA") == Error(InvalidLength(3))
 }
 
-pub fn scure_bad_pad_prefix_test() {
+pub fn scure_bad_pad_prefix_test() -> Nil {
   // "=Zm8" -> pad at start
   assert case standard.decode("=Zm8") {
     Error(InvalidCharacter("=", 0)) -> True
@@ -102,34 +102,34 @@ pub fn scure_bad_pad_prefix_test() {
   }
 }
 
-pub fn scure_bad_aaaaa_test() {
+pub fn scure_bad_aaaaa_test() -> Nil {
   // "AAAAA" -> 5 chars, not multiple of 4
   assert standard.decode("AAAAA") == Error(InvalidLength(5))
 }
 
-pub fn scure_bad_single_eq_test() {
+pub fn scure_bad_single_eq_test() -> Nil {
   assert standard.decode("=") == Error(InvalidLength(1))
 }
 
-pub fn scure_bad_double_eq_test() {
+pub fn scure_bad_double_eq_test() -> Nil {
   assert standard.decode("==") == Error(InvalidLength(2))
 }
 
 // --- CRLF rejection (RFC 4648 section 3.3) ---
 
-pub fn standard_decode_rejects_lf_test() {
+pub fn standard_decode_rejects_lf_test() -> Nil {
   // "Zm9v\n" is 5 chars -> 5 % 4 != 0 -> InvalidLength
   assert standard.decode("Zm9v\n") == Error(InvalidLength(5))
 }
 
-pub fn standard_decode_rejects_crlf_in_middle_test() {
+pub fn standard_decode_rejects_crlf_in_middle_test() -> Nil {
   // "Zg==\r\n" - \r\n is one grapheme cluster in Unicode -> 5 graphemes
   assert standard.decode("Zg==\r\n") == Error(InvalidLength(5))
 }
 
 // --- Padding-then-trailing-data regression ---
 
-pub fn standard_decode_data_after_double_pad_test() {
+pub fn standard_decode_data_after_double_pad_test() -> Nil {
   // "Zg==AAAA" must be rejected, not silently truncated
   assert case standard.decode("Zg==AAAA") {
     Error(InvalidLength(_)) -> True
@@ -137,7 +137,7 @@ pub fn standard_decode_data_after_double_pad_test() {
   }
 }
 
-pub fn standard_decode_data_after_single_pad_test() {
+pub fn standard_decode_data_after_single_pad_test() -> Nil {
   // "Zm8=AAAA" must be rejected
   assert case standard.decode("Zm8=AAAA") {
     Error(InvalidLength(_)) -> True
@@ -147,63 +147,63 @@ pub fn standard_decode_data_after_single_pad_test() {
 
 // --- Roundtrip corpus ---
 
-pub fn standard_roundtrip_test() {
+pub fn standard_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert standard.decode(standard.encode(data)) == Ok(data)
 }
 
-pub fn standard_roundtrip_empty_test() {
+pub fn standard_roundtrip_empty_test() -> Nil {
   assert standard.decode(standard.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn standard_roundtrip_single_zero_test() {
+pub fn standard_roundtrip_single_zero_test() -> Nil {
   assert standard.decode(standard.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn standard_roundtrip_leading_zeros_test() {
+pub fn standard_roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 0, 42>>
   assert standard.decode(standard.encode(data)) == Ok(data)
 }
 
-pub fn standard_roundtrip_high_bits_test() {
+pub fn standard_roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0x80>>
   assert standard.decode(standard.encode(data)) == Ok(data)
 }
 
 // ===== URL-safe =====
 
-pub fn urlsafe_encode_test() {
+pub fn urlsafe_encode_test() -> Nil {
   let data = <<251, 255, 254>>
   let encoded = urlsafe.encode(data)
   assert encoded == "-__-"
 }
 
-pub fn urlsafe_roundtrip_test() {
+pub fn urlsafe_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert urlsafe.decode(urlsafe.encode(data)) == Ok(data)
 }
 
-pub fn urlsafe_roundtrip_empty_test() {
+pub fn urlsafe_roundtrip_empty_test() -> Nil {
   assert urlsafe.decode(urlsafe.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn urlsafe_decode_truncated_test() {
+pub fn urlsafe_decode_truncated_test() -> Nil {
   assert urlsafe.decode("ab") == Error(InvalidLength(2))
 }
 
-pub fn urlsafe_decode_rejects_lf_test() {
+pub fn urlsafe_decode_rejects_lf_test() -> Nil {
   // "Zm9v\n" is 5 chars -> 5 % 4 != 0 -> InvalidLength
   assert urlsafe.decode("Zm9v\n") == Error(InvalidLength(5))
 }
 
-pub fn urlsafe_decode_data_after_double_pad_test() {
+pub fn urlsafe_decode_data_after_double_pad_test() -> Nil {
   assert case urlsafe.decode("Zg==AAAA") {
     Error(InvalidLength(_)) -> True
     _ -> False
   }
 }
 
-pub fn urlsafe_decode_data_after_single_pad_test() {
+pub fn urlsafe_decode_data_after_single_pad_test() -> Nil {
   assert case urlsafe.decode("Zm8=AAAA") {
     Error(InvalidLength(_)) -> True
     _ -> False
@@ -212,81 +212,81 @@ pub fn urlsafe_decode_data_after_single_pad_test() {
 
 // ===== No padding =====
 
-pub fn nopadding_encode_f_test() {
+pub fn nopadding_encode_f_test() -> Nil {
   assert nopadding.encode(<<"f":utf8>>) == "Zg"
 }
 
-pub fn nopadding_encode_fo_test() {
+pub fn nopadding_encode_fo_test() -> Nil {
   assert nopadding.encode(<<"fo":utf8>>) == "Zm8"
 }
 
-pub fn nopadding_roundtrip_test() {
+pub fn nopadding_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert nopadding.decode(nopadding.encode(data)) == Ok(data)
 }
 
-pub fn nopadding_roundtrip_empty_test() {
+pub fn nopadding_roundtrip_empty_test() -> Nil {
   assert nopadding.decode(nopadding.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn nopadding_decode_invalid_length_mod4_eq_1_test() {
+pub fn nopadding_decode_invalid_length_mod4_eq_1_test() -> Nil {
   // Length 5 -> 5 % 4 == 1 -> invalid
   assert nopadding.decode("AAAAA") == Error(InvalidLength(5))
 }
 
-pub fn nopadding_decode_rejects_padding_test() {
+pub fn nopadding_decode_rejects_padding_test() -> Nil {
   // "Zg==" is valid padded Base64 for "f", but nopadding must reject it
   assert nopadding.decode("Zg==") == Error(InvalidCharacter("=", 2))
 }
 
-pub fn nopadding_decode_rejects_single_pad_test() {
+pub fn nopadding_decode_rejects_single_pad_test() -> Nil {
   assert nopadding.decode("Zm8=") == Error(InvalidCharacter("=", 3))
 }
 
 // ===== URL-safe no padding =====
 
-pub fn urlsafe_nopadding_decode_rejects_double_pad_test() {
+pub fn urlsafe_nopadding_decode_rejects_double_pad_test() -> Nil {
   assert urlsafe_nopadding.decode("Zg==") == Error(InvalidCharacter("=", 2))
 }
 
-pub fn urlsafe_nopadding_decode_rejects_single_pad_test() {
+pub fn urlsafe_nopadding_decode_rejects_single_pad_test() -> Nil {
   assert urlsafe_nopadding.decode("Zm8=") == Error(InvalidCharacter("=", 3))
 }
 
 // ===== DQ =====
 
-pub fn dq_encode_empty_test() {
+pub fn dq_encode_empty_test() -> Nil {
   assert dq.encode(<<>>) == ""
 }
 
-pub fn dq_roundtrip_test() {
+pub fn dq_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert dq.decode(dq.encode(data)) == Ok(data)
 }
 
-pub fn dq_roundtrip_with_padding_test() {
+pub fn dq_roundtrip_with_padding_test() -> Nil {
   let data = <<"Hi":utf8>>
   assert dq.decode(dq.encode(data)) == Ok(data)
 }
 
-pub fn dq_roundtrip_empty_test() {
+pub fn dq_roundtrip_empty_test() -> Nil {
   assert dq.decode(dq.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn dq_decode_truncated_test() {
+pub fn dq_decode_truncated_test() -> Nil {
   // 1 or 2 or 3 hiragana is invalid (must be multiple of 4)
   assert dq.decode("あ") == Error(InvalidLength(1))
 }
 
-pub fn dq_decode_truncated_2_test() {
+pub fn dq_decode_truncated_2_test() -> Nil {
   assert dq.decode("あい") == Error(InvalidLength(2))
 }
 
-pub fn dq_decode_truncated_3_test() {
+pub fn dq_decode_truncated_3_test() -> Nil {
   assert dq.decode("あいう") == Error(InvalidLength(3))
 }
 
-pub fn dq_decode_data_after_double_pad_test() {
+pub fn dq_decode_data_after_double_pad_test() -> Nil {
   // Encode "f" -> 4 chars with 2 pads, then append valid chars
   let encoded = dq.encode(<<"f":utf8>>)
   let with_extra = encoded <> "あいうえ"
@@ -298,30 +298,30 @@ pub fn dq_decode_data_after_double_pad_test() {
 
 // --- DQ InvalidCharacter at each position ---
 
-pub fn dq_decode_invalid_char_pos0_double_pad_test() {
+pub fn dq_decode_invalid_char_pos0_double_pad_test() -> Nil {
   // "X" + valid + pad + pad  (invalid at position 0, double-pad branch)
   assert dq.decode("Xい・・") == Error(InvalidCharacter("X", 0))
 }
 
-pub fn dq_decode_invalid_char_pos1_double_pad_test() {
+pub fn dq_decode_invalid_char_pos1_double_pad_test() -> Nil {
   // valid + "X" + pad + pad  (invalid at position 1, double-pad branch)
   assert dq.decode("あX・・") == Error(InvalidCharacter("X", 1))
 }
 
-pub fn dq_decode_invalid_char_pos0_single_pad_test() {
+pub fn dq_decode_invalid_char_pos0_single_pad_test() -> Nil {
   // "X" + valid + valid + pad  (invalid at position 0, single-pad branch)
   assert dq.decode("Xいう・") == Error(InvalidCharacter("X", 0))
 }
 
-pub fn dq_decode_invalid_char_pos1_single_pad_test() {
+pub fn dq_decode_invalid_char_pos1_single_pad_test() -> Nil {
   assert dq.decode("あXう・") == Error(InvalidCharacter("X", 1))
 }
 
-pub fn dq_decode_invalid_char_pos2_single_pad_test() {
+pub fn dq_decode_invalid_char_pos2_single_pad_test() -> Nil {
   assert dq.decode("あいX・") == Error(InvalidCharacter("X", 2))
 }
 
-pub fn dq_decode_invalid_char_no_pad_test() {
+pub fn dq_decode_invalid_char_no_pad_test() -> Nil {
   // All 4 positions unpadded
   assert dq.decode("Xいうえ") == Error(InvalidCharacter("X", 0))
   assert dq.decode("あXうえ") == Error(InvalidCharacter("X", 1))
@@ -332,78 +332,78 @@ pub fn dq_decode_invalid_char_no_pad_test() {
 // --- DQ cross-reference vectors (shogo82148/base64dq) ---
 
 // RFC 4648 examples in DQ encoding
-pub fn dq_rfc4648_f_test() {
+pub fn dq_rfc4648_f_test() -> Nil {
   assert dq.encode(<<"f":utf8>>) == "はむ・・"
   assert dq.decode("はむ・・") == Ok(<<"f":utf8>>)
 }
 
-pub fn dq_rfc4648_fo_test() {
+pub fn dq_rfc4648_fo_test() -> Nil {
   assert dq.encode(<<"fo":utf8>>) == "はらび・"
   assert dq.decode("はらび・") == Ok(<<"fo":utf8>>)
 }
 
-pub fn dq_rfc4648_foo_test() {
+pub fn dq_rfc4648_foo_test() -> Nil {
   assert dq.encode(<<"foo":utf8>>) == "はらぶげ"
   assert dq.decode("はらぶげ") == Ok(<<"foo":utf8>>)
 }
 
-pub fn dq_rfc4648_foob_test() {
+pub fn dq_rfc4648_foob_test() -> Nil {
   assert dq.encode(<<"foob":utf8>>) == "はらぶげのむ・・"
   assert dq.decode("はらぶげのむ・・") == Ok(<<"foob":utf8>>)
 }
 
-pub fn dq_rfc4648_fooba_test() {
+pub fn dq_rfc4648_fooba_test() -> Nil {
   assert dq.encode(<<"fooba":utf8>>) == "はらぶげのらお・"
   assert dq.decode("はらぶげのらお・") == Ok(<<"fooba":utf8>>)
 }
 
-pub fn dq_rfc4648_foobar_test() {
+pub fn dq_rfc4648_foobar_test() -> Nil {
   assert dq.encode(<<"foobar":utf8>>) == "はらぶげのらかじ"
   assert dq.decode("はらぶげのらかじ") == Ok(<<"foobar":utf8>>)
 }
 
 // Wikipedia examples
-pub fn dq_wikipedia_sure_dot_test() {
+pub fn dq_wikipedia_sure_dot_test() -> Nil {
   assert dq.encode(<<"sure.":utf8>>) == "へぢにじはてづ・"
   assert dq.decode("へぢにじはてづ・") == Ok(<<"sure.":utf8>>)
 }
 
-pub fn dq_wikipedia_sure_test() {
+pub fn dq_wikipedia_sure_test() -> Nil {
   assert dq.encode(<<"sure":utf8>>) == "へぢにじはち・・"
   assert dq.decode("へぢにじはち・・") == Ok(<<"sure":utf8>>)
 }
 
-pub fn dq_wikipedia_sur_test() {
+pub fn dq_wikipedia_sur_test() -> Nil {
   assert dq.encode(<<"sur":utf8>>) == "へぢにじ"
   assert dq.decode("へぢにじ") == Ok(<<"sur":utf8>>)
 }
 
-pub fn dq_wikipedia_su_test() {
+pub fn dq_wikipedia_su_test() -> Nil {
   assert dq.encode(<<"su":utf8>>) == "へぢな・"
   assert dq.decode("へぢな・") == Ok(<<"su":utf8>>)
 }
 
 // DQ1 password vectors
-pub fn dq_dq1_password_vector_1_test() {
+pub fn dq_dq1_password_vector_1_test() -> Nil {
   let data = <<0x14, 0xFB, 0x9C, 0x03, 0xD9, 0x7E>>
   assert dq.encode(data) == "かたぐへあぶよべ"
   assert dq.decode("かたぐへあぶよべ") == Ok(data)
 }
 
-pub fn dq_dq1_password_vector_2_test() {
+pub fn dq_dq1_password_vector_2_test() -> Nil {
   let data = <<0x14, 0xFB, 0x9C, 0x03, 0xD9>>
   assert dq.encode(data) == "かたぐへあぶゆ・"
   assert dq.decode("かたぐへあぶゆ・") == Ok(data)
 }
 
-pub fn dq_dq1_password_vector_3_test() {
+pub fn dq_dq1_password_vector_3_test() -> Nil {
   let data = <<0x14, 0xFB, 0x9C, 0x03>>
   assert dq.encode(data) == "かたぐへあご・・"
   assert dq.decode("かたぐへあご・・") == Ok(data)
 }
 
 // Bigtest: "Twas brillig, and the slithy toves"
-pub fn dq_bigtest_test() {
+pub fn dq_bigtest_test() -> Nil {
   let data = <<"Twas brillig, and the slithy toves":utf8>>
   let expected = "にくほめへじいもへらよがふきよりしういめふらちむほきめよけくせがひねつるまていぜふぢはよへご・・"
   assert dq.encode(data) == expected
@@ -411,7 +411,7 @@ pub fn dq_bigtest_test() {
 }
 
 // Corrupt input cases from shogo82148/base64dq
-pub fn dq_decode_pad_at_start_test() {
+pub fn dq_decode_pad_at_start_test() -> Nil {
   // "・・・・" -> pad at position 0 is invalid
   assert case dq.decode("・・・・") {
     Error(InvalidCharacter("・", 0)) -> True
@@ -419,7 +419,7 @@ pub fn dq_decode_pad_at_start_test() {
   }
 }
 
-pub fn dq_decode_pad_after_one_char_test() {
+pub fn dq_decode_pad_after_one_char_test() -> Nil {
   // "が・・・" -> pad at position 1 in first group
   assert case dq.decode("が・・・") {
     Error(InvalidCharacter("・", _)) -> True
@@ -429,7 +429,7 @@ pub fn dq_decode_pad_after_one_char_test() {
 
 // --- DQ error cases ---
 
-pub fn dq_decode_non_hiragana_ascii_test() {
+pub fn dq_decode_non_hiragana_ascii_test() -> Nil {
   // ASCII "ABCD" is not in the DQ hiragana alphabet
   assert case dq.decode("ABCD") {
     Error(InvalidCharacter("A", 0)) -> True
@@ -437,7 +437,7 @@ pub fn dq_decode_non_hiragana_ascii_test() {
   }
 }
 
-pub fn dq_decode_non_hiragana_kanji_test() {
+pub fn dq_decode_non_hiragana_kanji_test() -> Nil {
   // Kanji is not in the DQ alphabet
   assert case dq.decode("漢字漢字") {
     Error(InvalidCharacter(_, 0)) -> True
@@ -445,7 +445,7 @@ pub fn dq_decode_non_hiragana_kanji_test() {
   }
 }
 
-pub fn dq_decode_stray_char_in_middle_test() {
+pub fn dq_decode_stray_char_in_middle_test() -> Nil {
   // 4-char aligned input with invalid first char
   assert case dq.decode("Xいうえ") {
     Error(InvalidCharacter("X", 0)) -> True

--- a/test/base8_test.gleam
+++ b/test/base8_test.gleam
@@ -1,60 +1,60 @@
 import yabase/base8
 import yabase/core/encoding.{InvalidCharacter}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert base8.encode(<<>>) == ""
 }
 
-pub fn encode_single_byte_test() {
+pub fn encode_single_byte_test() -> Nil {
   // 0x41 = 65 = octal 101
   assert base8.encode(<<0x41>>) == "101"
 }
 
-pub fn encode_zero_test() {
+pub fn encode_zero_test() -> Nil {
   assert base8.encode(<<0>>) == "0"
 }
 
-pub fn encode_ff_test() {
+pub fn encode_ff_test() -> Nil {
   // 0xff = 255 = octal 377
   assert base8.encode(<<0xff>>) == "377"
 }
 
-pub fn encode_leading_zeros_test() {
+pub fn encode_leading_zeros_test() -> Nil {
   assert base8.encode(<<0, 0, 1>>) == "001"
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert base8.decode("") == Ok(<<>>)
 }
 
-pub fn decode_single_byte_test() {
+pub fn decode_single_byte_test() -> Nil {
   assert base8.decode("101") == Ok(<<0x41>>)
 }
 
-pub fn decode_invalid_char_test() {
+pub fn decode_invalid_char_test() -> Nil {
   assert base8.decode("8") == Error(InvalidCharacter("8", 0))
 }
 
-pub fn decode_invalid_char_letter_test() {
+pub fn decode_invalid_char_letter_test() -> Nil {
   assert base8.decode("12a") == Error(InvalidCharacter("a", 2))
 }
 
-pub fn roundtrip_test() {
+pub fn roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert base8.decode(base8.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_binary_test() {
+pub fn roundtrip_binary_test() -> Nil {
   let data = <<0x00, 0xff, 0x80, 0x01>>
   assert base8.decode(base8.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_leading_zeros_test() {
+pub fn roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 0, 42>>
   assert base8.decode(base8.encode(data)) == Ok(data)
 }
 
 // Leading zero chars in decode produce leading 0x00 bytes (API contract)
-pub fn decode_leading_zeros_preserved_test() {
+pub fn decode_leading_zeros_preserved_test() -> Nil {
   assert base8.decode("001") == Ok(<<0, 0, 1>>)
 }

--- a/test/base91_test.gleam
+++ b/test/base91_test.gleam
@@ -1,78 +1,78 @@
 import yabase/base91
 import yabase/core/encoding.{InvalidCharacter}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert base91.encode(<<>>) == ""
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert base91.decode("") == Ok(<<>>)
 }
 
 // --- Fixed vectors (cross-checked with reference implementation) ---
 
-pub fn encode_test_test() {
+pub fn encode_test_test() -> Nil {
   assert base91.encode(<<"test":utf8>>) == "fPNKd"
 }
 
-pub fn decode_test_test() {
+pub fn decode_test_test() -> Nil {
   assert base91.decode("fPNKd") == Ok(<<"test":utf8>>)
 }
 
-pub fn encode_hello_world_test() {
+pub fn encode_hello_world_test() -> Nil {
   assert base91.encode(<<"Hello World":utf8>>) == ">OwJh>Io0Tv!lE"
 }
 
-pub fn decode_hello_world_test() {
+pub fn decode_hello_world_test() -> Nil {
   assert base91.decode(">OwJh>Io0Tv!lE") == Ok(<<"Hello World":utf8>>)
 }
 
 // --- Roundtrip corpus ---
 
-pub fn roundtrip_hello_test() {
+pub fn roundtrip_hello_test() -> Nil {
   let data = <<"Hello World":utf8>>
   assert base91.decode(base91.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_binary_test() {
+pub fn roundtrip_binary_test() -> Nil {
   let data = <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>
   assert base91.decode(base91.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_empty_test() {
+pub fn roundtrip_empty_test() -> Nil {
   assert base91.decode(base91.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn roundtrip_single_zero_test() {
+pub fn roundtrip_single_zero_test() -> Nil {
   assert base91.decode(base91.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn roundtrip_high_bits_test() {
+pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0xfd, 0xfc>>
   assert base91.decode(base91.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_varied_bytes_test() {
+pub fn roundtrip_varied_bytes_test() -> Nil {
   let data = <<1, 2, 3, 4, 5, 6, 7, 8>>
   assert base91.decode(base91.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_single_byte_test() {
+pub fn roundtrip_single_byte_test() -> Nil {
   assert base91.decode(base91.encode(<<42>>)) == Ok(<<42>>)
 }
 
-pub fn roundtrip_255_test() {
+pub fn roundtrip_255_test() -> Nil {
   assert base91.decode(base91.encode(<<255>>)) == Ok(<<255>>)
 }
 
 // --- Longer input roundtrip ---
 
-pub fn roundtrip_16_bytes_test() {
+pub fn roundtrip_16_bytes_test() -> Nil {
   let data = <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>>
   assert base91.decode(base91.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_32_bytes_test() {
+pub fn roundtrip_32_bytes_test() -> Nil {
   let data = <<
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
     22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
@@ -80,7 +80,7 @@ pub fn roundtrip_32_bytes_test() {
   assert base91.decode(base91.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_48_bytes_test() {
+pub fn roundtrip_48_bytes_test() -> Nil {
   let data = <<
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
     22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
@@ -89,7 +89,7 @@ pub fn roundtrip_48_bytes_test() {
   assert base91.decode(base91.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_64_bytes_test() {
+pub fn roundtrip_64_bytes_test() -> Nil {
   let data = <<
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
     22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
@@ -99,7 +99,7 @@ pub fn roundtrip_64_bytes_test() {
   assert base91.decode(base91.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_all_ff_32_test() {
+pub fn roundtrip_all_ff_32_test() -> Nil {
   let data = <<
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -110,21 +110,21 @@ pub fn roundtrip_all_ff_32_test() {
 
 // --- Error cases ---
 
-pub fn decode_invalid_char_space_test() {
+pub fn decode_invalid_char_space_test() -> Nil {
   assert case base91.decode(" ") {
     Error(InvalidCharacter(" ", 0)) -> True
     _ -> False
   }
 }
 
-pub fn decode_invalid_char_dash_test() {
+pub fn decode_invalid_char_dash_test() -> Nil {
   assert case base91.decode("-") {
     Error(InvalidCharacter("-", 0)) -> True
     _ -> False
   }
 }
 
-pub fn decode_invalid_char_embedded_test() {
+pub fn decode_invalid_char_embedded_test() -> Nil {
   // Valid chars around an invalid one
   assert case base91.decode("fP KNd") {
     Error(InvalidCharacter(" ", _)) -> True

--- a/test/bech32_test.gleam
+++ b/test/bech32_test.gleam
@@ -7,7 +7,7 @@ import yabase/core/encoding.{
 
 // ===== BIP 173 Bech32 =====
 
-pub fn bech32_roundtrip_test() {
+pub fn bech32_roundtrip_test() -> Nil {
   let data = <<0, 1, 2, 3, 4>>
   let assert Ok(encoded) = bech32.encode(Bech32V, "test", data)
   let assert Ok(decoded) = bech32.decode(encoded)
@@ -16,7 +16,7 @@ pub fn bech32_roundtrip_test() {
   assert decoded.data == data
 }
 
-pub fn bech32_empty_data_test() {
+pub fn bech32_empty_data_test() -> Nil {
   let assert Ok(encoded) = bech32.encode(Bech32V, "a", <<>>)
   let assert Ok(decoded) = bech32.decode(encoded)
   assert decoded.hrp == "a"
@@ -26,7 +26,7 @@ pub fn bech32_empty_data_test() {
 
 // ===== BIP 350 Bech32m =====
 
-pub fn bech32m_roundtrip_test() {
+pub fn bech32m_roundtrip_test() -> Nil {
   let data = <<0, 1, 2, 3>>
   let assert Ok(encoded) = bech32.encode(Bech32mV, "test", data)
   let assert Ok(decoded) = bech32.decode(encoded)
@@ -35,7 +35,7 @@ pub fn bech32m_roundtrip_test() {
   assert decoded.data == data
 }
 
-pub fn bech32m_empty_data_test() {
+pub fn bech32m_empty_data_test() -> Nil {
   let assert Ok(encoded) = bech32.encode(Bech32mV, "a", <<>>)
   let assert Ok(decoded) = bech32.decode(encoded)
   assert decoded.hrp == "a"
@@ -44,14 +44,14 @@ pub fn bech32m_empty_data_test() {
 
 // ===== Variant auto-detection =====
 
-pub fn auto_detect_bech32_test() {
+pub fn auto_detect_bech32_test() -> Nil {
   let data = <<10, 20>>
   let assert Ok(encoded) = bech32.encode(Bech32V, "bc", data)
   let assert Ok(decoded) = bech32.decode(encoded)
   assert decoded.variant == Bech32V
 }
 
-pub fn auto_detect_bech32m_test() {
+pub fn auto_detect_bech32m_test() -> Nil {
   let data = <<10, 20>>
   let assert Ok(encoded) = bech32.encode(Bech32mV, "bc", data)
   let assert Ok(decoded) = bech32.decode(encoded)
@@ -60,27 +60,27 @@ pub fn auto_detect_bech32m_test() {
 
 // ===== Error cases =====
 
-pub fn decode_invalid_checksum_test() {
+pub fn decode_invalid_checksum_test() -> Nil {
   let assert Ok(encoded) = bech32.encode(Bech32V, "test", <<1, 2, 3>>)
   let corrupted = encoded <> "q"
   assert bech32.decode(corrupted) == Error(InvalidChecksum)
 }
 
-pub fn decode_no_separator_test() {
+pub fn decode_no_separator_test() -> Nil {
   assert case bech32.decode("noseparator") {
     Error(InvalidHrp(_)) -> True
     _ -> False
   }
 }
 
-pub fn decode_empty_hrp_test() {
+pub fn decode_empty_hrp_test() -> Nil {
   assert case bech32.decode("1qqqqqp") {
     Error(InvalidHrp(_)) -> True
     _ -> False
   }
 }
 
-pub fn decode_mixed_case_test() {
+pub fn decode_mixed_case_test() -> Nil {
   assert case bech32.decode("Test1qqqqqq") {
     Error(InvalidCharacter("mixed-case", _)) -> True
     _ -> False
@@ -89,7 +89,7 @@ pub fn decode_mixed_case_test() {
 
 // ===== BIP 173/350 length constraints =====
 
-pub fn decode_overlength_reject_test() {
+pub fn decode_overlength_reject_test() -> Nil {
   let long_data = string.repeat("q", 89)
   let input = "a1" <> long_data
   assert string.length(input) == 91
@@ -99,7 +99,7 @@ pub fn decode_overlength_reject_test() {
   }
 }
 
-pub fn encode_hrp_too_long_test() {
+pub fn encode_hrp_too_long_test() -> Nil {
   let long_hrp = string.repeat("a", 84)
   assert case bech32.encode(Bech32V, long_hrp, <<1>>) {
     Error(InvalidHrp("HRP too long")) -> True
@@ -107,14 +107,14 @@ pub fn encode_hrp_too_long_test() {
   }
 }
 
-pub fn encode_empty_hrp_test() {
+pub fn encode_empty_hrp_test() -> Nil {
   assert case bech32.encode(Bech32V, "", <<1>>) {
     Error(InvalidHrp("empty HRP")) -> True
     _ -> False
   }
 }
 
-pub fn encode_result_overlength_test() {
+pub fn encode_result_overlength_test() -> Nil {
   let big_data = <<
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
     22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
@@ -131,7 +131,7 @@ pub fn encode_result_overlength_test() {
 // layer (witness version/length), not at the raw Bech32 layer.
 // Our bech32.decode is raw Bech32, so valid-Bech32 strings succeed.
 
-pub fn bip173_valid_bech32_but_invalid_segwit_test() {
+pub fn bip173_valid_bech32_but_invalid_segwit_test() -> Nil {
   // "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du" - valid Bech32, invalid segwit
   // Raw Bech32 decode should succeed.
   let assert Ok(decoded) =
@@ -140,7 +140,7 @@ pub fn bip173_valid_bech32_but_invalid_segwit_test() {
   assert decoded.variant == Bech32V
 }
 
-pub fn bip173_invalid_mixed_case_test() {
+pub fn bip173_invalid_mixed_case_test() -> Nil {
   // Mixed case is rejected at Bech32 level
   assert case bech32.decode("bc1QW508D6QEjXTDG4Y5R3ZaRVARYVQYZF3DU") {
     Error(InvalidCharacter("mixed-case", _)) -> True
@@ -148,7 +148,7 @@ pub fn bip173_invalid_mixed_case_test() {
   }
 }
 
-pub fn bip173_invalid_checksum_test() {
+pub fn bip173_invalid_checksum_test() -> Nil {
   // "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5" has invalid checksum
   // (last char changed from '4' to '5')
   assert case bech32.decode("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5") {
@@ -157,7 +157,7 @@ pub fn bip173_invalid_checksum_test() {
   }
 }
 
-pub fn padding_bits_preserved_on_roundtrip_test() {
+pub fn padding_bits_preserved_on_roundtrip_test() -> Nil {
   // 1 byte = 8 bits -> 2 five-bit groups = 10 bits -> 2 padding bits
   // Encode produces zero-padded groups; decode must recover the original byte.
   let assert Ok(encoded) = bech32.encode(Bech32V, "test", <<0xff>>)
@@ -167,7 +167,7 @@ pub fn padding_bits_preserved_on_roundtrip_test() {
 
 // ===== BIP 350 Bech32m specific vectors =====
 
-pub fn bech32m_bc_prefix_roundtrip_test() {
+pub fn bech32m_bc_prefix_roundtrip_test() -> Nil {
   let data = <<0, 0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96>>
   let assert Ok(encoded) = bech32.encode(Bech32mV, "bc", data)
   let assert Ok(decoded) = bech32.decode(encoded)
@@ -175,7 +175,7 @@ pub fn bech32m_bc_prefix_roundtrip_test() {
   assert decoded.data == data
 }
 
-pub fn bech32m_tb_prefix_roundtrip_test() {
+pub fn bech32m_tb_prefix_roundtrip_test() -> Nil {
   let data = <<1, 2, 3>>
   let assert Ok(encoded) = bech32.encode(Bech32mV, "tb", data)
   let assert Ok(decoded) = bech32.decode(encoded)
@@ -184,7 +184,7 @@ pub fn bech32m_tb_prefix_roundtrip_test() {
   assert decoded.data == data
 }
 
-pub fn bech32m_long_hrp_test() {
+pub fn bech32m_long_hrp_test() -> Nil {
   // 10 char HRP
   let data = <<42>>
   let assert Ok(encoded) = bech32.encode(Bech32mV, "abcdefghij", data)
@@ -195,7 +195,7 @@ pub fn bech32m_long_hrp_test() {
 
 // ===== Additional edge cases =====
 
-pub fn decode_all_uppercase_valid_test() {
+pub fn decode_all_uppercase_valid_test() -> Nil {
   // All-uppercase is valid per BIP 173; decode normalizes to lowercase
   let assert Ok(encoded) = bech32.encode(Bech32V, "test", <<1, 2>>)
   let upper = string_uppercase(encoded)
@@ -214,7 +214,7 @@ fn do_uppercase(s: String, acc: String) -> String {
   }
 }
 
-pub fn decode_hrp_out_of_range_test() {
+pub fn decode_hrp_out_of_range_test() -> Nil {
   // HRP with character below ASCII 33 (space = 32)
   assert case bech32.decode(" 1nwldj5") {
     Error(InvalidHrp(_)) -> True
@@ -222,7 +222,7 @@ pub fn decode_hrp_out_of_range_test() {
   }
 }
 
-pub fn decode_hrp_del_char_test() {
+pub fn decode_hrp_del_char_test() -> Nil {
   // HRP with DEL (127) is out of range
   assert case bech32.decode("\u{007F}1axkwrx") {
     Error(InvalidHrp(_)) -> True
@@ -230,7 +230,7 @@ pub fn decode_hrp_del_char_test() {
   }
 }
 
-pub fn decode_data_part_too_short_test() {
+pub fn decode_data_part_too_short_test() -> Nil {
   // Separator found but data part is less than 6 chars (checksum alone)
   assert case bech32.decode("a1aaaa") {
     Error(InvalidLength(_)) -> True
@@ -238,7 +238,7 @@ pub fn decode_data_part_too_short_test() {
   }
 }
 
-pub fn decode_data_part_exactly_6_chars_test() {
+pub fn decode_data_part_exactly_6_chars_test() -> Nil {
   // 6 chars in data part = checksum only, no actual data -> valid empty data
   let assert Ok(encoded) = bech32.encode(Bech32V, "a", <<>>)
   let assert Ok(decoded) = bech32.decode(encoded)
@@ -249,13 +249,13 @@ pub fn decode_data_part_exactly_6_chars_test() {
 // Source: https://github.com/sipa/bech32
 
 // Valid Bech32 strings (raw decode should succeed)
-pub fn sipa_valid_bech32_a12uel5l_test() {
+pub fn sipa_valid_bech32_a12uel5l_test() -> Nil {
   let assert Ok(d) = bech32.decode("A12UEL5L")
   assert d.hrp == "a"
   assert d.variant == Bech32V
 }
 
-pub fn sipa_valid_bech32_long_hrp_test() {
+pub fn sipa_valid_bech32_long_hrp_test() -> Nil {
   let assert Ok(d) =
     bech32.decode(
       "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
@@ -263,7 +263,7 @@ pub fn sipa_valid_bech32_long_hrp_test() {
   assert d.variant == Bech32V
 }
 
-pub fn sipa_valid_bech32_split_test() {
+pub fn sipa_valid_bech32_split_test() -> Nil {
   let assert Ok(d) =
     bech32.decode(
       "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
@@ -272,26 +272,26 @@ pub fn sipa_valid_bech32_split_test() {
   assert d.variant == Bech32V
 }
 
-pub fn sipa_valid_bech32_question_mark_test() {
+pub fn sipa_valid_bech32_question_mark_test() -> Nil {
   let assert Ok(d) = bech32.decode("?1ezyfcl")
   assert d.hrp == "?"
   assert d.variant == Bech32V
 }
 
 // Valid Bech32m strings
-pub fn sipa_valid_bech32m_a1lqfn3a_test() {
+pub fn sipa_valid_bech32m_a1lqfn3a_test() -> Nil {
   let assert Ok(d) = bech32.decode("A1LQFN3A")
   assert d.hrp == "a"
   assert d.variant == Bech32mV
 }
 
-pub fn sipa_valid_bech32m_question_mark_test() {
+pub fn sipa_valid_bech32m_question_mark_test() -> Nil {
   let assert Ok(d) = bech32.decode("?1v759aa")
   assert d.hrp == "?"
   assert d.variant == Bech32mV
 }
 
-pub fn sipa_valid_bech32m_split_test() {
+pub fn sipa_valid_bech32m_split_test() -> Nil {
   let assert Ok(d) =
     bech32.decode(
       "split1checkupstagehandshakeupstreamerranterredcaperredlc445v",
@@ -301,35 +301,35 @@ pub fn sipa_valid_bech32m_split_test() {
 }
 
 // Invalid Bech32 strings (must fail to decode)
-pub fn sipa_invalid_bech32_no_separator_test() {
+pub fn sipa_invalid_bech32_no_separator_test() -> Nil {
   assert case bech32.decode("pzry9x0s0muk") {
-    Error(_) -> True
+    Error(InvalidHrp(_)) -> True
     _ -> False
   }
 }
 
-pub fn sipa_invalid_bech32_empty_hrp_1pzry_test() {
+pub fn sipa_invalid_bech32_empty_hrp_1pzry_test() -> Nil {
   assert case bech32.decode("1pzry9x0s0muk") {
     Error(InvalidHrp(_)) -> True
     _ -> False
   }
 }
 
-pub fn sipa_invalid_bech32_empty_hrp_10a06t8_test() {
+pub fn sipa_invalid_bech32_empty_hrp_10a06t8_test() -> Nil {
   assert case bech32.decode("10a06t8") {
     Error(InvalidHrp(_)) -> True
     _ -> False
   }
 }
 
-pub fn sipa_invalid_bech32_empty_hrp_1qzzfhee_test() {
+pub fn sipa_invalid_bech32_empty_hrp_1qzzfhee_test() -> Nil {
   assert case bech32.decode("1qzzfhee") {
     Error(InvalidHrp(_)) -> True
     _ -> False
   }
 }
 
-pub fn sipa_invalid_bech32_too_short_li1dgmt3_test() {
+pub fn sipa_invalid_bech32_too_short_li1dgmt3_test() -> Nil {
   assert case bech32.decode("li1dgmt3") {
     Error(InvalidLength(_)) -> True
     _ -> False
@@ -337,35 +337,35 @@ pub fn sipa_invalid_bech32_too_short_li1dgmt3_test() {
 }
 
 // Invalid Bech32m strings
-pub fn sipa_invalid_bech32m_no_separator_test() {
+pub fn sipa_invalid_bech32m_no_separator_test() -> Nil {
   assert case bech32.decode("qyrz8wqd2c9m") {
-    Error(_) -> True
+    Error(InvalidHrp(_)) -> True
     _ -> False
   }
 }
 
-pub fn sipa_invalid_bech32m_empty_hrp_test() {
+pub fn sipa_invalid_bech32m_empty_hrp_test() -> Nil {
   assert case bech32.decode("1qyrz8wqd2c9m") {
     Error(InvalidHrp(_)) -> True
     _ -> False
   }
 }
 
-pub fn sipa_invalid_bech32m_too_short_in1muywd_test() {
+pub fn sipa_invalid_bech32m_too_short_in1muywd_test() -> Nil {
   assert case bech32.decode("in1muywd") {
     Error(InvalidLength(_)) -> True
     _ -> False
   }
 }
 
-pub fn sipa_invalid_bech32m_empty_hrp_16plkw9_test() {
+pub fn sipa_invalid_bech32m_empty_hrp_16plkw9_test() -> Nil {
   assert case bech32.decode("16plkw9") {
     Error(InvalidHrp(_)) -> True
     _ -> False
   }
 }
 
-pub fn sipa_invalid_bech32m_empty_hrp_1p2gdwpf_test() {
+pub fn sipa_invalid_bech32m_empty_hrp_1p2gdwpf_test() -> Nil {
   assert case bech32.decode("1p2gdwpf") {
     Error(InvalidHrp(_)) -> True
     _ -> False

--- a/test/dispatcher_test.gleam
+++ b/test/dispatcher_test.gleam
@@ -1,119 +1,119 @@
 import yabase/core/dispatcher
 import yabase/core/encoding.{
-  Adobe, Base10, Base16, Base2, Base32, Base36, Base45, Base58, Base62, Base64,
-  Base8, Base85, Base91, Bitcoin, Btoa, Clockwork, Crockford, CrockfordCheck, DQ,
-  Flickr, Hex, InvalidLength, NoPadding, RFC4648, Rfc1924, Standard, UrlSafe,
-  UrlSafeNoPadding, Z85, ZBase32,
+  type Encoding, Adobe, Base10, Base16, Base2, Base32, Base36, Base45, Base58,
+  Base62, Base64, Base8, Base85, Base91, Bitcoin, Btoa, Clockwork, Crockford,
+  CrockfordCheck, DQ, Flickr, Hex, InvalidLength, NoPadding, RFC4648, Rfc1924,
+  Standard, UrlSafe, UrlSafeNoPadding, Z85, ZBase32,
 }
 
 // Verify that each encoding roundtrips through the dispatcher.
 // These are thin wiring tests, not spec-vector tests.
 
-fn assert_roundtrip(enc, data) {
+fn assert_roundtrip(enc: Encoding, data: BitArray) -> Nil {
   let assert Ok(encoded) = dispatcher.encode(enc, data)
   assert dispatcher.decode_as(enc, encoded) == Ok(data)
 }
 
-pub fn base2_test() {
+pub fn base2_test() -> Nil {
   assert_roundtrip(Base2, <<"test":utf8>>)
 }
 
-pub fn base8_test() {
+pub fn base8_test() -> Nil {
   assert_roundtrip(Base8, <<"test":utf8>>)
 }
 
-pub fn base10_test() {
+pub fn base10_test() -> Nil {
   assert_roundtrip(Base10, <<"test":utf8>>)
 }
 
-pub fn base16_test() {
+pub fn base16_test() -> Nil {
   assert_roundtrip(Base16, <<"test":utf8>>)
 }
 
-pub fn base32_rfc4648_test() {
+pub fn base32_rfc4648_test() -> Nil {
   assert_roundtrip(Base32(RFC4648), <<"test":utf8>>)
 }
 
-pub fn base32_hex_test() {
+pub fn base32_hex_test() -> Nil {
   assert_roundtrip(Base32(Hex), <<"test":utf8>>)
 }
 
-pub fn base32_crockford_test() {
+pub fn base32_crockford_test() -> Nil {
   assert_roundtrip(Base32(Crockford), <<"test":utf8>>)
 }
 
-pub fn base32_crockford_check_test() {
+pub fn base32_crockford_check_test() -> Nil {
   assert_roundtrip(Base32(CrockfordCheck), <<"test":utf8>>)
 }
 
-pub fn base32_clockwork_test() {
+pub fn base32_clockwork_test() -> Nil {
   assert_roundtrip(Base32(Clockwork), <<"test":utf8>>)
 }
 
-pub fn base64_standard_test() {
+pub fn base64_standard_test() -> Nil {
   assert_roundtrip(Base64(Standard), <<"test":utf8>>)
 }
 
-pub fn base64_urlsafe_test() {
+pub fn base64_urlsafe_test() -> Nil {
   assert_roundtrip(Base64(UrlSafe), <<"test":utf8>>)
 }
 
-pub fn base64_nopadding_test() {
+pub fn base64_nopadding_test() -> Nil {
   assert_roundtrip(Base64(NoPadding), <<"test":utf8>>)
 }
 
-pub fn base64_dq_test() {
+pub fn base64_dq_test() -> Nil {
   assert_roundtrip(Base64(DQ), <<"test":utf8>>)
 }
 
-pub fn base36_test() {
+pub fn base36_test() -> Nil {
   assert_roundtrip(Base36, <<"test":utf8>>)
 }
 
-pub fn base45_test() {
+pub fn base45_test() -> Nil {
   assert_roundtrip(Base45, <<"test!!":utf8>>)
 }
 
-pub fn base58_bitcoin_test() {
+pub fn base58_bitcoin_test() -> Nil {
   assert_roundtrip(Base58(Bitcoin), <<"test":utf8>>)
 }
 
-pub fn base58_flickr_test() {
+pub fn base58_flickr_test() -> Nil {
   assert_roundtrip(Base58(Flickr), <<"test":utf8>>)
 }
 
-pub fn base62_test() {
+pub fn base62_test() -> Nil {
   assert_roundtrip(Base62, <<"test":utf8>>)
 }
 
-pub fn base85_btoa_test() {
+pub fn base85_btoa_test() -> Nil {
   assert_roundtrip(Base85(Btoa), <<"test1234":utf8>>)
 }
 
-pub fn base85_adobe_test() {
+pub fn base85_adobe_test() -> Nil {
   assert_roundtrip(Base85(Adobe), <<"test":utf8>>)
 }
 
-pub fn base85_rfc1924_test() {
+pub fn base85_rfc1924_test() -> Nil {
   assert_roundtrip(Base85(Rfc1924), <<1, 2, 3, 4>>)
 }
 
-pub fn base85_z85_test() {
+pub fn base85_z85_test() -> Nil {
   assert_roundtrip(Base85(Z85), <<0x86, 0x4F, 0xD2, 0x6F>>)
 }
 
-pub fn base85_z85_encode_non_aligned_error_test() {
+pub fn base85_z85_encode_non_aligned_error_test() -> Nil {
   assert dispatcher.encode(Base85(Z85), <<1, 2, 3>>) == Error(InvalidLength(3))
 }
 
-pub fn base91_test() {
+pub fn base91_test() -> Nil {
   assert_roundtrip(Base91, <<"test":utf8>>)
 }
 
-pub fn zbase32_test() {
+pub fn zbase32_test() -> Nil {
   assert_roundtrip(Base32(ZBase32), <<"test":utf8>>)
 }
 
-pub fn urlsafe_nopadding_test() {
+pub fn urlsafe_nopadding_test() -> Nil {
   assert_roundtrip(Base64(UrlSafeNoPadding), <<"test":utf8>>)
 }

--- a/test/facade_test.gleam
+++ b/test/facade_test.gleam
@@ -6,43 +6,43 @@ import yabase/facade
 
 // --- Roundtrip tests for each facade pair ---
 
-pub fn base2_roundtrip_test() {
+pub fn base2_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base2(facade.encode_base2(data)) == Ok(data)
 }
 
-pub fn base8_roundtrip_test() {
+pub fn base8_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base8(facade.encode_base8(data)) == Ok(data)
 }
 
-pub fn base10_roundtrip_test() {
+pub fn base10_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base10(facade.encode_base10(data)) == Ok(data)
 }
 
-pub fn base16_roundtrip_test() {
+pub fn base16_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base16(facade.encode_base16(data)) == Ok(data)
 }
 
-pub fn base32_roundtrip_test() {
+pub fn base32_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base32(facade.encode_base32(data)) == Ok(data)
 }
 
-pub fn base32_hex_roundtrip_test() {
+pub fn base32_hex_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base32_hex(facade.encode_base32_hex(data)) == Ok(data)
 }
 
-pub fn base32_crockford_roundtrip_test() {
+pub fn base32_crockford_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base32_crockford(facade.encode_base32_crockford(data))
     == Ok(data)
 }
 
-pub fn base32_crockford_check_roundtrip_test() {
+pub fn base32_crockford_check_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base32_crockford_check(
       facade.encode_base32_crockford_check(data),
@@ -50,86 +50,86 @@ pub fn base32_crockford_check_roundtrip_test() {
     == Ok(data)
 }
 
-pub fn base32_clockwork_roundtrip_test() {
+pub fn base32_clockwork_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base32_clockwork(facade.encode_base32_clockwork(data))
     == Ok(data)
 }
 
-pub fn base36_roundtrip_test() {
+pub fn base36_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base36(facade.encode_base36(data)) == Ok(data)
 }
 
-pub fn base45_roundtrip_test() {
+pub fn base45_roundtrip_test() -> Nil {
   let data = <<"Hello!":utf8>>
   assert facade.decode_base45(facade.encode_base45(data)) == Ok(data)
 }
 
-pub fn base58_roundtrip_test() {
+pub fn base58_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base58(facade.encode_base58(data)) == Ok(data)
 }
 
-pub fn base58_flickr_roundtrip_test() {
+pub fn base58_flickr_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base58_flickr(facade.encode_base58_flickr(data))
     == Ok(data)
 }
 
-pub fn base62_roundtrip_test() {
+pub fn base62_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base62(facade.encode_base62(data)) == Ok(data)
 }
 
-pub fn base64_roundtrip_test() {
+pub fn base64_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base64(facade.encode_base64(data)) == Ok(data)
 }
 
-pub fn base64_urlsafe_roundtrip_test() {
+pub fn base64_urlsafe_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base64_urlsafe(facade.encode_base64_urlsafe(data))
     == Ok(data)
 }
 
-pub fn base64_nopadding_roundtrip_test() {
+pub fn base64_nopadding_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base64_nopadding(facade.encode_base64_nopadding(data))
     == Ok(data)
 }
 
-pub fn base64_dq_roundtrip_test() {
+pub fn base64_dq_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base64_dq(facade.encode_base64_dq(data)) == Ok(data)
 }
 
-pub fn base91_roundtrip_test() {
+pub fn base91_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base91(facade.encode_base91(data)) == Ok(data)
 }
 
-pub fn ascii85_roundtrip_test() {
+pub fn ascii85_roundtrip_test() -> Nil {
   let data = <<"test":utf8>>
   assert facade.decode_ascii85(facade.encode_ascii85(data)) == Ok(data)
 }
 
-pub fn z85_roundtrip_test() {
+pub fn z85_roundtrip_test() -> Nil {
   let data = <<0x86, 0x4F, 0xD2, 0x6F>>
   let assert Ok(encoded) = facade.encode_z85(data)
   assert facade.decode_z85(encoded) == Ok(data)
 }
 
-pub fn z85_encode_non_aligned_error_test() {
+pub fn z85_encode_non_aligned_error_test() -> Nil {
   assert facade.encode_z85(<<1, 2, 3>>) == Error(InvalidLength(3))
 }
 
-pub fn zbase32_roundtrip_test() {
+pub fn zbase32_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_zbase32(facade.encode_zbase32(data)) == Ok(data)
 }
 
-pub fn base64_urlsafe_nopadding_roundtrip_test() {
+pub fn base64_urlsafe_nopadding_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base64_urlsafe_nopadding(
       facade.encode_base64_urlsafe_nopadding(data),
@@ -137,13 +137,13 @@ pub fn base64_urlsafe_nopadding_roundtrip_test() {
     == Ok(data)
 }
 
-pub fn adobe_ascii85_roundtrip_test() {
+pub fn adobe_ascii85_roundtrip_test() -> Nil {
   let data = <<"test":utf8>>
   assert facade.decode_adobe_ascii85(facade.encode_adobe_ascii85(data))
     == Ok(data)
 }
 
-pub fn rfc1924_base85_roundtrip_test() {
+pub fn rfc1924_base85_roundtrip_test() -> Nil {
   let data = <<1, 2, 3, 4>>
   let assert Ok(encoded) = facade.encode_rfc1924_base85(data)
   assert facade.decode_rfc1924_base85(encoded) == Ok(data)

--- a/test/multibase_test.gleam
+++ b/test/multibase_test.gleam
@@ -10,7 +10,7 @@ import yabase/core/multibase
 
 // ===== Official multibase registry vectors =====
 
-pub fn registry_0_base2_test() {
+pub fn registry_0_base2_test() -> Nil {
   let data = <<"Hi":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base2, data)
   assert encoded == "00100100001101001"
@@ -19,7 +19,7 @@ pub fn registry_0_base2_test() {
   assert decoded == data
 }
 
-pub fn registry_7_base8_test() {
+pub fn registry_7_base8_test() -> Nil {
   let data = <<"Hi":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base8, data)
   assert case encoded {
@@ -31,7 +31,7 @@ pub fn registry_7_base8_test() {
   assert decoded == data
 }
 
-pub fn registry_9_base10_test() {
+pub fn registry_9_base10_test() -> Nil {
   let data = <<"Hi":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base10, data)
   assert case encoded {
@@ -43,7 +43,7 @@ pub fn registry_9_base10_test() {
   assert decoded == data
 }
 
-pub fn registry_f_base16_test() {
+pub fn registry_f_base16_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base16, data)
   assert encoded == "f796573206d616e692021"
@@ -52,13 +52,13 @@ pub fn registry_f_base16_test() {
   assert decoded == data
 }
 
-pub fn registry_upper_f_base16_decode_test() {
+pub fn registry_upper_f_base16_decode_test() -> Nil {
   let assert Ok(Decoded(encoding: Base16, data: decoded)) =
     multibase.decode("F796573206D616E692021")
   assert decoded == <<"yes mani !":utf8>>
 }
 
-pub fn registry_c_base32pad_test() {
+pub fn registry_c_base32pad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base32(RFC4648), data)
   assert case encoded {
@@ -70,7 +70,7 @@ pub fn registry_c_base32pad_test() {
   assert decoded == data
 }
 
-pub fn registry_t_base32hexpad_test() {
+pub fn registry_t_base32hexpad_test() -> Nil {
   let data = <<"test":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base32(Hex), data)
   assert case encoded {
@@ -82,7 +82,7 @@ pub fn registry_t_base32hexpad_test() {
   assert decoded == data
 }
 
-pub fn registry_h_base32z_test() {
+pub fn registry_h_base32z_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base32(ZBase32), data)
   assert case encoded {
@@ -94,7 +94,7 @@ pub fn registry_h_base32z_test() {
   assert decoded == data
 }
 
-pub fn registry_k_base36_test() {
+pub fn registry_k_base36_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base36, data)
   assert case encoded {
@@ -106,7 +106,7 @@ pub fn registry_k_base36_test() {
   assert decoded == data
 }
 
-pub fn registry_z_base58btc_test() {
+pub fn registry_z_base58btc_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base58(Bitcoin), data)
   assert case encoded {
@@ -118,7 +118,7 @@ pub fn registry_z_base58btc_test() {
   assert decoded == data
 }
 
-pub fn registry_upper_z_base58flickr_test() {
+pub fn registry_upper_z_base58flickr_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base58(Flickr), data)
   assert case encoded {
@@ -130,7 +130,7 @@ pub fn registry_upper_z_base58flickr_test() {
   assert decoded == data
 }
 
-pub fn registry_upper_m_base64pad_test() {
+pub fn registry_upper_m_base64pad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base64(Standard), data)
   assert encoded == "MeWVzIG1hbmkgIQ=="
@@ -139,7 +139,7 @@ pub fn registry_upper_m_base64pad_test() {
   assert decoded == data
 }
 
-pub fn registry_lower_m_base64_test() {
+pub fn registry_lower_m_base64_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base64(NoPadding), data)
   assert encoded == "meWVzIG1hbmkgIQ"
@@ -148,7 +148,7 @@ pub fn registry_lower_m_base64_test() {
   assert decoded == data
 }
 
-pub fn registry_upper_u_base64urlpad_test() {
+pub fn registry_upper_u_base64urlpad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base64(UrlSafe), data)
   assert case encoded {
@@ -160,7 +160,7 @@ pub fn registry_upper_u_base64urlpad_test() {
   assert decoded == data
 }
 
-pub fn registry_lower_u_base64url_nopad_test() {
+pub fn registry_lower_u_base64url_nopad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) =
     multibase.encode_with_prefix(Base64(UrlSafeNoPadding), data)
@@ -175,21 +175,21 @@ pub fn registry_lower_u_base64url_nopad_test() {
 
 // ===== Unsupported encodings =====
 
-pub fn crockford_unsupported_test() {
+pub fn crockford_unsupported_test() -> Nil {
   assert case multibase.encode_with_prefix(Base32(Crockford), <<"x":utf8>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
   }
 }
 
-pub fn clockwork_unsupported_test() {
+pub fn clockwork_unsupported_test() -> Nil {
   assert case multibase.encode_with_prefix(Base32(Clockwork), <<"x":utf8>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
   }
 }
 
-pub fn registry_upper_r_base45_test() {
+pub fn registry_upper_r_base45_test() -> Nil {
   let data = <<"AB":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base45, data)
   assert case encoded {
@@ -201,55 +201,55 @@ pub fn registry_upper_r_base45_test() {
   assert decoded == data
 }
 
-pub fn registry_upper_b_base32upper_decode_test() {
+pub fn registry_upper_b_base32upper_decode_test() -> Nil {
   let assert Ok(Decoded(encoding: Base32(RFC4648), data: decoded)) =
     multibase.decode("BMY")
   assert decoded == <<"f":utf8>>
 }
 
-pub fn base62_unsupported_test() {
+pub fn base62_unsupported_test() -> Nil {
   assert case multibase.encode_with_prefix(Base62, <<"x":utf8>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
   }
 }
 
-pub fn base91_unsupported_test() {
+pub fn base91_unsupported_test() -> Nil {
   assert case multibase.encode_with_prefix(Base91, <<"x":utf8>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
   }
 }
 
-pub fn base85_btoa_unsupported_test() {
+pub fn base85_btoa_unsupported_test() -> Nil {
   assert case multibase.encode_with_prefix(Base85(Btoa), <<"x":utf8>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
   }
 }
 
-pub fn base85_adobe_unsupported_test() {
+pub fn base85_adobe_unsupported_test() -> Nil {
   assert case multibase.encode_with_prefix(Base85(Adobe), <<"x":utf8>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
   }
 }
 
-pub fn base85_rfc1924_unsupported_test() {
+pub fn base85_rfc1924_unsupported_test() -> Nil {
   assert case multibase.encode_with_prefix(Base85(Rfc1924), <<1, 2, 3, 4>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
   }
 }
 
-pub fn base85_z85_unsupported_test() {
+pub fn base85_z85_unsupported_test() -> Nil {
   assert case multibase.encode_with_prefix(Base85(Z85), <<1, 2, 3, 4>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
   }
 }
 
-pub fn dq_unsupported_test() {
+pub fn dq_unsupported_test() -> Nil {
   assert case multibase.encode_with_prefix(Base64(encoding.DQ), <<"x":utf8>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
@@ -258,15 +258,15 @@ pub fn dq_unsupported_test() {
 
 // ===== Decode error cases =====
 
-pub fn decode_unsupported_prefix_test() {
+pub fn decode_unsupported_prefix_test() -> Nil {
   assert multibase.decode("!invalid") == Error(UnsupportedPrefix("!"))
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert multibase.decode("") == Error(UnsupportedPrefix(""))
 }
 
-pub fn decode_bytes_roundtrip_test() {
+pub fn decode_bytes_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(Base32(RFC4648), data)
   assert multibase.decode_bytes(encoded) == Ok(data)
@@ -274,7 +274,7 @@ pub fn decode_bytes_roundtrip_test() {
 
 // ===== No-padding rejection through multibase wrapper =====
 
-pub fn multibase_m_rejects_padded_input_test() {
+pub fn multibase_m_rejects_padded_input_test() -> Nil {
   // m = base64 no-padding; "mZg==" has padding and must be rejected
   assert case multibase.decode("mZg==") {
     Error(InvalidCharacter("=", _)) -> True
@@ -282,7 +282,7 @@ pub fn multibase_m_rejects_padded_input_test() {
   }
 }
 
-pub fn multibase_u_rejects_padded_input_test() {
+pub fn multibase_u_rejects_padded_input_test() -> Nil {
   // u = base64url no-padding; "uZg==" has padding and must be rejected
   assert case multibase.decode("uZg==") {
     Error(InvalidCharacter("=", _)) -> True
@@ -295,7 +295,7 @@ pub fn multibase_u_rejects_padded_input_test() {
 // these test that non-canonical alias prefixes decode correctly.
 
 // base32pad (c) decoder accepts unpadded input (RFC 4648 decoder flexibility)
-pub fn decode_base32pad_accepts_unpadded_test() {
+pub fn decode_base32pad_accepts_unpadded_test() -> Nil {
   let data = <<"f":utf8>>
   // "cMY======" is canonical padded; "cMY" is unpadded
   let assert Ok(Decoded(encoding: Base32(RFC4648), data: decoded)) =
@@ -303,7 +303,7 @@ pub fn decode_base32pad_accepts_unpadded_test() {
   assert decoded == data
 }
 
-pub fn decode_base32hexpad_accepts_unpadded_test() {
+pub fn decode_base32hexpad_accepts_unpadded_test() -> Nil {
   let data = <<"f":utf8>>
   // "tCO======" is canonical padded; "tCO" is unpadded
   let assert Ok(Decoded(encoding: Base32(Hex), data: decoded)) =
@@ -311,7 +311,7 @@ pub fn decode_base32hexpad_accepts_unpadded_test() {
   assert decoded == data
 }
 
-pub fn decode_alias_upper_c_base32pad_test() {
+pub fn decode_alias_upper_c_base32pad_test() -> Nil {
   // C = base32pad (uppercase); encode emits c
   let data = <<"Hi":utf8>>
   let assert Ok(canonical) = multibase.encode_with_prefix(Base32(RFC4648), data)
@@ -322,14 +322,14 @@ pub fn decode_alias_upper_c_base32pad_test() {
   assert decoded == data
 }
 
-pub fn decode_alias_lowercase_b_base32_nopad_test() {
+pub fn decode_alias_lowercase_b_base32_nopad_test() -> Nil {
   // b = base32 no-padding (lowercase); maps to RFC4648 codec
   let assert Ok(Decoded(encoding: Base32(RFC4648), data: decoded)) =
     multibase.decode("bMY")
   assert decoded == <<"f":utf8>>
 }
 
-pub fn decode_alias_upper_t_base32hexpad_test() {
+pub fn decode_alias_upper_t_base32hexpad_test() -> Nil {
   // T = base32hexpad (uppercase); encode emits t
   let data = <<"Hi":utf8>>
   let assert Ok(canonical) = multibase.encode_with_prefix(Base32(Hex), data)
@@ -339,7 +339,7 @@ pub fn decode_alias_upper_t_base32hexpad_test() {
   assert decoded == data
 }
 
-pub fn decode_alias_lowercase_v_base32hex_nopad_test() {
+pub fn decode_alias_lowercase_v_base32hex_nopad_test() -> Nil {
   // v = base32hex no-padding; maps to Hex codec
   let data = <<"Hi":utf8>>
   let assert Ok(canonical) = multibase.encode_with_prefix(Base32(Hex), data)
@@ -351,7 +351,7 @@ pub fn decode_alias_lowercase_v_base32hex_nopad_test() {
   assert decoded == data
 }
 
-pub fn decode_alias_upper_v_base32hex_nopad_test() {
+pub fn decode_alias_upper_v_base32hex_nopad_test() -> Nil {
   let data = <<"Hi":utf8>>
   let assert Ok(canonical) = multibase.encode_with_prefix(Base32(Hex), data)
   let body = string.drop_start(canonical, 1) |> string.replace("=", "")
@@ -361,7 +361,7 @@ pub fn decode_alias_upper_v_base32hex_nopad_test() {
   assert decoded == data
 }
 
-pub fn decode_alias_upper_k_base36_test() {
+pub fn decode_alias_upper_k_base36_test() -> Nil {
   // K = base36 (uppercase); encode emits k
   let data = <<"Hi":utf8>>
   let assert Ok(canonical) = multibase.encode_with_prefix(Base36, data)
@@ -375,70 +375,70 @@ pub fn decode_alias_upper_k_base36_test() {
 // Source: https://github.com/multiformats/multibase/tree/master/tests
 
 // basic.csv: "yes mani !"
-pub fn spec_basic_base16_test() {
+pub fn spec_basic_base16_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base16, data: d)) =
     multibase.decode("f796573206d616e692021")
   assert d == data
 }
 
-pub fn spec_basic_base32pad_test() {
+pub fn spec_basic_base32pad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base32(RFC4648), data: d)) =
     multibase.decode("cpfsxgidnmfxgsibb")
   assert d == data
 }
 
-pub fn spec_basic_base32z_test() {
+pub fn spec_basic_base32z_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base32(ZBase32), data: d)) =
     multibase.decode("hxf1zgedpcfzg1ebb")
   assert d == data
 }
 
-pub fn spec_basic_base36_test() {
+pub fn spec_basic_base36_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base36, data: d)) =
     multibase.decode("k2lcpzo5yikidynfl")
   assert d == data
 }
 
-pub fn spec_basic_base58btc_test() {
+pub fn spec_basic_base58btc_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base58(Bitcoin), data: d)) =
     multibase.decode("z7paNL19xttacUY")
   assert d == data
 }
 
-pub fn spec_basic_base58flickr_test() {
+pub fn spec_basic_base58flickr_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base58(Flickr), data: d)) =
     multibase.decode("Z7Pznk19XTTzBtx")
   assert d == data
 }
 
-pub fn spec_basic_base64_test() {
+pub fn spec_basic_base64_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base64(NoPadding), data: d)) =
     multibase.decode("meWVzIG1hbmkgIQ")
   assert d == data
 }
 
-pub fn spec_basic_base64pad_test() {
+pub fn spec_basic_base64pad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base64(Standard), data: d)) =
     multibase.decode("MeWVzIG1hbmkgIQ==")
   assert d == data
 }
 
-pub fn spec_basic_base64url_test() {
+pub fn spec_basic_base64url_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base64(UrlSafeNoPadding), data: d)) =
     multibase.decode("ueWVzIG1hbmkgIQ")
   assert d == data
 }
 
-pub fn spec_basic_base64urlpad_test() {
+pub fn spec_basic_base64urlpad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base64(UrlSafe), data: d)) =
     multibase.decode("UeWVzIG1hbmkgIQ==")
@@ -446,35 +446,35 @@ pub fn spec_basic_base64urlpad_test() {
 }
 
 // leading_zero.csv: "\x00yes mani !"
-pub fn spec_leading_zero_base16_test() {
+pub fn spec_leading_zero_base16_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base16, data: d)) =
     multibase.decode("f00796573206d616e692021")
   assert d == data
 }
 
-pub fn spec_leading_zero_base36_test() {
+pub fn spec_leading_zero_base36_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base36, data: d)) =
     multibase.decode("k02lcpzo5yikidynfl")
   assert d == data
 }
 
-pub fn spec_leading_zero_base58btc_test() {
+pub fn spec_leading_zero_base58btc_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base58(Bitcoin), data: d)) =
     multibase.decode("z17paNL19xttacUY")
   assert d == data
 }
 
-pub fn spec_leading_zero_base58flickr_test() {
+pub fn spec_leading_zero_base58flickr_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base58(Flickr), data: d)) =
     multibase.decode("Z17Pznk19XTTzBtx")
   assert d == data
 }
 
-pub fn spec_leading_zero_base64pad_test() {
+pub fn spec_leading_zero_base64pad_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base64(Standard), data: d)) =
     multibase.decode("MAHllcyBtYW5pICE=")
@@ -482,21 +482,21 @@ pub fn spec_leading_zero_base64pad_test() {
 }
 
 // two_leading_zeros.csv: "\x00\x00yes mani !"
-pub fn spec_two_leading_zeros_base16_test() {
+pub fn spec_two_leading_zeros_base16_test() -> Nil {
   let data = <<0, 0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base16, data: d)) =
     multibase.decode("f0000796573206d616e692021")
   assert d == data
 }
 
-pub fn spec_two_leading_zeros_base58btc_test() {
+pub fn spec_two_leading_zeros_base58btc_test() -> Nil {
   let data = <<0, 0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base58(Bitcoin), data: d)) =
     multibase.decode("z117paNL19xttacUY")
   assert d == data
 }
 
-pub fn spec_two_leading_zeros_base36_test() {
+pub fn spec_two_leading_zeros_base36_test() -> Nil {
   let data = <<0, 0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: Base36, data: d)) =
     multibase.decode("k002lcpzo5yikidynfl")

--- a/test/rfc1924_base85_test.gleam
+++ b/test/rfc1924_base85_test.gleam
@@ -1,46 +1,46 @@
 import yabase/core/encoding.{InvalidLength, Overflow}
 import yabase/rfc1924_base85
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert rfc1924_base85.encode(<<>>) == Ok("")
 }
 
-pub fn encode_non_aligned_error_test() {
+pub fn encode_non_aligned_error_test() -> Nil {
   assert rfc1924_base85.encode(<<1, 2, 3>>) == Error(InvalidLength(3))
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert rfc1924_base85.decode("") == Ok(<<>>)
 }
 
-pub fn decode_invalid_length_test() {
+pub fn decode_invalid_length_test() -> Nil {
   assert rfc1924_base85.decode("abc") == Error(InvalidLength(3))
 }
 
-pub fn decode_overflow_test() {
+pub fn decode_overflow_test() -> Nil {
   // Maximum possible: all '~' (index 84) -> 84*85^4+... > 2^32
   assert rfc1924_base85.decode("~~~~~") == Error(Overflow)
 }
 
-pub fn roundtrip_4bytes_test() {
+pub fn roundtrip_4bytes_test() -> Nil {
   let data = <<0x01, 0x02, 0x03, 0x04>>
   let assert Ok(encoded) = rfc1924_base85.encode(data)
   assert rfc1924_base85.decode(encoded) == Ok(data)
 }
 
-pub fn roundtrip_8bytes_test() {
+pub fn roundtrip_8bytes_test() -> Nil {
   let data = <<0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe>>
   let assert Ok(encoded) = rfc1924_base85.encode(data)
   assert rfc1924_base85.decode(encoded) == Ok(data)
 }
 
-pub fn roundtrip_all_zeros_test() {
+pub fn roundtrip_all_zeros_test() -> Nil {
   let data = <<0, 0, 0, 0>>
   let assert Ok(encoded) = rfc1924_base85.encode(data)
   assert rfc1924_base85.decode(encoded) == Ok(data)
 }
 
-pub fn roundtrip_all_ff_test() {
+pub fn roundtrip_all_ff_test() -> Nil {
   let data = <<0xff, 0xff, 0xff, 0xff>>
   let assert Ok(encoded) = rfc1924_base85.encode(data)
   assert rfc1924_base85.decode(encoded) == Ok(data)

--- a/test/sha256_test.gleam
+++ b/test/sha256_test.gleam
@@ -2,7 +2,7 @@
 import gleam/string
 import yabase/internal/sha256
 
-pub fn sha256_empty_test() {
+pub fn sha256_empty_test() -> Nil {
   // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
   let hash = sha256.hash(<<>>)
   assert hash
@@ -13,7 +13,7 @@ pub fn sha256_empty_test() {
     >>
 }
 
-pub fn sha256_abc_test() {
+pub fn sha256_abc_test() -> Nil {
   // SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
   let hash = sha256.hash(<<"abc":utf8>>)
   assert hash
@@ -24,7 +24,7 @@ pub fn sha256_abc_test() {
     >>
 }
 
-pub fn sha256_448bit_test() {
+pub fn sha256_448bit_test() -> Nil {
   // NIST FIPS 180-4 one-block message: "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
   // This is exactly 448 bits (56 bytes), which exercises the padding boundary.
   let hash =
@@ -39,7 +39,7 @@ pub fn sha256_448bit_test() {
     >>
 }
 
-pub fn sha256_896bit_test() {
+pub fn sha256_896bit_test() -> Nil {
   // NIST two-block message (112 bytes):
   // "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
   let hash =
@@ -54,7 +54,7 @@ pub fn sha256_896bit_test() {
     >>
 }
 
-pub fn sha256_55byte_test() {
+pub fn sha256_55byte_test() -> Nil {
   // 55 bytes: fills one block with data exactly up to padding boundary - 1
   let input = string.repeat("a", 55)
   let hash = sha256.hash(<<input:utf8>>)
@@ -66,7 +66,7 @@ pub fn sha256_55byte_test() {
     >>
 }
 
-pub fn sha256_56byte_test() {
+pub fn sha256_56byte_test() -> Nil {
   // 56 bytes: exactly at the padding boundary, requires two blocks
   let input = string.repeat("a", 56)
   let hash = sha256.hash(<<input:utf8>>)
@@ -78,7 +78,7 @@ pub fn sha256_56byte_test() {
     >>
 }
 
-pub fn sha256_64byte_test() {
+pub fn sha256_64byte_test() -> Nil {
   // 64 bytes: exactly one full block, padding goes into second block
   let input = string.repeat("a", 64)
   let hash = sha256.hash(<<input:utf8>>)

--- a/test/yabase_test.gleam
+++ b/test/yabase_test.gleam
@@ -12,20 +12,20 @@ pub fn main() -> Nil {
 
 // --- yabase.encode / yabase.decode roundtrip ---
 
-pub fn encode_decode_base16_test() {
+pub fn encode_decode_base16_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(encoded) = yabase.encode(Base16, data)
   assert yabase.decode(Base16, encoded) == Ok(data)
 }
 
-pub fn encode_decode_base64_test() {
+pub fn encode_decode_base64_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(encoded) = yabase.encode(Base64(Standard), data)
   assert encoded == "SGVsbG8="
   assert yabase.decode(Base64(Standard), encoded) == Ok(data)
 }
 
-pub fn encode_decode_base32_test() {
+pub fn encode_decode_base32_test() -> Nil {
   let data = <<"foo":utf8>>
   let assert Ok(encoded) = yabase.encode(Base32(RFC4648), data)
   assert encoded == "MZXW6==="
@@ -34,7 +34,7 @@ pub fn encode_decode_base32_test() {
 
 // --- yabase.encode_multibase / yabase.decode_multibase roundtrip ---
 
-pub fn multibase_roundtrip_base16_test() {
+pub fn multibase_roundtrip_base16_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(prefixed) = yabase.encode_multibase(Base16, data)
   let assert Ok(Decoded(encoding: Base16, data: decoded)) =
@@ -42,7 +42,7 @@ pub fn multibase_roundtrip_base16_test() {
   assert decoded == data
 }
 
-pub fn multibase_roundtrip_base58_bitcoin_test() {
+pub fn multibase_roundtrip_base58_bitcoin_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(prefixed) = yabase.encode_multibase(Base58(Bitcoin), data)
   let assert Ok(Decoded(encoding: Base58(Bitcoin), data: decoded)) =
@@ -50,7 +50,7 @@ pub fn multibase_roundtrip_base58_bitcoin_test() {
   assert decoded == data
 }
 
-pub fn multibase_roundtrip_base58_flickr_test() {
+pub fn multibase_roundtrip_base58_flickr_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(prefixed) = yabase.encode_multibase(Base58(Flickr), data)
   assert case prefixed {
@@ -62,7 +62,7 @@ pub fn multibase_roundtrip_base58_flickr_test() {
   assert decoded == data
 }
 
-pub fn multibase_roundtrip_base64_nopad_test() {
+pub fn multibase_roundtrip_base64_nopad_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(prefixed) = yabase.encode_multibase(Base64(NoPadding), data)
   let assert Ok(Decoded(encoding: Base64(NoPadding), data: decoded)) =
@@ -72,22 +72,22 @@ pub fn multibase_roundtrip_base64_nopad_test() {
 
 // --- Error cases ---
 
-pub fn decode_multibase_unsupported_prefix_test() {
+pub fn decode_multibase_unsupported_prefix_test() -> Nil {
   assert yabase.decode_multibase("!whatever") == Error(UnsupportedPrefix("!"))
 }
 
-pub fn decode_multibase_empty_test() {
+pub fn decode_multibase_empty_test() -> Nil {
   assert yabase.decode_multibase("") == Error(UnsupportedPrefix(""))
 }
 
-pub fn encode_multibase_dq_unsupported_test() {
+pub fn encode_multibase_dq_unsupported_test() -> Nil {
   assert case yabase.encode_multibase(Base64(DQ), <<"x":utf8>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
   }
 }
 
-pub fn encode_multibase_ascii85_unsupported_test() {
+pub fn encode_multibase_ascii85_unsupported_test() -> Nil {
   assert case yabase.encode_multibase(Base85(Btoa), <<"test":utf8>>) {
     Error(UnsupportedMultibaseEncoding(_)) -> True
     _ -> False
@@ -96,13 +96,13 @@ pub fn encode_multibase_ascii85_unsupported_test() {
 
 // --- Variant coverage ---
 
-pub fn encode_decode_urlsafe_nopadding_test() {
+pub fn encode_decode_urlsafe_nopadding_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(encoded) = yabase.encode(Base64(UrlSafeNoPadding), data)
   assert yabase.decode(Base64(UrlSafeNoPadding), encoded) == Ok(data)
 }
 
-pub fn multibase_roundtrip_urlsafe_nopadding_test() {
+pub fn multibase_roundtrip_urlsafe_nopadding_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(prefixed) =
     yabase.encode_multibase(Base64(UrlSafeNoPadding), data)
@@ -115,7 +115,7 @@ pub fn multibase_roundtrip_urlsafe_nopadding_test() {
   assert decoded == data
 }
 
-pub fn decode_multibase_rejects_padded_nopadding_test() {
+pub fn decode_multibase_rejects_padded_nopadding_test() -> Nil {
   // u = base64url no-padding through top-level API
   assert case yabase.decode_multibase("uZg==") {
     Error(InvalidCharacter("=", _)) -> True
@@ -123,7 +123,7 @@ pub fn decode_multibase_rejects_padded_nopadding_test() {
   }
 }
 
-pub fn multibase_roundtrip_base45_test() {
+pub fn multibase_roundtrip_base45_test() -> Nil {
   let data = <<"AB":utf8>>
   let assert Ok(prefixed) = yabase.encode_multibase(Base45, data)
   assert case prefixed {

--- a/test/z85_test.gleam
+++ b/test/z85_test.gleam
@@ -1,42 +1,42 @@
 import yabase/core/encoding.{InvalidLength, Overflow}
 import yabase/z85
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert z85.encode(<<>>) == Ok("")
 }
 
-pub fn encode_known_value_test() {
+pub fn encode_known_value_test() -> Nil {
   // 4 bytes -> 5 Z85 characters
   assert z85.encode(<<0x86, 0x4F, 0xD2, 0x6F>>) == Ok("Hello")
 }
 
-pub fn encode_non_4byte_error_test() {
+pub fn encode_non_4byte_error_test() -> Nil {
   // 3 bytes is not a multiple of 4
   assert z85.encode(<<1, 2, 3>>) == Error(InvalidLength(3))
 }
 
-pub fn encode_5byte_error_test() {
+pub fn encode_5byte_error_test() -> Nil {
   assert z85.encode(<<1, 2, 3, 4, 5>>) == Error(InvalidLength(5))
 }
 
-pub fn decode_invalid_length_test() {
+pub fn decode_invalid_length_test() -> Nil {
   // 3 chars is not a multiple of 5
   assert z85.decode("abc") == Error(InvalidLength(3))
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert z85.decode("") == Ok(<<>>)
 }
 
 // --- Overflow (85^5 > 2^32) ---
 
-pub fn decode_overflow_max_z85_group_test() {
+pub fn decode_overflow_max_z85_group_test() -> Nil {
   // "#####" = all index 84 -> 84*85^4 + 84*85^3 + 84*85^2 + 84*85 + 84
   // = 84 * (85^4 + 85^3 + 85^2 + 85 + 1) = 84 * 52_200_625 + ... > 2^32
   assert z85.decode("#####") == Error(Overflow)
 }
 
-pub fn decode_overflow_boundary_test() {
+pub fn decode_overflow_boundary_test() -> Nil {
   // The maximum valid Z85 value is %nSc0 = 0xFFFFFFFF = 4,294,967,295
   // %nSc1 (last char incremented) would be 4,294,967,296 = overflow
   // Instead test with a clearly overflowing group
@@ -45,25 +45,25 @@ pub fn decode_overflow_boundary_test() {
 
 // --- Roundtrip ---
 
-pub fn roundtrip_4bytes_test() {
+pub fn roundtrip_4bytes_test() -> Nil {
   let data = <<0x86, 0x4F, 0xD2, 0x6F>>
   let assert Ok(encoded) = z85.encode(data)
   assert z85.decode(encoded) == Ok(data)
 }
 
-pub fn roundtrip_8bytes_test() {
+pub fn roundtrip_8bytes_test() -> Nil {
   let data = <<0x86, 0x4F, 0xD2, 0x6F, 0xB5, 0x59, 0xF7, 0x5B>>
   let assert Ok(encoded) = z85.encode(data)
   assert z85.decode(encoded) == Ok(data)
 }
 
-pub fn roundtrip_all_zeros_test() {
+pub fn roundtrip_all_zeros_test() -> Nil {
   let data = <<0, 0, 0, 0>>
   let assert Ok(encoded) = z85.encode(data)
   assert z85.decode(encoded) == Ok(data)
 }
 
-pub fn roundtrip_high_bits_test() {
+pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xff, 0xff, 0xff>>
   let assert Ok(encoded) = z85.encode(data)
   assert z85.decode(encoded) == Ok(data)

--- a/test/zbase32_test.gleam
+++ b/test/zbase32_test.gleam
@@ -1,47 +1,47 @@
 import yabase/base32/zbase32
 import yabase/core/encoding.{InvalidCharacter}
 
-pub fn encode_empty_test() {
+pub fn encode_empty_test() -> Nil {
   assert zbase32.encode(<<>>) == ""
 }
 
-pub fn encode_hello_test() {
+pub fn encode_hello_test() -> Nil {
   // "Hello" in z-base-32
   let encoded = zbase32.encode(<<"Hello":utf8>>)
   // Roundtrip verification
   assert zbase32.decode(encoded) == Ok(<<"Hello":utf8>>)
 }
 
-pub fn decode_empty_test() {
+pub fn decode_empty_test() -> Nil {
   assert zbase32.decode("") == Ok(<<>>)
 }
 
-pub fn decode_invalid_char_test() {
+pub fn decode_invalid_char_test() -> Nil {
   assert case zbase32.decode("!!!!") {
     Error(InvalidCharacter(_, _)) -> True
     _ -> False
   }
 }
 
-pub fn roundtrip_test() {
+pub fn roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert zbase32.decode(zbase32.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_empty_test() {
+pub fn roundtrip_empty_test() -> Nil {
   assert zbase32.decode(zbase32.encode(<<>>)) == Ok(<<>>)
 }
 
-pub fn roundtrip_single_zero_test() {
+pub fn roundtrip_single_zero_test() -> Nil {
   assert zbase32.decode(zbase32.encode(<<0>>)) == Ok(<<0>>)
 }
 
-pub fn roundtrip_high_bits_test() {
+pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0xfd>>
   assert zbase32.decode(zbase32.encode(data)) == Ok(data)
 }
 
-pub fn roundtrip_leading_zeros_test() {
+pub fn roundtrip_leading_zeros_test() -> Nil {
   let data = <<0, 0, 42>>
   assert zbase32.decode(zbase32.encode(data)) == Ok(data)
 }


### PR DESCRIPTION
## Summary
Add `glinter` with a strict repository-wide configuration and enforce it in CI and `just`.
Update source, examples, and tests so the linter passes under the new rules while keeping the remaining ignores narrow and explicit.

## Changes
- add `glinter` as a dev dependency and configure all available rules as errors
- add `just lint` and run `glinter` as part of `just check`
- run `gleam run -m glinter` in GitHub Actions CI
- fix lint findings across `src/`, `test/`, and `examples/`, including missing type annotations, short variable names, and `string.inspect` usage
- keep a small set of focused ignores for test-only patterns and parser-heavy modules where labels or complexity rules are too noisy

## Design Decisions
- use `warnings_as_errors = true` and explicit rule levels so the repo stays on the strictest practical configuration
- lint examples and tests in addition to production code to keep the whole repository consistent
- prefer code fixes over ignores; only leave ignores where the rule would significantly hurt API ergonomics or readability

## Limitations
- a few module-level ignores remain for `label_possible`, `deep_nesting`, and `function_complexity` in parser-heavy or API-sensitive code paths
