### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-25
+
 ### Fixed
 
 - `decode` for Base64 (Standard, URL-safe, NoPadding, DQ) and

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.2.1"
+version = "0.3.0"
 target = "erlang"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]


### PR DESCRIPTION
### Fixed

- `decode` for Base64 (Standard, URL-safe, NoPadding, DQ) and
  Base32 (RFC 4648, Hex, Clockwork, z-base-32) now reports
  `InvalidCharacter` with the offending byte and its position when
  the input contains whitespace or other non-alphabet bytes,
  instead of a misleading `InvalidLength` triggered by the
  whitespace shifting the total length off the expected modulus.
  The alphabet check runs before the length check across all of
  these codecs. The behaviour for inputs that genuinely have a
  bad length but only alphabet bytes is unchanged. URL-safe
  no-padding already followed this contract and is unchanged.
  (#7)

### Documentation

- README "Quick start" rewritten to use the `yabase/facade`
  module so the headline example no longer trips the project's own
  `assert_ok_pattern = "error"` glinter rule on the encode side.
  A short note explains the encode/decode asymmetry and points
  readers at the unified API for the runtime-encoding-selection
  case. (#6)
