### PR TITLE
docs(readme): rewrite quick-start to use facade module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Documentation
+
+- README "Quick start" rewritten to use the `yabase/facade`
+  module so the headline example no longer trips the project's own
+  `assert_ok_pattern = "error"` glinter rule on the encode side.
+  A short note explains the encode/decode asymmetry and points
+  readers at the unified API for the runtime-encoding-selection
+  case. (#6)
+
 ## [0.2.1] - 2026-04-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -25,19 +25,34 @@ gleam add yabase
 
 ## Quick start
 
+The simplest entry point is the facade module: one function per
+encoding. `encode_*` returns a plain `String` because the encodings
+covered here cannot fail on a valid `BitArray`; `decode_*` returns
+`Result` because a malformed input is a real error.
+
 ```gleam
-import yabase
-import yabase/core/encoding.{Base64, Standard}
+import yabase/facade
 
 pub fn main() {
-  // Unified API
-  let assert Ok(encoded) = yabase.encode(Base64(Standard), <<"Hello":utf8>>)
+  let encoded = facade.encode_base64(<<"Hello":utf8>>)
   // encoded == "SGVsbG8="
 
-  let assert Ok(_decoded) = yabase.decode(Base64(Standard), encoded)
+  let assert Ok(_decoded) = facade.decode_base64(encoded)
   // _decoded == <<"Hello":utf8>>
 }
 ```
+
+> **Why not `let assert` on encode?** yabase's own `gleam.toml`
+> enables glinter's `assert_ok_pattern = "error"` rule, so the
+> recommended shape in production code is to avoid `let assert
+> Ok(_)` for cases that cannot meaningfully fail. The facade
+> returns plain `String` for infallible encodings and only the
+> decode side is `Result`-shaped — there `let assert` is fine in a
+> README snippet but real code should propagate the error. If you
+> need to pick an encoding at runtime, see the unified API in
+> [API layers](#api-layers); `yabase.encode` is `Result`-shaped
+> for every variant because the `Encoding` ADT erases per-variant
+> error possibilities.
 
 ## Supported encodings
 


### PR DESCRIPTION
## Summary

The README quick-start opened with
`let assert Ok(encoded) = yabase.encode(...)`. yabase's own
`gleam.toml` enables glinter's `assert_ok_pattern = \"error\"` rule
(only suppressed under `test/**`), so a user who pasted the
quick-start into their `src/` and adopted the same lint setup that
yabase visibly recommends would immediately fail their own lint.

This change rewrites the quick-start to use `yabase/facade`, where
the encode side returns plain `String` (no `let assert` needed) and
the decode side stays `Result`-shaped (decode genuinely can fail).
A short note explains the encode/decode asymmetry and points
readers at the unified API for the runtime-encoding-selection case.

## Changes

- `README.md`:
  - Replace the `import yabase` / `import yabase/core/encoding`
    quick-start with the `import yabase/facade` shape, removing the
    `let assert Ok(encoded)` on the encode side.
  - Add a brief preamble pointing at the facade module as the
    simplest entry, plus a follow-up note explaining why
    `yabase.encode` is `Result`-shaped (the `Encoding` ADT erases
    per-variant error possibilities) and where to read more
    (\"API layers\" section).
  - Keep the existing $\"API layers$\" section unchanged — the
    unified API and low-level modules are still there for the
    runtime-encoding-selection and direct-codec cases respectively.
- `CHANGELOG.md`: add an `[Unreleased]` section noting the README
  rewrite under \`### Documentation\`.

## Design Decisions

- Picked Issue Option 1 (rewrite the quick-start) rather than only
  Option 2 (add a note). The note alone would explain the trap but
  still leave a `let assert` in the headline example; readers form
  their first impression from the code, not the prose, so the
  example itself needs to be the recommended shape.
- Kept the `let assert Ok(_decoded)` on the decode side. Decode
  genuinely can fail on malformed input, so propagating the
  `Result` is the recommended shape in real code; the `let assert`
  is acceptable in a README snippet for brevity, and the new note
  flags this asymmetry explicitly so readers do not blindly apply
  the same shape to their production decode call sites.
- Did not split the `Encoding` ADT into infallible / fallible
  halves (Issue's bigger swing). That would be a breaking change
  affecting every existing call site; the README fix is cheap,
  helps now, and is non-breaking. The ADT split could land
  separately if there is appetite for the API churn.
- Preserved every other README section verbatim, including the
  \"API layers\" examples that legitimately use `let assert` to
  illustrate the unified API. Rewriting those would have pushed
  this change beyond \"docs\" scope.

## Limitations

- This is a documentation-only fix; the underlying API surface is
  unchanged. Users on the unified `yabase.encode` / `yabase.decode`
  pair still get a `Result(_, _)` on every variant. The note in
  the README points at the facade for callers who want the
  infallible shape.

Closes #6