### PR TITLE
docs(base32/crockford): make bignum-shape semantics loud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- `yabase/base32/crockford` makes the bignum-shape semantics loud at
+  the module level and on `encode/1`. The encoder treats input as a
+  big-endian unsigned integer and emits the base-32 representation
+  with leading zeros stripped, so output length varies with the
+  numeric magnitude of the input rather than its byte length — 5
+  random bytes whose top byte is `0x00` round-trip to a 7-character
+  string, not 8. Callers who want fixed-length, byte-aligned Base32
+  framing (ULID / NanoID / Stripe-style IDs) should use
+  `yabase/base32/rfc4648` instead. The pointer is now in both
+  docstrings so a reader scanning either surface sees the choice
+  immediately. (#22)
+
 ### Added
 
 - `bech32.encode_default(hrp, data)` is a convenience wrapper around

--- a/src/yabase/base32/crockford.gleam
+++ b/src/yabase/base32/crockford.gleam
@@ -1,17 +1,51 @@
 /// Crockford's Base32 encoding.
-/// Encodes data as a number in base 32 per https://www.crockford.com/base32.html
-/// Alphabet: 0123456789ABCDEFGHJKMNPQRSTVWXYZ
-/// Case-insensitive decoding. O->0, I/L->1 on decode. Hyphens ignored.
-/// No padding.
+///
+/// Encodes data as a number in base 32 per
+/// <https://www.crockford.com/base32.html>.
+///
+/// Alphabet: `0123456789ABCDEFGHJKMNPQRSTVWXYZ`.
+/// Case-insensitive decoding. `O`→`0`, `I`/`L`→`1` on decode.
+/// Hyphens ignored. No padding.
+///
+/// **Big-integer shape, NOT byte-aligned (issue #22).** This module
+/// treats the input `BitArray` as a big-endian unsigned integer and
+/// emits the base-32 representation of that integer with leading
+/// zeros stripped. The output length therefore depends on the
+/// numeric magnitude of the input, not on the input's byte length:
+/// 5 random bytes whose top byte is `0x00` round-trip to a
+/// 7-character string, while 5 random bytes whose top byte is
+/// `0xFF` round-trip to an 8-character string.
+///
+/// If you want **fixed-length, byte-aligned** Base32 output (the
+/// shape callers usually expect from "Base32" — same as ULID /
+/// NanoID / Stripe-style IDs), use [`yabase/base32/rfc4648`](./rfc4648.html)
+/// instead. RFC 4648 emits exactly `ceil(byte_count * 8 / 5)`
+/// characters of output for any input, and pads to a multiple of 8
+/// when needed.
+///
+/// This module is the right pick when you want Crockford's
+/// human-typeable alphabet *and* the bignum semantics — for example
+/// when encoding a numeric ID that already fits the base-32
+/// integer model.
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidChecksum, InvalidLength}
 import yabase/internal/bignum
 
 const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
-/// Encode a BitArray to Crockford Base32 string.
+/// Encode a BitArray to a Crockford Base32 string (bignum shape).
+///
 /// The input is treated as a big-endian unsigned integer and
-/// converted to base 32 using Crockford's alphabet.
+/// converted to base 32 using Crockford's alphabet, with leading
+/// zero digits stripped. As a result the output length **varies
+/// with the numeric magnitude** of the input, not with its byte
+/// length — see the module-level docstring for the implications
+/// (issue #22).
+///
+/// If you want fixed-length 8-character output for every 5-byte
+/// input (the byte-aligned framing ULID / NanoID expect), use
+/// [`yabase/base32/rfc4648.encode`](../rfc4648.html#encode)
+/// instead.
 pub fn encode(data: BitArray) -> String {
   bignum.encode(data, 32, alphabet)
 }


### PR DESCRIPTION
## Summary

Fixes Issue #22. `yabase/base32/crockford.encode` treats its input
as a big-endian unsigned integer and emits the base-32 representation
with leading zeros stripped. Output length therefore varies with the
numeric magnitude of the input, not its byte length:

```gleam
crockford.encode(<<0x00, 0x12, 0x34, 0x56, 0x78>>)  -- "8AHKCY"  (6 chars)
crockford.encode(<<0xFF, 0x12, 0x34, 0x56, 0x78>>)  -- "ZW48HK74" (8 chars)
```

Most callers reaching for "Crockford Base32" come from ULID /
NanoID / Stripe-style ID design contexts, where the expectation is
**byte-aligned** output (5 bits per char, fixed-length for
fixed-length input). The mismatch silently breaks fixed-width
parsers downstream — and the bignum shape is only visible deep in
the existing `encode/1` docstring (`bignum.encode(data, 32, alphabet)`).

This PR makes the shape loud at the module level and on
`encode/1`, and points readers at `yabase/base32/rfc4648` for
fixed-length byte-aligned output.

## Changes

- `src/yabase/base32/crockford.gleam`:
  - Module-level docstring rewritten with a "**Big-integer shape,
    NOT byte-aligned (issue #22)**" paragraph that calls out the
    leading-zero-stripping behaviour, gives a concrete length
    example, and points to `yabase/base32/rfc4648` for the
    byte-aligned alternative. Closes with the use case where
    crockford is the right pick: encoding a numeric ID that
    already fits the base-32 integer model.
  - `encode/1` docstring expands the original two-line summary to
    name "bignum shape", flag the variable output length, and
    repeat the rfc4648 pointer for readers who land on the function
    directly.
- `CHANGELOG.md`: documents under `### Documentation` in
  Unreleased.

## Design Decisions

- **Docs note only, not a new function.** The issue floated three
  options: (1) docstring note, (2) `encode_padded(data, width)`,
  (3) a separate `crockford_aligned` companion module. (1) is the
  user's recommended starting point; (2) and (3) are larger
  surface changes that don't unbreak the core misunderstanding —
  callers who reach for "Crockford" because of the alphabet are
  already at the wrong module if they want byte-aligned output.
  Pointing them at `rfc4648` resolves the issue at the navigation
  layer rather than the API layer.
- **No code change.** Existing behaviour is preserved exactly;
  this is a pure documentation PR.

## Test Plan

- [x] `gleam format .` — clean.
- [x] `gleam test` — 619 passes (no behaviour change).
- [x] Re-read both updated docstrings against the issue's
  reproduction to confirm the bignum semantics and the
  `rfc4648` pointer surface immediately.

Closes #22
