### PR TITLE
fix(bech32): reject uppercase HRP in encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `bech32.encode` now rejects uppercase or mixed-case HRPs with
+  `Error(InvalidHrp("HRP must be lowercase"))` instead of silently
+  lowercasing the input. BIP 173 mandates a lowercase HRP, and the
+  previous silent normalization could mask bugs where the HRP was used
+  as a key or identifier elsewhere (the caller passed `"BC"` but the
+  emitted address — and the round-tripped HRP after decode — was
+  `"bc"`). **Breaking change** for callers that passed uppercase or
+  mixed-case input; lowercase the HRP at the call site if you start from
+  a mixed-case identifier. The decoder still accepts an all-uppercase
+  Bech32 string as before. (#15)
+
 ### Fixed
 
 - `intid.decode_int_*` now reject the empty string with

--- a/src/yabase/bech32.gleam
+++ b/src/yabase/bech32.gleam
@@ -34,7 +34,11 @@ const bech32m_const = 0x2bc830a3
 
 /// Encode byte data with Bech32 or Bech32m.
 /// variant: Bech32 (BIP 173) or Bech32m (BIP 350).
-/// hrp: human-readable part (e.g. "bc" for Bitcoin mainnet).
+/// hrp: human-readable part (e.g. `"bc"` for Bitcoin mainnet). Must be
+///   all lowercase per BIP 173 — uppercase characters are rejected with
+///   `Error(InvalidHrp("HRP must be lowercase"))` rather than silently
+///   normalized, so the input is never quietly mutated. Lowercase the
+///   value at the call site if you started from a mixed-case identifier.
 /// data: raw bytes (8-to-5 bit conversion is done internally).
 pub fn encode(
   variant: Bech32Variant,
@@ -87,15 +91,22 @@ fn encode_variant(
   hrp: String,
   data: BitArray,
 ) -> Result(String, CodecError) {
-  let lower_hrp = string.lowercase(hrp)
-  let hrp_len = string.length(lower_hrp)
+  // BIP 173: encoders MUST emit a lowercase HRP. Reject uppercase input
+  // explicitly instead of silently lowercasing it, so the caller never
+  // sees their HRP quietly mutated (which previously masked bugs where
+  // the HRP was used as a key/identifier elsewhere in the application).
+  use <- bool.guard(
+    when: hrp != string.lowercase(hrp),
+    return: Error(InvalidHrp("HRP must be lowercase")),
+  )
+  let hrp_len = string.length(hrp)
   case hrp_len < 1 {
     True -> Error(InvalidHrp("empty HRP"))
     False ->
       case hrp_len > 83 {
         True -> Error(InvalidHrp("HRP too long"))
         False ->
-          case validate_hrp(lower_hrp, 0) {
+          case validate_hrp(hrp, 0) {
             Error(e) -> Error(e)
             Ok(Nil) -> {
               let data_values = bytes_to_5bit_groups(data)
@@ -103,14 +114,13 @@ fn encode_variant(
                 Bech32V -> bech32_const
                 Bech32mV -> bech32m_const
               }
-              let checksum =
-                create_checksum(lower_hrp, data_values, checksum_const)
+              let checksum = create_checksum(hrp, data_values, checksum_const)
               let all_values = list_append(data_values, checksum)
               let encoded_data =
                 values_to_chars(all_values, [])
                 |> list.reverse
                 |> string.join("")
-              let result = lower_hrp <> "1" <> encoded_data
+              let result = hrp <> "1" <> encoded_data
               // BIP 173: total length must not exceed 90
               case string.length(result) > 90 {
                 True -> Error(InvalidLength(string.length(result)))

--- a/test/bech32_test.gleam
+++ b/test/bech32_test.gleam
@@ -114,6 +114,33 @@ pub fn encode_empty_hrp_test() -> Nil {
   }
 }
 
+pub fn encode_uppercase_hrp_rejected_test() -> Nil {
+  // BIP 173 mandates a lowercase HRP. Issue #15 — `encode` previously
+  // silently lowercased uppercase input, which mutated the caller's HRP
+  // identifier without any signal. The expected behavior is to reject.
+  assert case bech32.encode(Bech32V, "BC", <<1, 2, 3>>) {
+    Error(InvalidHrp("HRP must be lowercase")) -> True
+    _ -> False
+  }
+}
+
+pub fn encode_mixed_case_hrp_rejected_test() -> Nil {
+  // Mixed case is also rejected — any deviation from all-lowercase falls
+  // under the same BIP 173 rule.
+  assert case bech32.encode(Bech32V, "Bc", <<1, 2, 3>>) {
+    Error(InvalidHrp("HRP must be lowercase")) -> True
+    _ -> False
+  }
+}
+
+pub fn encode_uppercase_hrp_rejected_for_bech32m_test() -> Nil {
+  // Same rule applies to the Bech32m variant.
+  assert case bech32.encode(Bech32mV, "BC", <<1, 2, 3>>) {
+    Error(InvalidHrp("HRP must be lowercase")) -> True
+    _ -> False
+  }
+}
+
 pub fn encode_result_overlength_test() -> Nil {
   let big_data = <<
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,


### PR DESCRIPTION
## Summary

`bech32.encode` previously accepted any-case HRP and silently lowercased it
internally. Per BIP 173 the HRP must be lowercase, and the silent
normalization caused the caller's input string to disappear into the
output without any signal — `encode(Bech32, "BC", data)` returned an
address starting with `"bc1..."` even though the caller never asked for
that change. Reject uppercase or mixed-case HRPs explicitly so the input
is never quietly mutated.

**Breaking change** for callers that passed uppercase or mixed-case HRPs.
Lowercase the HRP at the call site (`string.lowercase`) if you start from
a mixed-case identifier.

## Changes

- `src/yabase/bech32.gleam`: replace the unconditional
  `let lower_hrp = string.lowercase(hrp)` in `encode_variant/3` with a
  `bool.guard` that returns `Error(InvalidHrp("HRP must be lowercase"))`
  when the input differs from its lowercased form. Use the original
  `hrp` directly through the rest of the function. Update the public
  `encode/3` doc comment to document the new contract.
- `test/bech32_test.gleam`: add three tests pinning the new behavior —
  `encode_uppercase_hrp_rejected_test` (`"BC"` with `Bech32V`),
  `encode_mixed_case_hrp_rejected_test` (`"Bc"` with `Bech32V`), and
  `encode_uppercase_hrp_rejected_for_bech32m_test` (`"BC"` with
  `Bech32mV`). Existing tests already use lowercase HRPs and continue to
  pass without modification.
- `CHANGELOG.md`: add a `### Changed` entry under `## [Unreleased]`
  spelling out the breaking-change note.

## Design Decisions

- **Reject rather than document the silent lowercasing.** The issue
  offered both options; rejection matches BIP 173's strict reading
  ("the HRP MUST be lowercase") and prevents a class of bugs where the
  HRP doubles as a key/identifier elsewhere in the caller's code. Users
  who want the old behavior can call `string.lowercase` themselves; users
  who relied on the old behavior to mask a typo were silently shipping
  the wrong HRP.
- **Reuse `InvalidHrp` rather than introduce a new variant.** The
  `CodecError` type already models HRP problems with `InvalidHrp(reason:
  String)` and the rest of the module returns string-keyed reasons
  (`"empty HRP"`, `"HRP too long"`). Adding a new variant would have
  forced every caller's pattern match to grow without paying for itself.
- **Do not change `decode/1`.** The decoder still accepts an
  all-uppercase Bech32 string (it lowercases for canonicalization while
  still rejecting mixed case), which is a separate, well-defined
  contract from the encoder's input validation. Tightening the decoder
  is out of scope.

Closes #15
