### PR TITLE
feat(bech32): add encode_default helper that picks Bech32m (BIP 350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `bech32.encode_default(hrp, data)` is a convenience wrapper around
+  `bech32.encode(Bech32m, hrp, data)` for application authors who want
+  a short, copy-pasteable, error-resistant ID with a custom HRP and
+  don't need to choose between BIP 173 and BIP 350. The default is
+  `Bech32m` (BIP 350) — the strict-checksum variant that every
+  non-SegWit-v0 use case should prefer. The variant-explicit
+  `encode/3` remains the only correct entry point for SegWit
+  witness-program addresses where the caller must distinguish the
+  two BIPs. (#21)
+
 ## [0.5.0] - 2026-04-27
 
 ### Changed

--- a/src/yabase/bech32.gleam
+++ b/src/yabase/bech32.gleam
@@ -48,6 +48,27 @@ pub fn encode(
   encode_variant(variant, hrp, data)
 }
 
+/// Encode byte data with the recommended default variant (Bech32m,
+/// BIP 350) for callers that don't need to distinguish BIP 173 from
+/// BIP 350.
+///
+/// Issue #21: Bitcoin / SegWit tooling has a load-bearing reason to
+/// pick `Bech32` (BIP 173) over `Bech32m` (BIP 350) — witness version
+/// 0 must use BIP 173, witness version 1+ must use BIP 350. Outside
+/// that one use case, every other `bech32`-shaped use (short
+/// human-readable IDs with a custom HRP, copy-pasteable application
+/// tokens, etc.) is better served by the strict-checksum BIP 350
+/// variant. This helper picks `Bech32m` so application authors who
+/// just want "give me a short, error-resistant ID with my HRP"
+/// don't have to decide which BIP they're targeting.
+///
+/// Use the variant-explicit `encode/3` if you actually need
+/// `Bech32` (BIP 173) — for example when implementing SegWit v0
+/// witness-program addresses.
+pub fn encode_default(hrp: String, data: BitArray) -> Result(String, CodecError) {
+  encode_variant(Bech32mV, hrp, data)
+}
+
 /// Decode a Bech32 or Bech32m string, auto-detecting the variant.
 /// Per BIP 173: total length <= 90, HRP length 1..83.
 pub fn decode(input: String) -> Result(Bech32Decoded, CodecError) {

--- a/test/bech32_test.gleam
+++ b/test/bech32_test.gleam
@@ -42,6 +42,40 @@ pub fn bech32m_empty_data_test() -> Nil {
   assert decoded.variant == Bech32mV
 }
 
+// ===== Default-variant convenience (issue #21) =====
+
+/// `encode_default` lets app authors emit a Bech32-shaped ID with
+/// just an HRP and a payload — no variant choice. The default is
+/// `Bech32m` (BIP 350), the strict-checksum variant recommended for
+/// every non-SegWit-v0 use.
+pub fn encode_default_picks_bech32m_test() -> Nil {
+  let data = <<10, 20, 30, 40>>
+  let assert Ok(encoded) = bech32.encode_default("post", data)
+  let assert Ok(decoded) = bech32.decode(encoded)
+  assert decoded.hrp == "post"
+  assert decoded.variant == Bech32mV
+  assert decoded.data == data
+}
+
+/// `encode_default` matches `encode(Bech32mV, ..)` byte-for-byte —
+/// it's a thin alias, not a different algorithm.
+pub fn encode_default_matches_explicit_bech32m_test() -> Nil {
+  let data = <<1, 2, 3, 4, 5>>
+  let assert Ok(via_default) = bech32.encode_default("test", data)
+  let assert Ok(via_explicit) = bech32.encode(Bech32mV, "test", data)
+  assert via_default == via_explicit
+}
+
+/// `encode_default` still applies HRP validation — uppercase HRPs
+/// are rejected exactly like `encode(...)` would, so the convenience
+/// helper doesn't bypass any safety check.
+pub fn encode_default_rejects_uppercase_hrp_test() -> Nil {
+  assert case bech32.encode_default("BC", <<0>>) {
+    Error(InvalidHrp(_)) -> True
+    _ -> False
+  }
+}
+
 // ===== Variant auto-detection =====
 
 pub fn auto_detect_bech32_test() -> Nil {


### PR DESCRIPTION
## Summary

Fixes Issue #21. `bech32.encode` requires the caller to pick
between `Bech32` (BIP 173) and `Bech32m` (BIP 350) on every call.
For Bitcoin / SegWit tooling the choice is load-bearing — witness
version 0 must use BIP 173, witness version 1+ must use BIP 350 —
but for the much more common Gleam use case (short
copy-pasteable IDs with a custom HRP, application tokens, etc.)
the variant is friction the caller doesn't have context for.

`bech32.encode_default(hrp, data)` is a thin wrapper that picks
`Bech32m`, so non-SegWit callers can stop making a decision they
don't need to make:

```gleam
fn fresh_post_id() -> String {
  let random = crypto.strong_random_bytes(16)
  case bech32.encode_default("post", random) {
    Ok(s) -> s
    Error(_) -> panic
  }
}
```

The variant-explicit `encode/3` remains the only correct entry
point for SegWit witness-program addresses.

## Why Bech32m as the default

The BIP 350 spec says: *"The default for new bech32 deployments
is the use of Bech32m as it has stronger error-detection
guarantees."* For a generic ID-encoding helper that's the right
choice — `Bech32` only outperforms `Bech32m` for the specific
SegWit-v0 backwards-compat case, and that case has its own
explicit `encode(Bech32V, ..)` call.

## Changes

- `src/yabase/bech32.gleam`: new `encode_default/2` function that
  delegates to the existing `encode_variant` with `Bech32mV`. Doc
  comment explains when to fall back to `encode/3`.
- `test/bech32_test.gleam`: three new regression tests:
  - `encode_default_picks_bech32m_test` — round-trip via
    `encode_default` followed by `decode` reports
    `variant == Bech32mV`.
  - `encode_default_matches_explicit_bech32m_test` — output is
    byte-identical to `encode(Bech32mV, ..)`, confirming this is a
    thin alias.
  - `encode_default_rejects_uppercase_hrp_test` — HRP validation
    still applies; the convenience helper doesn't bypass any safety
    check.
- `CHANGELOG.md`: documents under `### Added` in Unreleased.

## Design Decisions

- **Convenience helper, not a config flag.** A "set the default
  variant globally" knob would surprise readers — bech32 is
  algorithm-explicit by design, and the spec recommends BIP 350 as
  the default for new deployments. A new function whose name
  signals the choice (`encode_default`) is clearer than
  configuration.
- **Don't touch `decode`.** The existing decoder already
  auto-detects the variant from the checksum, so the
  variant-friction problem is one-sided (encode-only). No decoder
  change is needed.

## Test Plan

- [x] `gleam format .` — clean.
- [x] `gleam test` — 619 passes (3 new regression tests for #21).
- [x] Verified `encode_default(hrp, data)` and `encode(Bech32mV,
  hrp, data)` produce byte-identical output via the equality test.

Closes #21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new convenience function for Bech32 encoding that automatically applies the Bech32m checksum variant, streamlining encoding for standard use cases while maintaining explicit variant selection for advanced scenarios.

* **Documentation**
  * Updated changelog documenting the new encoding convenience function and guidance on variant selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->