### PR TITLE
fix(base16)!: default to uppercase per RFC 4648 §8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **base16 (BREAKING)**: `base16.encode` and `facade.encode_base16`
+  now emit canonical uppercase hex (`0-9 A-F`) per RFC 4648 §8.
+  The previous lowercase output (`"deadbeef"` for `<<0xde, 0xad,
+  0xbe, 0xef>>`) departed from the spec's canonical form and broke
+  string-equality comparisons against systems that follow it (HTTP
+  Signature, Erlang `crypto:hash`'s default uppercase output, IPFS
+  multibase prefix `F`, etc.). Callers who specifically need the
+  lowercase variant — `sha256sum` shell output, IPFS multibase
+  prefix `f`, JWT implementations that emit lowercase digests —
+  should switch to `base16.encode_lowercase` /
+  `facade.encode_base16_lowercase`. The decoder remains
+  case-insensitive, so round-trips work in both directions. The
+  multibase encoder still emits the registry-canonical lowercase
+  form under prefix `f` (and would emit uppercase under prefix
+  `F`, currently unused on the encode side); only the
+  unprefixed `base16.encode` path is affected. (#19)
+
 ### Documentation
 
 - `yabase/base32/crockford` makes the bignum-shape semantics loud at

--- a/src/yabase/base16.gleam
+++ b/src/yabase/base16.gleam
@@ -1,23 +1,48 @@
 /// Base16 (hexadecimal) encoding and decoding.
+///
+/// Issue #19: `encode/1` now emits the canonical uppercase form
+/// (`0-9 A-F`) per RFC 4648 §8. Use `encode_lowercase/1` for the
+/// opt-in lowercase variant. The decoder remains case-insensitive,
+/// so round-trips with both encoders work.
 import gleam/bit_array
 import gleam/int
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter, InvalidLength}
 
-/// Encode a BitArray to a lowercase hexadecimal string.
+/// Encode a BitArray to an uppercase hexadecimal string per
+/// RFC 4648 §8 (the canonical Base 16 encoding).
+///
+/// Use `encode_lowercase/1` when interoperating with tools that
+/// emit lowercase hex (e.g. `sha256sum`, IPFS multibase prefix `f`,
+/// many JSON Web Token implementations); the decoder accepts either
+/// case, so round-trips work in both directions.
 pub fn encode(data: BitArray) -> String {
-  encode_bytes(data, [])
+  encode_bytes(data, [], string.uppercase)
   |> list.reverse
   |> string.join("")
 }
 
-fn encode_bytes(data: BitArray, acc: List(String)) -> List(String) {
+/// Encode a BitArray to a lowercase hexadecimal string. Use this
+/// when interoperating with tools that expect the lowercase variant
+/// (`sha256sum` shell output, IPFS multibase prefix `f`, etc.). The
+/// canonical RFC 4648 §8 form is uppercase — see `encode/1`.
+pub fn encode_lowercase(data: BitArray) -> String {
+  encode_bytes(data, [], string.lowercase)
+  |> list.reverse
+  |> string.join("")
+}
+
+fn encode_bytes(
+  data: BitArray,
+  acc: List(String),
+  case_fn: fn(String) -> String,
+) -> List(String) {
   case data {
     <<byte:int, rest:bits>> -> {
       let high = int.to_base16(byte / 16)
       let low = int.to_base16(byte % 16)
-      encode_bytes(rest, [string.lowercase(high <> low), ..acc])
+      encode_bytes(rest, [case_fn(high <> low), ..acc], case_fn)
     }
     _ -> acc
   }

--- a/src/yabase/core/multibase.gleam
+++ b/src/yabase/core/multibase.gleam
@@ -31,7 +31,20 @@ pub fn encode_with_prefix(
     Error(Nil) -> Error(UnsupportedMultibaseEncoding(encoding_name(enc)))
     Ok(prefix) ->
       dispatcher.encode(enc, data)
-      |> result.map(fn(encoded) { prefix <> encoded })
+      |> result.map(fn(encoded) { prefix <> normalise_for_prefix(enc, encoded) })
+  }
+}
+
+/// Issue #19: `base16.encode` now emits the canonical RFC 4648 §8
+/// uppercase form, but the multibase registry pins prefix `f` to
+/// lowercase Base16 (uppercase Base16 carries the distinct prefix
+/// `F`, currently unused in this module's encode-side mapping).
+/// Lowercase the dispatcher's Base16 output so multibase strings
+/// stay registry-conformant; other encodings round-trip unchanged.
+fn normalise_for_prefix(enc: Encoding, encoded: String) -> String {
+  case enc {
+    Base16Encoding -> string.lowercase(encoded)
+    _ -> encoded
   }
 }
 

--- a/src/yabase/facade.gleam
+++ b/src/yabase/facade.gleam
@@ -68,9 +68,20 @@ pub fn decode_base10(input: String) -> Result(BitArray, CodecError) {
 
 // --- Base16 ---
 
-/// Encode a BitArray to a lowercase hexadecimal string.
+/// Encode a BitArray to an uppercase hexadecimal string per RFC 4648
+/// §8 (canonical Base 16). Use `encode_base16_lowercase` for the
+/// non-canonical lowercase variant. The decoder remains
+/// case-insensitive — see `decode_base16`. (Issue #19)
 pub fn encode_base16(data: BitArray) -> String {
   base16.encode(data)
+}
+
+/// Encode a BitArray to a lowercase hexadecimal string. Use when
+/// interoperating with `sha256sum`-style tools or the IPFS multibase
+/// prefix `f`; the canonical RFC 4648 §8 form is uppercase, served
+/// by `encode_base16`.
+pub fn encode_base16_lowercase(data: BitArray) -> String {
+  base16.encode_lowercase(data)
 }
 
 /// Decode a hexadecimal string to a BitArray. Case-insensitive.

--- a/test/base16_test.gleam
+++ b/test/base16_test.gleam
@@ -7,12 +7,16 @@ pub fn encode_empty_test() -> Nil {
   assert base16.encode(<<>>) == ""
 }
 
+// Issue #19: encode/1 emits canonical RFC 4648 §8 uppercase. Use
+// encode_lowercase/1 (covered separately below) for the opt-in
+// non-canonical form.
+
 pub fn encode_hello_test() -> Nil {
-  assert base16.encode(<<"Hello":utf8>>) == "48656c6c6f"
+  assert base16.encode(<<"Hello":utf8>>) == "48656C6C6F"
 }
 
 pub fn encode_single_byte_test() -> Nil {
-  assert base16.encode(<<255>>) == "ff"
+  assert base16.encode(<<255>>) == "FF"
 }
 
 pub fn encode_zero_byte_test() -> Nil {
@@ -20,7 +24,7 @@ pub fn encode_zero_byte_test() -> Nil {
 }
 
 pub fn encode_binary_test() -> Nil {
-  assert base16.encode(<<0xde, 0xad, 0xbe, 0xef>>) == "deadbeef"
+  assert base16.encode(<<0xde, 0xad, 0xbe, 0xef>>) == "DEADBEEF"
 }
 
 pub fn encode_leading_zeros_test() -> Nil {
@@ -32,7 +36,29 @@ pub fn encode_all_zeros_test() -> Nil {
 }
 
 pub fn encode_high_bit_bytes_test() -> Nil {
-  assert base16.encode(<<0xff, 0x80, 0x7f>>) == "ff807f"
+  assert base16.encode(<<0xff, 0x80, 0x7f>>) == "FF807F"
+}
+
+// --- Issue #19: encode_lowercase opt-in form ---
+
+pub fn encode_lowercase_hello_test() -> Nil {
+  assert base16.encode_lowercase(<<"Hello":utf8>>) == "48656c6c6f"
+}
+
+pub fn encode_lowercase_binary_test() -> Nil {
+  assert base16.encode_lowercase(<<0xde, 0xad, 0xbe, 0xef>>) == "deadbeef"
+}
+
+pub fn encode_lowercase_decoder_round_trip_test() -> Nil {
+  // Decoder is case-insensitive, so the lowercase encoder still
+  // round-trips through the same `decode/1` entry point.
+  let data = <<0xff, 0x80, 0x7f, 0x00, 0x10>>
+  assert base16.decode(base16.encode_lowercase(data)) == Ok(data)
+}
+
+pub fn encode_uppercase_decoder_round_trip_test() -> Nil {
+  let data = <<0xff, 0x80, 0x7f, 0x00, 0x10>>
+  assert base16.decode(base16.encode(data)) == Ok(data)
 }
 
 // --- Decode fixed vectors ---

--- a/test/facade_test.gleam
+++ b/test/facade_test.gleam
@@ -26,6 +26,20 @@ pub fn base16_roundtrip_test() -> Nil {
   assert facade.decode_base16(facade.encode_base16(data)) == Ok(data)
 }
 
+// Issue #19: `encode_base16` emits canonical uppercase per RFC 4648
+// §8; `encode_base16_lowercase` is the opt-in lowercase variant. The
+// decoder is case-insensitive so both round-trip cleanly.
+pub fn base16_uppercase_canonical_test() -> Nil {
+  assert facade.encode_base16(<<0xde, 0xad, 0xbe, 0xef>>) == "DEADBEEF"
+}
+
+pub fn base16_lowercase_round_trip_test() -> Nil {
+  let data = <<"Hello":utf8>>
+  let lowercase = facade.encode_base16_lowercase(data)
+  assert lowercase == "48656c6c6f"
+  assert facade.decode_base16(lowercase) == Ok(data)
+}
+
 pub fn base32_roundtrip_test() -> Nil {
   let data = <<"Hello":utf8>>
   assert facade.decode_base32(facade.encode_base32(data)) == Ok(data)


### PR DESCRIPTION
## Summary

Fixes Issue #19. `base16.encode` and `facade.encode_base16` returned
lowercase hex (`"89504e47..."`) which departs from RFC 4648 §8's
canonical uppercase form (`"89504E47..."`). The lowercase output
broke string-equality comparisons against:

- HTTP Signature schemes that hash-then-hex.
- Erlang/OTP `crypto:hash(sha256, ...) |> binary:bin_to_hex` (uppercase
  by default).
- IPFS multibase prefix `F` (uppercase) — yabase emitting lowercase
  under the unprefixed name hid that distinction.
- TLS fingerprint and API key hash comparators that emit uppercase.

Make the default uppercase per the RFC and add
`base16.encode_lowercase` / `facade.encode_base16_lowercase` for the
opt-in lowercase variant. The decoder is already case-insensitive so
round-trips work in both directions.

```gleam
base16.encode(<<0x89, 0x50, 0x4E, 0x47, ...>>)
// "89504E470D0A1A0A"   (RFC 4648 §8 canonical)

base16.encode_lowercase(<<0x89, 0x50, 0x4E, 0x47, ...>>)
// "89504e470d0a1a0a"   (sha256sum / IPFS multibase prefix `f` shape)
```

## Multibase prefix `f` is unaffected

The multibase registry pins prefix `f` to lowercase Base16 (uppercase
Base16 carries the distinct prefix `F`, currently unused on the
encode side). Now that `base16.encode` emits uppercase, the multibase
encoder explicitly lowercases its Base16 output before prepending
`"f"`. The `multibase.encode_with_prefix(Base16, ...)` and
`yabase.encode_multibase(Base16, ...)` strings are byte-identical to
before — only the unprefixed `base16.encode` / `facade.encode_base16`
output changes.

## Changes

- `src/yabase/base16.gleam`:
  - `encode/1` returns uppercase per RFC 4648 §8.
  - New `encode_lowercase/1` for the opt-in lowercase variant.
  - Implementation factored through a single `encode_bytes` helper
    that takes a `case_fn` parameter so the two encoders share the
    walk and only differ in the case-folding step.
  - Module-level docstring documents the change.
- `src/yabase/facade.gleam`:
  - `encode_base16` re-export documents the canonical-uppercase
    contract.
  - New `encode_base16_lowercase` re-export of `base16.encode_lowercase`.
- `src/yabase/core/multibase.gleam`:
  - `encode_with_prefix` now applies `string.lowercase` to Base16
    output specifically, preserving the registry-canonical form for
    prefix `f` regardless of what `base16.encode` returns. Other
    encodings round-trip unchanged via a small switch.
- `test/base16_test.gleam`:
  - Existing fixed-vector tests updated to assert uppercase
    output (`"DEADBEEF"`, `"FF807F"`, `"48656C6C6F"`).
  - Three new tests pin the lowercase opt-in form, confirm both
    encoders round-trip through the case-insensitive decoder, and
    cover the matching `encode_uppercase_decoder_round_trip_test`.
- `test/facade_test.gleam`:
  - Two new facade tests cover the uppercase canonical assertion
    and the lowercase round-trip via the facade.
- `CHANGELOG.md`: documents under `### Changed` (BREAKING) in
  Unreleased.

## Design Decisions

- **Default uppercase, opt-in lowercase.** The issue explicitly
  asks for the RFC 4648 §8 default plus an `encode_base16_lowercase`
  pair, mirroring the existing pattern (`base32_rfc4648` vs
  `base32_hex` vs `crockford`). Keeping the default lowercase
  would only update the docs without resolving the
  cross-implementation drift the issue describes.
- **Multibase preserves the registry shape.** Lowercasing inside
  `encode_with_prefix` rather than at the dispatcher keeps the
  fix one-sided: `dispatcher.encode(Base16, ...)` (the unified
  `yabase.encode(...)` path) returns the new uppercase form, and
  `yabase.encode_multibase(Base16, ...)` continues to return the
  prefix-`f` lowercase form callers already depend on.

## Test Plan

- [x] `gleam format .` — clean.
- [x] `gleam test` — 625 passes (5 new tests for #19, 3 existing
  fixed-vector tests updated).
- [x] `gleam run -m glinter` — no issues.
- [x] Verified via the new round-trip tests that
  `base16.decode(base16.encode(data)) == Ok(data)` and
  `base16.decode(base16.encode_lowercase(data)) == Ok(data)` for the
  same input (decoder is case-insensitive).

Closes #19
