### PR TITLE
fix(intid): reject empty string in decode_int_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `intid.decode_int_*` now reject the empty string with
+  `Error(InvalidLength(0))` instead of returning `Ok(0)`. Treating an empty
+  input as zero made it impossible for callers to distinguish "no ID was
+  supplied" from "the ID is the integer zero", which matters for URL
+  routing, form parsing, and database lookups. The byte-oriented decoders
+  in `yabase/facade` (e.g. `base62.decode("")`) keep their `Ok(<<>>)`
+  round-trip semantics. **Breaking change** for callers that relied on the
+  previous `Ok(0)` for empty input — guard the empty case before calling
+  `decode_int_*`. (#14)
+
 ## [0.4.0] - 2026-04-26
 
 ### Added

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -17,19 +17,28 @@
 //// return the same `Int`), so input from external sources that
 //// zero-pads is accepted without ceremony.
 ////
+//// `decode_int_*` rejects the empty string with
+//// `Error(InvalidLength(0))` rather than treating it as zero. Callers
+//// can therefore distinguish "no ID was supplied" from "the ID is
+//// zero" — important for URL routing, form parsing, and database
+//// lookups. The byte-oriented decoders in `yabase/facade` retain the
+//// `Ok(<<>>)` round-trip behavior for empty input.
+////
 //// Negative inputs are normalized to `int.absolute_value` before
 //// encoding — the magnitude is what gets stored. The decode side
 //// always returns a non-negative `Int`.
 
+import gleam/bool
 import gleam/int
 import gleam/result
+import gleam/string
 import yabase/base32/crockford as base32_crockford
 import yabase/base32/rfc4648 as base32_rfc4648
 import yabase/base36
 import yabase/base58/bitcoin as base58_bitcoin
 import yabase/base58/flickr as base58_flickr
 import yabase/base62
-import yabase/core/encoding.{type CodecError}
+import yabase/core/encoding.{type CodecError, InvalidLength}
 import yabase/internal/bignum
 
 /// Encode a non-negative `Int` as a Base32 (RFC 4648) string.
@@ -39,6 +48,7 @@ pub fn encode_int_base32_rfc4648(value: Int) -> String {
 
 /// Decode a Base32 (RFC 4648) string back to an `Int`.
 pub fn decode_int_base32_rfc4648(input: String) -> Result(Int, CodecError) {
+  use input <- result.try(reject_empty(input))
   base32_rfc4648.decode(input)
   |> result.map(bytes_to_int)
 }
@@ -50,6 +60,7 @@ pub fn encode_int_base32_crockford(value: Int) -> String {
 
 /// Decode a Crockford Base32 string back to an `Int`.
 pub fn decode_int_base32_crockford(input: String) -> Result(Int, CodecError) {
+  use input <- result.try(reject_empty(input))
   base32_crockford.decode(input)
   |> result.map(bytes_to_int)
 }
@@ -61,6 +72,7 @@ pub fn encode_int_base36(value: Int) -> String {
 
 /// Decode a Base36 string back to an `Int`.
 pub fn decode_int_base36(input: String) -> Result(Int, CodecError) {
+  use input <- result.try(reject_empty(input))
   base36.decode(input)
   |> result.map(bytes_to_int)
 }
@@ -72,6 +84,7 @@ pub fn encode_int_base58(value: Int) -> String {
 
 /// Decode a Base58 (Bitcoin alphabet) string back to an `Int`.
 pub fn decode_int_base58(input: String) -> Result(Int, CodecError) {
+  use input <- result.try(reject_empty(input))
   base58_bitcoin.decode(input)
   |> result.map(bytes_to_int)
 }
@@ -83,6 +96,7 @@ pub fn encode_int_base58_flickr(value: Int) -> String {
 
 /// Decode a Base58 (Flickr alphabet) string back to an `Int`.
 pub fn decode_int_base58_flickr(input: String) -> Result(Int, CodecError) {
+  use input <- result.try(reject_empty(input))
   base58_flickr.decode(input)
   |> result.map(bytes_to_int)
 }
@@ -94,8 +108,20 @@ pub fn encode_int_base62(value: Int) -> String {
 
 /// Decode a Base62 string back to an `Int`.
 pub fn decode_int_base62(input: String) -> Result(Int, CodecError) {
+  use input <- result.try(reject_empty(input))
   base62.decode(input)
   |> result.map(bytes_to_int)
+}
+
+// `decode_int_*` rejects the empty string so callers can distinguish
+// "no input" from a zero-valued ID. The byte-oriented decoders keep
+// their `Ok(<<>>)` semantics for round-tripping empty inputs.
+fn reject_empty(input: String) -> Result(String, CodecError) {
+  use <- bool.guard(
+    when: string.is_empty(input),
+    return: Error(InvalidLength(0)),
+  )
+  Ok(input)
 }
 
 fn int_to_bytes_be(value: Int) -> BitArray {

--- a/test/intid_test.gleam
+++ b/test/intid_test.gleam
@@ -1,4 +1,4 @@
-import yabase/core/encoding.{InvalidCharacter}
+import yabase/core/encoding.{InvalidCharacter, InvalidLength}
 import yabase/intid
 
 // === Base32 (RFC 4648) ===
@@ -16,7 +16,7 @@ pub fn encode_int_base32_rfc4648_max_byte_test() -> Nil {
 }
 
 pub fn decode_int_base32_rfc4648_empty_test() -> Nil {
-  assert intid.decode_int_base32_rfc4648("") == Ok(0)
+  assert intid.decode_int_base32_rfc4648("") == Error(InvalidLength(0))
 }
 
 pub fn decode_int_base32_rfc4648_roundtrip_test() -> Nil {
@@ -48,7 +48,7 @@ pub fn encode_int_base32_crockford_two_digit_max_test() -> Nil {
 }
 
 pub fn decode_int_base32_crockford_empty_test() -> Nil {
-  assert intid.decode_int_base32_crockford("") == Ok(0)
+  assert intid.decode_int_base32_crockford("") == Error(InvalidLength(0))
 }
 
 pub fn decode_int_base32_crockford_leading_zero_tolerant_test() -> Nil {
@@ -80,7 +80,7 @@ pub fn encode_int_base36_two_digit_max_test() -> Nil {
 }
 
 pub fn decode_int_base36_empty_test() -> Nil {
-  assert intid.decode_int_base36("") == Ok(0)
+  assert intid.decode_int_base36("") == Error(InvalidLength(0))
 }
 
 pub fn decode_int_base36_leading_zero_tolerant_test() -> Nil {
@@ -119,7 +119,7 @@ pub fn encode_int_base58_two_digit_test() -> Nil {
 }
 
 pub fn decode_int_base58_empty_test() -> Nil {
-  assert intid.decode_int_base58("") == Ok(0)
+  assert intid.decode_int_base58("") == Error(InvalidLength(0))
 }
 
 pub fn decode_int_base58_leading_zero_tolerant_test() -> Nil {
@@ -151,7 +151,7 @@ pub fn decode_int_base58_flickr_roundtrip_test() -> Nil {
 }
 
 pub fn decode_int_base58_flickr_empty_test() -> Nil {
-  assert intid.decode_int_base58_flickr("") == Ok(0)
+  assert intid.decode_int_base58_flickr("") == Error(InvalidLength(0))
 }
 
 // === Base62 ===
@@ -173,7 +173,7 @@ pub fn encode_int_base62_large_test() -> Nil {
 }
 
 pub fn decode_int_base62_empty_test() -> Nil {
-  assert intid.decode_int_base62("") == Ok(0)
+  assert intid.decode_int_base62("") == Error(InvalidLength(0))
 }
 
 pub fn decode_int_base62_roundtrip_test() -> Nil {


### PR DESCRIPTION
## Summary

`intid.decode_int_*` previously returned `Ok(0)` when given the empty
string, making it indistinguishable from `Ok(0)` for an actual zero-valued
input (`decode_int_base62("")` and `decode_int_base62("0")` both returned
`Ok(0)`). This made it impossible for callers to tell "no ID was supplied"
from "the ID is the integer zero" — important for URL routing, form
parsing, and database lookups. Reject the empty string at the int wrapper
layer with `Error(InvalidLength(0))`.

**Breaking change** for callers that relied on `Ok(0)` for empty input.
Guard the empty case before calling `decode_int_*`.

## Changes

- `src/yabase/intid.gleam`: add a private `reject_empty/1` helper that
  returns `Error(InvalidLength(0))` for an empty input via `bool.guard`,
  and gate every `decode_int_*` (`base32_rfc4648`, `base32_crockford`,
  `base36`, `base58`, `base58_flickr`, `base62`) on it before delegating
  to the byte decoder. Update the module-level docs to describe the new
  empty-input contract and contrast it with the byte-oriented decoders.
- `test/intid_test.gleam`: import `InvalidLength` and update the six
  `decode_int_*_empty_test` assertions from `Ok(0)` to
  `Error(InvalidLength(0))`.
- `CHANGELOG.md`: add a `### Fixed` entry under `## [Unreleased]` calling
  out the breaking-change note explicitly.

## Design Decisions

- **Wrap at the int layer, not at `bignum.decode`.** Several non-bignum
  byte decoders (`ascii85`, `zbase32`, `base45`, `base16`, `base64.*`,
  `base32.rfc4648`, `base91`, `z85`, `base2`, `rfc1924_base85`) and the
  bignum-backed byte decoders all currently treat `decode("")` as
  `Ok(<<>>)` so that `decode(encode(<<>>)) == Ok(<<>>)` round-trips. That
  contract is well-defined for byte payloads and is exercised by tests
  across the suite. The empty-input bug is specific to the integer use
  case, where "no input" and "the integer 0" are semantically distinct,
  so the guard is placed in the `intid` wrappers instead of pushing a
  cross-cutting break through the lower decoders.
- **Reuse the existing `InvalidLength` variant.** `CodecError` already
  models length issues with `InvalidLength(length: Int)`. Using
  `InvalidLength(0)` avoids growing the error surface and matches how
  callers already pattern-match on length errors elsewhere.
- **`bool.guard` over `case`.** The repo's `glinter` rule
  `prefer_guard_clause` flags the `case True/False` form and the
  surrounding code uses `bool.guard` for the same shape, so the helper
  follows that idiom for consistency.

## Limitations

- The byte-oriented decoders (`base62.decode`, `base58.decode`, etc.)
  still accept the empty string and return `Ok(<<>>)`. That is intentional
  here — flipping their contract would break the round-trip property
  with `encode(<<>>) == ""` — but is a separate decision worth a follow-up
  if the project ever wants a uniform "empty input is invalid" rule.

Closes #14
