### PR TITLE
fix(decode): validate alphabet before length across base64 and base32 codecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `decode` for Base64 (Standard, URL-safe, NoPadding, DQ) and
+  Base32 (RFC 4648, Hex, Clockwork, z-base-32) now reports
+  `InvalidCharacter` with the offending byte and its position when
+  the input contains whitespace or other non-alphabet bytes,
+  instead of a misleading `InvalidLength` triggered by the
+  whitespace shifting the total length off the expected modulus.
+  The alphabet check runs before the length check across all of
+  these codecs. The behaviour for inputs that genuinely have a
+  bad length but only alphabet bytes is unchanged. URL-safe
+  no-padding already followed this contract and is unchanged.
+  (#7)
+
 ### Documentation
 
 - README "Quick start" rewritten to use the `yabase/facade`

--- a/src/yabase/base32/clockwork.gleam
+++ b/src/yabase/base32/clockwork.gleam
@@ -32,12 +32,35 @@ fn encode_bits(data: BitArray, acc: List(String)) -> List(String) {
 
 /// Decode a Clockwork Base32 string to a BitArray.
 /// Case-insensitive. o/O->0, i/I/l/L->1.
+///
+/// Non-alphabet characters (whitespace, CR/LF, punctuation outside
+/// Clockwork's accepted set) are rejected with `InvalidCharacter`
+/// carrying the offending byte and its position. The alphabet
+/// check runs before the length check so the caller does not see
+/// a misleading `InvalidLength` when the real fault is an
+/// out-of-alphabet byte.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
   let upper = string.uppercase(input)
-  let len = string.length(upper)
-  case len % 8 {
-    1 | 3 | 6 -> Error(InvalidLength(len))
-    _ -> decode_chars(upper, <<>>, 0)
+  case validate_alphabet(upper, 0) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      let len = string.length(upper)
+      case len % 8 {
+        1 | 3 | 6 -> Error(InvalidLength(len))
+        _ -> decode_chars(upper, <<>>, 0)
+      }
+    }
+  }
+}
+
+fn validate_alphabet(input: String, pos: Int) -> Result(Nil, CodecError) {
+  case string.pop_grapheme(input) {
+    Error(Nil) -> Ok(Nil)
+    Ok(#(c, rest)) ->
+      case char_to_value(c) {
+        Ok(_) -> validate_alphabet(rest, pos + 1)
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
+      }
   }
 }
 

--- a/src/yabase/base32/hex.gleam
+++ b/src/yabase/base32/hex.gleam
@@ -1,5 +1,6 @@
 /// Base32 Hex encoding (RFC 4648, extended hex alphabet).
 import gleam/bit_array
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
@@ -39,8 +40,22 @@ fn add_padding(encoded: String) -> String {
 }
 
 /// Decode a Base32 Hex string to a BitArray.
+///
+/// Non-alphabet characters (whitespace, CR/LF, punctuation outside
+/// `0-9`, `A-V`, and `=`) are rejected with `InvalidCharacter`
+/// carrying the offending byte and its position. The alphabet check
+/// runs before the length check so the caller does not see a
+/// misleading `InvalidLength` when the real fault is an
+/// out-of-alphabet byte.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
   let upper = string.uppercase(input)
+  case validate_alphabet(upper, 0) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> decode_validated(upper)
+  }
+}
+
+fn decode_validated(upper: String) -> Result(BitArray, CodecError) {
   let input_len = string.length(upper)
   let has_padding = string.contains(upper, pad)
   case has_padding && input_len % 8 != 0 {
@@ -60,6 +75,25 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
           }
         }
       }
+  }
+}
+
+fn validate_alphabet(input: String, pos: Int) -> Result(Nil, CodecError) {
+  case string.pop_grapheme(input) {
+    Error(Nil) -> Ok(Nil)
+    Ok(#(c, rest)) ->
+      case is_alphabet(c) {
+        True -> validate_alphabet(rest, pos + 1)
+        False -> Error(InvalidCharacter(c, pos))
+      }
+  }
+}
+
+fn is_alphabet(c: String) -> Bool {
+  use <- bool.guard(when: c == pad, return: True)
+  case char_to_value(c) {
+    Ok(_) -> True
+    Error(Nil) -> False
   }
 }
 

--- a/src/yabase/base32/rfc4648.gleam
+++ b/src/yabase/base32/rfc4648.gleam
@@ -1,5 +1,6 @@
 /// Base32 encoding per RFC 4648.
 import gleam/bit_array
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
@@ -39,8 +40,22 @@ fn add_padding(encoded: String) -> String {
 }
 
 /// Decode a Base32 string (with or without padding) to a BitArray.
+///
+/// Non-alphabet characters (whitespace, CR/LF, punctuation outside
+/// `A-Z`, `2-7`, and `=`) are rejected with `InvalidCharacter`
+/// carrying the offending byte and its position. The alphabet check
+/// runs before the length check so the caller does not see a
+/// misleading `InvalidLength` when the real fault is an
+/// out-of-alphabet byte.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
   let upper = string.uppercase(input)
+  case validate_alphabet(upper, 0) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> decode_validated(upper)
+  }
+}
+
+fn decode_validated(upper: String) -> Result(BitArray, CodecError) {
   let input_len = string.length(upper)
   let has_padding = string.contains(upper, pad)
   // If padding is present, total length must be a multiple of 8
@@ -62,6 +77,25 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
           }
         }
       }
+  }
+}
+
+fn validate_alphabet(input: String, pos: Int) -> Result(Nil, CodecError) {
+  case string.pop_grapheme(input) {
+    Error(Nil) -> Ok(Nil)
+    Ok(#(c, rest)) ->
+      case is_alphabet(c) {
+        True -> validate_alphabet(rest, pos + 1)
+        False -> Error(InvalidCharacter(c, pos))
+      }
+  }
+}
+
+fn is_alphabet(c: String) -> Bool {
+  use <- bool.guard(when: c == pad, return: True)
+  case char_to_value(c) {
+    Ok(_) -> True
+    Error(Nil) -> False
   }
 }
 

--- a/src/yabase/base32/zbase32.gleam
+++ b/src/yabase/base32/zbase32.gleam
@@ -31,12 +31,35 @@ fn encode_bits(data: BitArray, acc: List(String)) -> List(String) {
 }
 
 /// Decode a z-base-32 string to a BitArray.
+///
+/// Non-alphabet characters (whitespace, CR/LF, punctuation outside
+/// z-base-32's accepted set) are rejected with `InvalidCharacter`
+/// carrying the offending byte and its position. The alphabet check
+/// runs before the length check so the caller does not see a
+/// misleading `InvalidLength` when the real fault is an
+/// out-of-alphabet byte.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
   let lower = string.lowercase(input)
-  let len = string.length(lower)
-  case len % 8 {
-    1 | 3 | 6 -> Error(InvalidLength(len))
-    _ -> decode_chars(lower, <<>>, 0)
+  case validate_alphabet(lower, 0) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      let len = string.length(lower)
+      case len % 8 {
+        1 | 3 | 6 -> Error(InvalidLength(len))
+        _ -> decode_chars(lower, <<>>, 0)
+      }
+    }
+  }
+}
+
+fn validate_alphabet(input: String, pos: Int) -> Result(Nil, CodecError) {
+  case string.pop_grapheme(input) {
+    Error(Nil) -> Ok(Nil)
+    Ok(#(c, rest)) ->
+      case char_to_value(c) {
+        Ok(_) -> validate_alphabet(rest, pos + 1)
+        Error(Nil) -> Error(InvalidCharacter(c, pos))
+      }
   }
 }
 

--- a/src/yabase/base64/dq.gleam
+++ b/src/yabase/base64/dq.gleam
@@ -2,6 +2,7 @@
 /// Uses Japanese hiragana as the 64-symbol alphabet.
 /// Padding character: ・ (middle dot).
 import gleam/bit_array
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
@@ -45,12 +46,46 @@ fn encode_chunks(data: BitArray, acc: List(String)) -> List(String) {
 }
 
 /// Decode a Base64 DQ (hiragana) string to a BitArray.
+///
+/// Non-alphabet graphemes (whitespace, ASCII, mismatched kana, etc.)
+/// are rejected with `InvalidCharacter` carrying the offending
+/// grapheme and its position. The alphabet check runs before the
+/// length check so the caller does not see a misleading
+/// `InvalidLength` when the real fault is an out-of-alphabet
+/// grapheme.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
   let graphemes = string.to_graphemes(input)
-  let len = list.length(graphemes)
-  case len % 4 {
-    0 -> decode_graphemes(graphemes, <<>>, 0)
-    _ -> Error(InvalidLength(len))
+  case validate_alphabet(graphemes, 0) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      let len = list.length(graphemes)
+      case len % 4 {
+        0 -> decode_graphemes(graphemes, <<>>, 0)
+        _ -> Error(InvalidLength(len))
+      }
+    }
+  }
+}
+
+fn validate_alphabet(
+  graphemes: List(String),
+  pos: Int,
+) -> Result(Nil, CodecError) {
+  case graphemes {
+    [] -> Ok(Nil)
+    [c, ..rest] ->
+      case is_alphabet(c) {
+        True -> validate_alphabet(rest, pos + 1)
+        False -> Error(InvalidCharacter(c, pos))
+      }
+  }
+}
+
+fn is_alphabet(c: String) -> Bool {
+  use <- bool.guard(when: c == dq_pad, return: True)
+  case dq_value_of(c) {
+    Ok(_) -> True
+    Error(Nil) -> False
   }
 }
 

--- a/src/yabase/base64/nopadding.gleam
+++ b/src/yabase/base64/nopadding.gleam
@@ -1,9 +1,10 @@
 /// Base64 encoding without padding.
 /// Same as standard Base64 but padding characters are stripped.
-import gleam/bool
 import gleam/string
 import yabase/base64/standard
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
+
+const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
 /// Encode a BitArray to Base64 without padding.
 pub fn encode(data: BitArray) -> String {
@@ -13,33 +14,35 @@ pub fn encode(data: BitArray) -> String {
 
 /// Decode a Base64 string (without padding) to a BitArray.
 /// Length % 4 must be 0, 2, or 3 (never 1).
-/// Padding characters (=) are rejected.
+/// Padding characters (=) and any non-alphabet byte (whitespace,
+/// CR/LF, punctuation) are rejected with `InvalidCharacter` carrying
+/// the offending byte and its position. The alphabet check runs
+/// before the length check so a whitespace byte does not surface as
+/// a misleading `InvalidLength`.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
-  use <- bool.guard(
-    when: string.contains(input, "="),
-    return: Error(InvalidCharacter("=", find_char_pos(input, "=", 0))),
-  )
-  let len = string.length(input)
-  case len % 4 {
-    1 -> Error(InvalidLength(len))
-    _ -> {
-      let padded = add_padding(input)
-      standard.decode(padded)
+  case validate_alphabet(input, 0) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      let len = string.length(input)
+      case len % 4 {
+        1 -> Error(InvalidLength(len))
+        _ -> {
+          let padded = add_padding(input)
+          standard.decode(padded)
+        }
+      }
     }
   }
 }
 
-fn find_char_pos(input: String, target: String, pos: Int) -> Int {
+fn validate_alphabet(input: String, pos: Int) -> Result(Nil, CodecError) {
   case string.pop_grapheme(input) {
-    Ok(#(char, rest)) ->
-      case char == target {
-        True -> pos
-        False -> find_char_pos(rest, target, pos + 1)
+    Error(Nil) -> Ok(Nil)
+    Ok(#(c, rest)) ->
+      case string.contains(alphabet, c) {
+        True -> validate_alphabet(rest, pos + 1)
+        False -> Error(InvalidCharacter(c, pos))
       }
-    Error(error) -> {
-      let _nil_error = error
-      pos
-    }
   }
 }
 

--- a/src/yabase/base64/standard.gleam
+++ b/src/yabase/base64/standard.gleam
@@ -1,5 +1,6 @@
 /// Standard Base64 encoding per RFC 4648.
 import gleam/bit_array
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
@@ -31,13 +32,41 @@ fn encode_chunks(data: BitArray, acc: List(String)) -> List(String) {
 }
 
 /// Decode a standard Base64 string to a BitArray.
-/// Per RFC 4648 section 3.3, non-alphabet characters (including CR/LF)
-/// are rejected.
+/// Per RFC 4648 section 3.3, non-alphabet characters (including
+/// whitespace, CR/LF, and other punctuation) are rejected. The
+/// alphabet check runs before the length check so the caller sees
+/// `InvalidCharacter` (with the offending byte and its position)
+/// rather than a misleading `InvalidLength` whenever the real fault
+/// is an out-of-alphabet byte.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
-  let len = string.length(input)
-  case len % 4 {
-    0 -> decode_chars(input, <<>>, 0)
-    _ -> Error(InvalidLength(len))
+  case validate_alphabet(input, 0) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      let len = string.length(input)
+      case len % 4 {
+        0 -> decode_chars(input, <<>>, 0)
+        _ -> Error(InvalidLength(len))
+      }
+    }
+  }
+}
+
+fn validate_alphabet(input: String, pos: Int) -> Result(Nil, CodecError) {
+  case string.pop_grapheme(input) {
+    Error(Nil) -> Ok(Nil)
+    Ok(#(c, rest)) ->
+      case is_alphabet(c) {
+        True -> validate_alphabet(rest, pos + 1)
+        False -> Error(InvalidCharacter(c, pos))
+      }
+  }
+}
+
+fn is_alphabet(c: String) -> Bool {
+  use <- bool.guard(when: c == pad, return: True)
+  case value_of(c) {
+    Ok(_) -> True
+    Error(Nil) -> False
   }
 }
 

--- a/src/yabase/base64/urlsafe.gleam
+++ b/src/yabase/base64/urlsafe.gleam
@@ -1,6 +1,7 @@
 /// URL-safe Base64 encoding (RFC 4648 section 5).
 /// Uses - instead of + and _ instead of /.
 import gleam/bit_array
+import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
@@ -33,13 +34,40 @@ fn encode_chunks(data: BitArray, acc: List(String)) -> List(String) {
 }
 
 /// Decode a URL-safe Base64 string to a BitArray.
-/// Per RFC 4648 section 3.3, non-alphabet characters (including CR/LF)
-/// are rejected.
+/// Per RFC 4648 section 3.3, non-alphabet characters (including
+/// whitespace, CR/LF, and other punctuation) are rejected. The
+/// alphabet check runs before the length check so the caller sees
+/// `InvalidCharacter` rather than `InvalidLength` whenever the real
+/// fault is an out-of-alphabet byte.
 pub fn decode(input: String) -> Result(BitArray, CodecError) {
-  let len = string.length(input)
-  case len % 4 {
-    0 -> decode_chars(input, <<>>, 0)
-    _ -> Error(InvalidLength(len))
+  case validate_alphabet(input, 0) {
+    Error(e) -> Error(e)
+    Ok(Nil) -> {
+      let len = string.length(input)
+      case len % 4 {
+        0 -> decode_chars(input, <<>>, 0)
+        _ -> Error(InvalidLength(len))
+      }
+    }
+  }
+}
+
+fn validate_alphabet(input: String, pos: Int) -> Result(Nil, CodecError) {
+  case string.pop_grapheme(input) {
+    Error(Nil) -> Ok(Nil)
+    Ok(#(c, rest)) ->
+      case is_alphabet(c) {
+        True -> validate_alphabet(rest, pos + 1)
+        False -> Error(InvalidCharacter(c, pos))
+      }
+  }
+}
+
+fn is_alphabet(c: String) -> Bool {
+  use <- bool.guard(when: c == pad, return: True)
+  case value_of(c) {
+    Ok(_) -> True
+    Error(Nil) -> False
   }
 }
 

--- a/test/base32_test.gleam
+++ b/test/base32_test.gleam
@@ -84,6 +84,21 @@ pub fn rfc4648_decode_pure_padding_test() -> Nil {
   }
 }
 
+// --- Whitespace and other non-alphabet bytes (#7) ---
+//
+// Whitespace surfaces as InvalidCharacter with its position; the
+// alphabet check runs before the length check so the diagnostic
+// points at the real fault rather than at a misleading length
+// mismatch.
+
+pub fn rfc4648_decode_rejects_lf_test() -> Nil {
+  assert rfc4648.decode("MZXW6\n===") == Error(InvalidCharacter("\n", 5))
+}
+
+pub fn rfc4648_decode_rejects_space_test() -> Nil {
+  assert rfc4648.decode("MZXW 6===") == Error(InvalidCharacter(" ", 4))
+}
+
 // --- Unpadded decode ---
 
 pub fn rfc4648_decode_unpadded_f_test() -> Nil {

--- a/test/base64_test.gleam
+++ b/test/base64_test.gleam
@@ -116,15 +116,26 @@ pub fn scure_bad_double_eq_test() -> Nil {
 }
 
 // --- CRLF rejection (RFC 4648 section 3.3) ---
+//
+// Whitespace is rejected with `InvalidCharacter` carrying the
+// offending byte and its position; the alphabet check runs before
+// the length check so the diagnostic points at the real fault
+// rather than at a misleading length mismatch (#7).
 
 pub fn standard_decode_rejects_lf_test() -> Nil {
-  // "Zm9v\n" is 5 chars -> 5 % 4 != 0 -> InvalidLength
-  assert standard.decode("Zm9v\n") == Error(InvalidLength(5))
+  assert standard.decode("Zm9v\n") == Error(InvalidCharacter("\n", 4))
 }
 
 pub fn standard_decode_rejects_crlf_in_middle_test() -> Nil {
-  // "Zg==\r\n" - \r\n is one grapheme cluster in Unicode -> 5 graphemes
-  assert standard.decode("Zg==\r\n") == Error(InvalidLength(5))
+  // "Zg==\r\n" - \r\n is one grapheme cluster in Unicode at position 4.
+  assert standard.decode("Zg==\r\n") == Error(InvalidCharacter("\r\n", 4))
+}
+
+pub fn standard_decode_rejects_space_in_middle_test() -> Nil {
+  // The headline #7 reproduction: a space inside an otherwise
+  // 4-aligned input must surface as InvalidCharacter, not
+  // InvalidLength.
+  assert standard.decode("SGk =") == Error(InvalidCharacter(" ", 3))
 }
 
 // --- Padding-then-trailing-data regression ---
@@ -192,8 +203,9 @@ pub fn urlsafe_decode_truncated_test() -> Nil {
 }
 
 pub fn urlsafe_decode_rejects_lf_test() -> Nil {
-  // "Zm9v\n" is 5 chars -> 5 % 4 != 0 -> InvalidLength
-  assert urlsafe.decode("Zm9v\n") == Error(InvalidLength(5))
+  // Whitespace surfaces as InvalidCharacter with its position (#7),
+  // not as a misleading InvalidLength.
+  assert urlsafe.decode("Zm9v\n") == Error(InvalidCharacter("\n", 4))
 }
 
 pub fn urlsafe_decode_data_after_double_pad_test() -> Nil {


### PR DESCRIPTION
## Summary

`yabase.decode(Base64(Standard), \"SGk =\")` returned
`Error(InvalidLength(5))` when the real fault was the space at
position 3. The diagnostic told the user to fix something they
hadn't broken — the input was the right length once the whitespace
was removed; what they actually needed to know was \"there is a
space at offset 3 that is not in the Base64 alphabet.\"

This change makes every padded Base64 / Base32 codec validate the
alphabet **before** the length check, so a non-alphabet byte
(whitespace, CR/LF, punctuation) surfaces as
`InvalidCharacter(byte, position)` regardless of how the byte
shifted the input modulus. Inputs whose only fault is a true length
mismatch (e.g. `\"AA=\"` for Base64) still return `InvalidLength`
unchanged.

## Changes

Source — added a `validate_alphabet` first-pass and an
`is_alphabet` helper to each affected `decode`, gated by the
existing `value_of` / `char_to_value` table so the alphabet stays
the single source of truth. Padding (`=`) is treated as a valid
alphabet byte at this stage — invalid padding placement is still
caught by the existing post-strip checks.

- `src/yabase/base64/standard.gleam`
- `src/yabase/base64/urlsafe.gleam`
- `src/yabase/base64/nopadding.gleam` — also dropped the redundant
  `bool.guard(string.contains(input, \"=\"))` and `find_char_pos`
  helper, since the new `validate_alphabet` rejects \`=\` (it is
  not in the no-padding alphabet) with the same
  \`InvalidCharacter(\"=\", pos)\` shape but using the shared scan.
- `src/yabase/base64/dq.gleam` — alphabet-first scan over the
  hiragana grapheme list, mirroring the ASCII codecs.
- `src/yabase/base32/rfc4648.gleam`
- `src/yabase/base32/hex.gleam`
- `src/yabase/base32/clockwork.gleam`
- `src/yabase/base32/zbase32.gleam`

`urlsafe_nopadding` already followed this contract (it scans for
the first invalid character before doing the length check); left
unchanged. `crockford` routes through the `bignum` decoder which
has its own validation path; left out of scope here.

Tests:

- `test/base64_test.gleam`:
  - Update `standard_decode_rejects_lf_test` and
    `standard_decode_rejects_crlf_in_middle_test` to expect
    `InvalidCharacter` (their previous `InvalidLength` expectation
    was pinning the bug).
  - Add `standard_decode_rejects_space_in_middle_test` covering
    the headline #7 reproduction (`\"SGk =\"` → space at offset 3).
  - Update `urlsafe_decode_rejects_lf_test` to the new
    `InvalidCharacter` shape.
- `test/base32_test.gleam`:
  - Add `rfc4648_decode_rejects_lf_test` and
    `rfc4648_decode_rejects_space_test`.

CHANGELOG — note the diagnostic improvement under \`### Fixed\`.

## Design Decisions

- Picked Issue Option 1 (strict, validate alphabet first) over
  Option 2 (silently strip whitespace per RFC 4648 §3.3 \"MAY
  ignore\"). Option 2 would change the semantic shape of every
  decode call site (e.g., `\"SGk \\nQ==\"` would suddenly succeed
  where it used to fail), which is a behaviour change without an
  explicit caller opt-in. The strict diagnostic fix is purely
  additive on the success set: every input that decoded before
  still decodes, every input that failed before still fails — only
  the **error variant** changes for whitespace inputs, from
  `InvalidLength` to the more actionable `InvalidCharacter`.
- Implemented per codec rather than via a dispatcher refactor (the
  Issue's suggested shape) because each codec already owns its
  alphabet table; the dispatcher does not know which bytes are
  legal. A single shared \`validate\` helper would have required
  threading an alphabet predicate through every codec, which is the
  same code surface as the per-codec helper.
- Treated padding (`=`) as a valid alphabet byte at the
  \`validate_alphabet\` stage so the existing \`validate_padding\`
  / \`take_4\` checks continue to handle bad padding placement
  exactly as before. Failing on an early `=` here would have
  changed the error variant for inputs like `\"=AB=\"` from
  `InvalidCharacter(\"=\", 0)` (current downstream behaviour) to a
  near-identical but distinct earlier failure — same shape, no
  user benefit, would have moved test fixtures unnecessarily.
- Removed `nopadding`'s ad-hoc `find_char_pos` + `bool.guard`
  pre-scan after introducing the shared `validate_alphabet`, since
  the latter handles `=` rejection with the same
  `InvalidCharacter(\"=\", pos)` shape but as part of the unified
  alphabet check. Net change: less code, identical user-visible
  behaviour for the existing test corpus.

## Limitations

- Base16, Base91, Ascii85, Z85, RFC 1924 Base85, Base45, and
  Bech32 are out of scope for this PR. Their failure shapes were
  not flagged by #7 and several use a different decode pipeline
  (bignum, padded-by-5, etc.); a follow-up could audit those
  individually if they exhibit the same diagnostic confusion.
- Crockford Base32 decode is out of scope for the same reason
  (bignum-based). Its current validation already catches non-
  alphabet bytes inside `bignum.decode`; the diagnostic shape may
  differ slightly but does not return a misleading
  `InvalidLength`.
- The behaviour of `decode_check` for Crockford and the
  multi-stage `bech32`/`base58check` decoders is unchanged.

Closes #7