### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-27
+
 ### Changed
 
 - `bech32.encode` now rejects uppercase or mixed-case HRPs with

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.4.0"
+version = "0.5.0"
 target = "erlang"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]


### PR DESCRIPTION
### Changed

- `bech32.encode` now rejects uppercase or mixed-case HRPs with
  `Error(InvalidHrp("HRP must be lowercase"))` instead of silently
  lowercasing the input. BIP 173 mandates a lowercase HRP, and the
  previous silent normalization could mask bugs where the HRP was used
  as a key or identifier elsewhere (the caller passed `"BC"` but the
  emitted address — and the round-tripped HRP after decode — was
  `"bc"`). **Breaking change** for callers that passed uppercase or
  mixed-case input; lowercase the HRP at the call site if you start from
  a mixed-case identifier. The decoder still accepts an all-uppercase
  Bech32 string as before. (#15)

### Fixed

- `intid.decode_int_*` now reject the empty string with
  `Error(InvalidLength(0))` instead of returning `Ok(0)`. Treating an empty
  input as zero made it impossible for callers to distinguish "no ID was
  supplied" from "the ID is the integer zero", which matters for URL
  routing, form parsing, and database lookups. The byte-oriented decoders
  in `yabase/facade` (e.g. `base62.decode("")`) keep their `Ok(<<>>)`
  round-trip semantics. **Breaking change** for callers that relied on the
  previous `Ok(0)` for empty input — guard the empty case before calling
  `decode_int_*`. (#14)
