### PR TITLE
feat(intid): add encode_int_*/decode_int_* helpers for short IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- New `yabase/intid` module with `encode_int_*` / `decode_int_*`
+  helpers for short URL-safe identifier use cases (DB autoincrement
+  ids, sequence numbers, hash truncations). Covers Base32 (RFC 4648,
+  Crockford), Base36, Base58 (Bitcoin, Flickr), and Base62. Without
+  these helpers every caller had to re-implement the same
+  `Int -> big-endian bytes -> trim-leading-zero` shim plus the inverse
+  for decode (~40 lines per project). `encode_int_*` emits canonical
+  form (no leading zero characters); `decode_int_*` is tolerant of
+  leading zero characters so externally zero-padded input round-trips
+  to the same `Int`. Negative inputs are normalized via
+  `int.absolute_value` before encoding. Decode returns
+  `Result(Int, CodecError)` to match the rest of the library. (#11)
+
 ## [0.3.0] - 2026-04-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ pub fn main() {
 > for every variant because the `Encoding` ADT erases per-variant
 > error possibilities.
 
+## Integer IDs
+
+Short URL-safe identifiers — DB autoincrement ids, sequence numbers, hash truncations — usually want `Int -> compact string` rather than `BitArray -> String`. The `yabase/intid` module provides this directly so callers do not have to write the `Int -> big-endian bytes -> trim-leading-zero` shim themselves.
+
+```gleam
+import yabase/intid
+
+pub fn main() {
+  let token = intid.encode_int_base58(42)
+  // token == "j"
+
+  let assert Ok(_n) = intid.decode_int_base58(token)
+  // _n == 42
+}
+```
+
+Available: `encode_int_base32_rfc4648`, `encode_int_base32_crockford`, `encode_int_base36`, `encode_int_base58`, `encode_int_base58_flickr`, `encode_int_base62` and their matching `decode_int_*` (returning `Result(Int, CodecError)`).
+
+`encode_int_*` emits canonical form. `decode_int_*` is tolerant of leading zero characters (`decode_int_base58("0042")` and `decode_int_base58("42")` return the same `Int`). Negative inputs are normalized via `int.absolute_value` before encoding.
+
 ## Supported encodings
 
 ### Core
@@ -231,6 +251,7 @@ let assert Ok(_decoded) = base58check.decode(encoded)
 | `yabase/base58/bitcoin` | Base58 (Bitcoin alphabet) |
 | `yabase/base58/flickr` | Base58 (Flickr alphabet) |
 | `yabase/base62` | Base62 |
+| `yabase/intid` | `Int <-> short string` helpers for IDs (Base32 / Base36 / Base58 / Base62) |
 | `yabase/base91` | Base91 |
 | `yabase/ascii85` | Ascii85 (btoa) |
 | `yabase/adobe_ascii85` | Adobe Ascii85 (PDF/PostScript, `<~` `~>` delimiters) |

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -1,0 +1,121 @@
+//// Integer helpers for short URL-safe identifiers.
+////
+//// The byte-oriented codecs in `yabase/facade` are the right tool when
+//// the input is opaque bytes (hashes, public keys, raw payloads). For
+//// the very common short-ID case — DB autoincrement ids, sequence
+//// numbers, hash truncations — callers want `Int -> compact string`
+//// directly. Without these helpers every project re-implements the
+//// same `Int -> big-endian bytes -> trim-leading-zero` shim.
+////
+//// `encode_int_*` emits canonical form: no leading zero characters
+//// beyond what the value itself requires (`encode_int_base58(0) ==
+//// "1"`, the alphabet's zero character; `encode_int_base58(58) ==
+//// "21"`, no leading `"1"`).
+////
+//// `decode_int_*` is tolerant of leading zero characters
+//// (`decode_int_base58("0042")` and `decode_int_base58("42")` both
+//// return the same `Int`), so input from external sources that
+//// zero-pads is accepted without ceremony.
+////
+//// Negative inputs are normalized to `int.absolute_value` before
+//// encoding — the magnitude is what gets stored. The decode side
+//// always returns a non-negative `Int`.
+
+import gleam/int
+import gleam/result
+import yabase/base32/crockford as base32_crockford
+import yabase/base32/rfc4648 as base32_rfc4648
+import yabase/base36
+import yabase/base58/bitcoin as base58_bitcoin
+import yabase/base58/flickr as base58_flickr
+import yabase/base62
+import yabase/core/encoding.{type CodecError}
+import yabase/internal/bignum
+
+/// Encode a non-negative `Int` as a Base32 (RFC 4648) string.
+pub fn encode_int_base32_rfc4648(value: Int) -> String {
+  base32_rfc4648.encode(int_to_bytes_be(value))
+}
+
+/// Decode a Base32 (RFC 4648) string back to an `Int`.
+pub fn decode_int_base32_rfc4648(input: String) -> Result(Int, CodecError) {
+  base32_rfc4648.decode(input)
+  |> result.map(bytes_to_int)
+}
+
+/// Encode a non-negative `Int` as a Crockford Base32 string.
+pub fn encode_int_base32_crockford(value: Int) -> String {
+  base32_crockford.encode(int_to_bytes_be(value))
+}
+
+/// Decode a Crockford Base32 string back to an `Int`.
+pub fn decode_int_base32_crockford(input: String) -> Result(Int, CodecError) {
+  base32_crockford.decode(input)
+  |> result.map(bytes_to_int)
+}
+
+/// Encode a non-negative `Int` as a Base36 string.
+pub fn encode_int_base36(value: Int) -> String {
+  base36.encode(int_to_bytes_be(value))
+}
+
+/// Decode a Base36 string back to an `Int`.
+pub fn decode_int_base36(input: String) -> Result(Int, CodecError) {
+  base36.decode(input)
+  |> result.map(bytes_to_int)
+}
+
+/// Encode a non-negative `Int` as a Base58 (Bitcoin alphabet) string.
+pub fn encode_int_base58(value: Int) -> String {
+  base58_bitcoin.encode(int_to_bytes_be(value))
+}
+
+/// Decode a Base58 (Bitcoin alphabet) string back to an `Int`.
+pub fn decode_int_base58(input: String) -> Result(Int, CodecError) {
+  base58_bitcoin.decode(input)
+  |> result.map(bytes_to_int)
+}
+
+/// Encode a non-negative `Int` as a Base58 (Flickr alphabet) string.
+pub fn encode_int_base58_flickr(value: Int) -> String {
+  base58_flickr.encode(int_to_bytes_be(value))
+}
+
+/// Decode a Base58 (Flickr alphabet) string back to an `Int`.
+pub fn decode_int_base58_flickr(input: String) -> Result(Int, CodecError) {
+  base58_flickr.decode(input)
+  |> result.map(bytes_to_int)
+}
+
+/// Encode a non-negative `Int` as a Base62 string.
+pub fn encode_int_base62(value: Int) -> String {
+  base62.encode(int_to_bytes_be(value))
+}
+
+/// Decode a Base62 string back to an `Int`.
+pub fn decode_int_base62(input: String) -> Result(Int, CodecError) {
+  base62.decode(input)
+  |> result.map(bytes_to_int)
+}
+
+fn int_to_bytes_be(value: Int) -> BitArray {
+  let magnitude = int.absolute_value(value)
+  case magnitude {
+    0 -> <<0>>
+    _ -> accumulate_bytes(magnitude, <<>>)
+  }
+}
+
+fn accumulate_bytes(num: Int, acc: BitArray) -> BitArray {
+  case num {
+    0 -> acc
+    _ -> {
+      let byte = num % 256
+      accumulate_bytes(num / 256, <<byte, acc:bits>>)
+    }
+  }
+}
+
+fn bytes_to_int(data: BitArray) -> Int {
+  bignum.bytes_to_int(data, 0)
+}

--- a/test/intid_test.gleam
+++ b/test/intid_test.gleam
@@ -1,0 +1,196 @@
+import yabase/core/encoding.{InvalidCharacter}
+import yabase/intid
+
+// === Base32 (RFC 4648) ===
+
+pub fn encode_int_base32_rfc4648_zero_test() -> Nil {
+  assert intid.encode_int_base32_rfc4648(0) == "AA======"
+}
+
+pub fn encode_int_base32_rfc4648_one_test() -> Nil {
+  assert intid.encode_int_base32_rfc4648(1) == "AE======"
+}
+
+pub fn encode_int_base32_rfc4648_max_byte_test() -> Nil {
+  assert intid.encode_int_base32_rfc4648(255) == "74======"
+}
+
+pub fn decode_int_base32_rfc4648_empty_test() -> Nil {
+  assert intid.decode_int_base32_rfc4648("") == Ok(0)
+}
+
+pub fn decode_int_base32_rfc4648_roundtrip_test() -> Nil {
+  let encoded = intid.encode_int_base32_rfc4648(1_234_567)
+  assert intid.decode_int_base32_rfc4648(encoded) == Ok(1_234_567)
+}
+
+pub fn decode_int_base32_rfc4648_invalid_char_test() -> Nil {
+  assert intid.decode_int_base32_rfc4648("!!!!!!!!")
+    == Error(InvalidCharacter("!", 0))
+}
+
+// === Base32 (Crockford) ===
+
+pub fn encode_int_base32_crockford_zero_test() -> Nil {
+  assert intid.encode_int_base32_crockford(0) == "0"
+}
+
+pub fn encode_int_base32_crockford_alphabet_max_test() -> Nil {
+  assert intid.encode_int_base32_crockford(31) == "Z"
+}
+
+pub fn encode_int_base32_crockford_carry_test() -> Nil {
+  assert intid.encode_int_base32_crockford(32) == "10"
+}
+
+pub fn encode_int_base32_crockford_two_digit_max_test() -> Nil {
+  assert intid.encode_int_base32_crockford(1023) == "ZZ"
+}
+
+pub fn decode_int_base32_crockford_empty_test() -> Nil {
+  assert intid.decode_int_base32_crockford("") == Ok(0)
+}
+
+pub fn decode_int_base32_crockford_leading_zero_tolerant_test() -> Nil {
+  assert intid.decode_int_base32_crockford("0042")
+    == intid.decode_int_base32_crockford("42")
+}
+
+pub fn decode_int_base32_crockford_roundtrip_test() -> Nil {
+  let encoded = intid.encode_int_base32_crockford(987_654)
+  assert intid.decode_int_base32_crockford(encoded) == Ok(987_654)
+}
+
+// === Base36 ===
+
+pub fn encode_int_base36_zero_test() -> Nil {
+  assert intid.encode_int_base36(0) == "0"
+}
+
+pub fn encode_int_base36_alphabet_max_test() -> Nil {
+  assert intid.encode_int_base36(35) == "z"
+}
+
+pub fn encode_int_base36_carry_test() -> Nil {
+  assert intid.encode_int_base36(36) == "10"
+}
+
+pub fn encode_int_base36_two_digit_max_test() -> Nil {
+  assert intid.encode_int_base36(1295) == "zz"
+}
+
+pub fn decode_int_base36_empty_test() -> Nil {
+  assert intid.decode_int_base36("") == Ok(0)
+}
+
+pub fn decode_int_base36_leading_zero_tolerant_test() -> Nil {
+  assert intid.decode_int_base36("0042") == intid.decode_int_base36("42")
+}
+
+pub fn decode_int_base36_roundtrip_test() -> Nil {
+  let encoded = intid.encode_int_base36(8_675_309)
+  assert intid.decode_int_base36(encoded) == Ok(8_675_309)
+}
+
+pub fn decode_int_base36_invalid_char_test() -> Nil {
+  assert intid.decode_int_base36("!") == Error(InvalidCharacter("!", 0))
+}
+
+// === Base58 (Bitcoin) ===
+
+pub fn encode_int_base58_zero_test() -> Nil {
+  assert intid.encode_int_base58(0) == "1"
+}
+
+pub fn encode_int_base58_small_test() -> Nil {
+  assert intid.encode_int_base58(42) == "j"
+}
+
+pub fn encode_int_base58_alphabet_max_test() -> Nil {
+  assert intid.encode_int_base58(57) == "z"
+}
+
+pub fn encode_int_base58_carry_test() -> Nil {
+  assert intid.encode_int_base58(58) == "21"
+}
+
+pub fn encode_int_base58_two_digit_test() -> Nil {
+  assert intid.encode_int_base58(1234) == "NH"
+}
+
+pub fn decode_int_base58_empty_test() -> Nil {
+  assert intid.decode_int_base58("") == Ok(0)
+}
+
+pub fn decode_int_base58_leading_zero_tolerant_test() -> Nil {
+  assert intid.decode_int_base58("11NH") == intid.decode_int_base58("NH")
+}
+
+pub fn decode_int_base58_roundtrip_test() -> Nil {
+  let encoded = intid.encode_int_base58(9_999_999_999)
+  assert intid.decode_int_base58(encoded) == Ok(9_999_999_999)
+}
+
+pub fn decode_int_base58_invalid_char_test() -> Nil {
+  assert intid.decode_int_base58("0") == Error(InvalidCharacter("0", 0))
+}
+
+// === Base58 (Flickr) ===
+
+pub fn encode_int_base58_flickr_zero_test() -> Nil {
+  assert intid.encode_int_base58_flickr(0) == "1"
+}
+
+pub fn encode_int_base58_flickr_small_test() -> Nil {
+  assert intid.encode_int_base58_flickr(42) == "J"
+}
+
+pub fn decode_int_base58_flickr_roundtrip_test() -> Nil {
+  let encoded = intid.encode_int_base58_flickr(1_234_567)
+  assert intid.decode_int_base58_flickr(encoded) == Ok(1_234_567)
+}
+
+pub fn decode_int_base58_flickr_empty_test() -> Nil {
+  assert intid.decode_int_base58_flickr("") == Ok(0)
+}
+
+// === Base62 ===
+
+pub fn encode_int_base62_zero_test() -> Nil {
+  assert intid.encode_int_base62(0) == "0"
+}
+
+pub fn encode_int_base62_alphabet_max_test() -> Nil {
+  assert intid.encode_int_base62(61) == "z"
+}
+
+pub fn encode_int_base62_carry_test() -> Nil {
+  assert intid.encode_int_base62(62) == "10"
+}
+
+pub fn encode_int_base62_large_test() -> Nil {
+  assert intid.encode_int_base62(1_234_567_890) == "1LY7VK"
+}
+
+pub fn decode_int_base62_empty_test() -> Nil {
+  assert intid.decode_int_base62("") == Ok(0)
+}
+
+pub fn decode_int_base62_roundtrip_test() -> Nil {
+  let encoded = intid.encode_int_base62(2_147_483_647)
+  assert intid.decode_int_base62(encoded) == Ok(2_147_483_647)
+}
+
+pub fn decode_int_base62_leading_zero_tolerant_test() -> Nil {
+  assert intid.decode_int_base62("00abc") == intid.decode_int_base62("abc")
+}
+
+// === Cross-cutting: negative inputs are absorbed as |n| ===
+
+pub fn encode_int_base58_negative_normalized_test() -> Nil {
+  assert intid.encode_int_base58(-42) == intid.encode_int_base58(42)
+}
+
+pub fn encode_int_base62_negative_normalized_test() -> Nil {
+  assert intid.encode_int_base62(-1) == intid.encode_int_base62(1)
+}


### PR DESCRIPTION
## Summary

Adds a new `yabase/intid` module with `encode_int_*` / `decode_int_*` helpers covering Base32 (RFC 4648, Crockford), Base36, Base58 (Bitcoin, Flickr), and Base62. The byte-oriented codecs in `yabase/facade` are the right fit when the input is opaque bytes, but the very common short-ID use case (DB autoincrement ids, sequence numbers, hash truncations) wants `Int -> compact string` directly. Without these helpers every project re-implements the same `Int -> big-endian bytes -> trim-leading-zero` shim plus the inverse for decode (~40 lines per caller).

## Changes

- `src/yabase/intid.gleam` (new): 12 public functions (6 `encode_int_*` / 6 `decode_int_*`) that wrap the existing low-level codecs. A small private helper converts `Int` to a minimal big-endian `BitArray`; decode flows the codec's `BitArray` result through `bignum.bytes_to_int`.
- `test/intid_test.gleam` (new): 36 tests covering canonical-form encode, alphabet boundary values (e.g. `encode_int_base58(57) == "z"`, `encode_int_base58(58) == "21"`), round-trip for each codec, leading-zero-tolerant decode, invalid-character decode errors, and the negative-input normalization invariant.
- `README.md`: new `## Integer IDs` section between Quick start and Supported encodings, plus a row in the Modules table.
- `CHANGELOG.md`: `## [Unreleased] / Added` entry describing the helpers and their semantics.

## Design Decisions

- **`encode_int_*` returns `String`, not `Result(String, _)`.** Matches the rest of `yabase/facade` where every `encode_*` is total. Keeping the API total avoids callers having to `result.try` for an operation that has no meaningful failure mode for the target use case.
- **Negative inputs are normalized via `int.absolute_value` before encoding.** Documented behaviour rather than a silent zero or a runtime crash. The Issue's target use case (autoincrement ids, sequence numbers) does not produce negatives, so this is a defensive policy for pathological inputs rather than a load-bearing semantic.
- **`decode_int_*` returns `Result(Int, CodecError)`, not `Result(Int, Nil)`.** The Issue's example sketch used `Nil` but the rest of the library uniformly uses `CodecError`, so this preserves the consistent decode-error story (callers can pattern-match the same way as for `decode_base58` etc.).
- **Canonical form on encode, tolerant decode.** `encode_int_base58(0) == "1"` (the alphabet's zero character, single character). `decode_int_base58("0042")` and `decode_int_base58("42")` both normalize to the same `Int` because the underlying `bignum` codec treats leading zero characters as leading `0x00` bytes which then get absorbed by `bytes_to_int`. Encode side stays canonical (no leading zero characters beyond what the value requires) so a stable string representation per `Int` is guaranteed.
- **Single-file module, not `yabase/intid/{base32, base36, ...}` submodules.** The Issue author's example used `yabase/intid` (single module). Each public function is 1-2 lines (delegating to the underlying low-level codec), so the module stays small and the dispatch table is easier to scan.
- **No change to `bignum`.** The internal helper `int_to_bytes` stays private to `bignum`; `intid` carries its own 5-line equivalent. This keeps `yabase/internal/*` as an implementation detail rather than a published surface.

## Limitations

- `encode_int_base32_rfc4648(0) == "AA======"` (8 characters with padding) — RFC 4648 is bit-level so single-byte inputs always produce a fixed-length padded output. This is technically correct but produces longer IDs than the bignum-based codecs (`encode_int_base32_crockford(0) == "0"`). Callers picking a codec for short URL-safe IDs should prefer Crockford / Base36 / Base58 / Base62 over RFC 4648.

Closes #11
