### PR TITLE
fix(sha256): drop JS-target Truncated-bit-array warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **internal/sha256**: drop the JavaScript-target compile warning
+  ("Truncated bit array segment ... 64-bit long int, but on the
+  JavaScript target numbers have at most 52 bits") that fired on
+  every clean compile of any project depending on this package
+  from the JS target. The previous `<<block:bytes-size(64),
+  rest:bits>>` segment pattern was misinterpreted by the compiler
+  as a 64-bit integer segment; switch `process_blocks` to use
+  `bit_array.slice` so the split is expressed in stdlib terms with
+  no segment-pattern parsing. Runtime behaviour is unchanged on
+  both targets — `process_blocks` still consumes 64-byte blocks
+  in source order and feeds the same SHA-256 compression rounds.
+  New regression tests pin the SHA-256 output for 65-byte and
+  200-byte inputs (the 65-byte case crosses the block boundary
+  exactly once, which is where the warning would have masked any
+  real corruption). `Base58Check` and `Bech32` round-trips that
+  rely on this SHA-256 inner loop are unaffected. (#20)
+
 ### Changed
 
 - **base16 (BREAKING)**: `base16.encode` and `facade.encode_base16`

--- a/src/yabase/internal/sha256.gleam
+++ b/src/yabase/internal/sha256.gleam
@@ -225,18 +225,37 @@ fn pad_zeros(data: BitArray) -> BitArray {
   }
 }
 
-// Process 512-bit (64-byte) blocks
+// Process 512-bit (64-byte) blocks.
+//
+// Issue #20: the previous `<<block:bytes-size(64), rest:bits>>`
+// pattern triggered a JavaScript-target compile warning
+// ("Truncated bit array segment ... 64-bit long int, but on the
+// JavaScript target numbers have at most 52 bits"). Whether or
+// not that was a Gleam-compiler false positive, the warning fired
+// on every clean compile of any project depending on this package
+// from the JS target. Switch to `bit_array.slice` so the split is
+// expressed in stdlib terms — no segment-pattern parsing, no
+// warning, identical runtime behaviour on both targets. The
+// double `case` on slice results never falls through to the `_, _`
+// arm because the surrounding `total >= 64` guard guarantees both
+// slices succeed; the arm exists only to keep the function total
+// without resorting to `let assert`.
 fn process_blocks(
   data: BitArray,
   state: #(Int, Int, Int, Int, Int, Int, Int, Int),
 ) -> #(Int, Int, Int, Int, Int, Int, Int, Int) {
-  case data {
-    <<block:bytes-size(64), rest:bits>> -> {
-      let schedule = parse_block(block)
-      let new_state = compress(state, schedule)
-      process_blocks(rest, new_state)
-    }
-    _ -> state
+  let total = bit_array.byte_size(data)
+  case total >= 64 {
+    False -> state
+    True ->
+      case bit_array.slice(data, 0, 64), bit_array.slice(data, 64, total - 64) {
+        Ok(block), Ok(rest) -> {
+          let schedule = parse_block(block)
+          let new_state = compress(state, schedule)
+          process_blocks(rest, new_state)
+        }
+        _, _ -> state
+      }
   }
 }
 

--- a/test/sha256_test.gleam
+++ b/test/sha256_test.gleam
@@ -89,3 +89,40 @@ pub fn sha256_64byte_test() -> Nil {
       0x99, 0x73, 0x37, 0xdf, 0x15, 0x46, 0x68, 0xeb,
     >>
 }
+
+/// Issue #20: 65-byte input forces `process_blocks` to consume one
+/// full 64-byte block and a remainder of one byte before padding.
+/// The previous `<<block:bytes-size(64), rest:bits>>` pattern made
+/// the Gleam compiler warn about a 64-bit int truncation on the JS
+/// target — if the warning was correct, the second block iteration
+/// would have been silently corrupted on JS and this hash would
+/// not match. The fix routes `process_blocks` through
+/// `bit_array.slice` instead of the segment-pattern split; this
+/// test pins the result so any future regression of either mechanism
+/// is caught.
+pub fn sha256_65byte_crosses_block_boundary_test() -> Nil {
+  let input = string.repeat("a", 65)
+  let hash = sha256.hash(<<input:utf8>>)
+  assert hash
+    == <<
+      0x63, 0x53, 0x61, 0xc4, 0x8b, 0xb9, 0xea, 0xb1, 0x41, 0x98, 0xe7, 0x6e,
+      0xa8, 0xab, 0x7f, 0x1a, 0x41, 0x68, 0x5d, 0x6a, 0xd6, 0x2a, 0xa9, 0x14,
+      0x6d, 0x30, 0x1d, 0x4f, 0x17, 0xeb, 0x0a, 0xe0,
+    >>
+}
+
+/// Issue #20 (extended): a 200-byte input requires three full block
+/// iterations of `process_blocks` plus padding into a fourth. With
+/// the segment-pattern split corrupted, the trailing iterations
+/// would compound the error, so a long input pins the loop's
+/// correctness across multiple block-boundary crossings.
+pub fn sha256_200byte_test() -> Nil {
+  let input = string.repeat("a", 200)
+  let hash = sha256.hash(<<input:utf8>>)
+  assert hash
+    == <<
+      0xc2, 0xa9, 0x08, 0xd9, 0x8f, 0x5d, 0xf9, 0x87, 0xad, 0xe4, 0x1b, 0x5f,
+      0xce, 0x21, 0x30, 0x67, 0xef, 0xbc, 0xc2, 0x1e, 0xf2, 0x24, 0x02, 0x12,
+      0xa4, 0x1e, 0x54, 0xb5, 0xe7, 0xc2, 0x8a, 0xe5,
+    >>
+}


### PR DESCRIPTION
## Summary

Fixes Issue #20. The previous `<<block:bytes-size(64), rest:bits>>`
segment pattern in `process_blocks` triggered a Gleam compile
warning on the JavaScript target:

```
warning: Truncated bit array segment
234 │     <<block:bytes-size(64), rest:bits>> -> {
    │                   ^^^^^^^^

This segment is a 64-bit long int, but on the JavaScript target
numbers have at most 52 bits. It would be truncated to its first
52 bits.

Hint: Did you mean to use the `bytes` segment option?
```

The warning fired on every clean compile of any project depending
on this package from the JS target. The package itself ships a
SHA-256 implementation that `Base58Check` and `Bech32`/`Bech32m`
rely on for their checksum step, so the warning surfaced exactly
where the README claims cross-target purity.

Switch `process_blocks` to express the 64-byte block split via
`bit_array.slice` instead of segment-pattern matching. Runtime
behaviour is unchanged on both targets — the same 64-byte chunks
are fed into the same compression rounds — but the segment-pattern
parse is gone, so the warning never fires.

```
$ gleam build --target javascript
# (after the fix: no Truncated bit array segment warning)
```

## Changes

- `src/yabase/internal/sha256.gleam`:
  - `process_blocks` now computes `bit_array.byte_size(data)` once,
    guards on `total >= 64`, and uses
    `bit_array.slice(data, 0, 64)` and `bit_array.slice(data, 64,
    total - 64)` to obtain the block and the remainder. The double
    `case` arms keep the function total without resorting to
    `let assert` (which would trip glinter's `assert_ok_pattern`
    rule); the `_, _ -> state` fallback is unreachable under the
    `total >= 64` guard but its presence satisfies exhaustive
    matching.
  - Doc comment explains the change and notes that the runtime
    behaviour is identical to the segment-pattern form.
- `test/sha256_test.gleam`: two new regression tests:
  - `sha256_65byte_crosses_block_boundary_test` — 65 'a' input
    forces exactly one full block plus a one-byte remainder.
    This is where the warning would have masked any real
    corruption (52 bits ≠ 64 bytes); the test pins the result
    so any future regression is caught.
  - `sha256_200byte_test` — 200 'a' input exercises three full
    block iterations plus padding, covering the case where the
    error would have compounded across many blocks.
- `CHANGELOG.md`: documents under `### Fixed` in Unreleased.

## Design Decisions

- **Stdlib slice over segment pattern.** The issue suggested two
  options: rewrite the pattern, or refactor to `bit_array.slice`.
  The slice form is unambiguous to the compiler, portable across
  Gleam versions, and matches how SHA-256 is implemented in other
  Gleam libraries.
- **No `let assert`.** The codebase has zero existing `nolint`
  comments and zero `let assert` in `src/`, so I avoid both —
  the surrounding `total >= 64` guard makes both slices succeed
  by construction, and the `_, _ -> state` arm is a defensive
  no-op that the linter and the type system both accept.
- **65-byte and 200-byte vectors.** The expected outputs come
  from the now-fixed implementation itself: the existing 64-byte
  test (which uses a long-standing FIPS 180-4-style vector)
  passes with the refactor, confirming one full iteration of
  `process_blocks` is correct; the new vectors then pin the
  multi-iteration cases.

## Test Plan

- [x] `gleam format .` — clean.
- [x] `gleam test` — 627 passes (2 new regression tests for #20).
- [x] `gleam run -m glinter` — no issues.
- [x] `gleam build --target javascript | grep "Truncated bit
  array segment"` — empty (warning is gone).

Closes #20
