### PR TITLE
feat(intid): add bounded decode variants with int64/int53 caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `yabase/intid` now exposes a bounded decode family:
+  `decode_int_base32_rfc4648_bounded`,
+  `decode_int_base32_crockford_bounded`,
+  `decode_int_base36_bounded`, `decode_int_base58_bounded`,
+  `decode_int_base58_flickr_bounded`, and `decode_int_base62_bounded`.
+  Each takes `input:` and `max:` labels and returns
+  `Error(Overflow)` when the decoded value exceeds `max`. Two cap
+  constants are exported alongside: `intid.int64_max` (`2^63 - 1`,
+  the signed 64-bit ceiling that SQLite `INTEGER`, Postgres
+  `bigserial`, and MySQL `BIGINT` all share) and
+  `intid.int53_max` (`2^53 - 1`, `Number.MAX_SAFE_INTEGER` for the
+  JavaScript-target boundary). The existing unbounded `decode_int_*`
+  family is unchanged: it still accepts strings of any length and
+  returns Erlang's bignum, which is the right behaviour when the
+  decoded value stays inside the BEAM. The bounded variants exist
+  for the case where the value flows into a fixed-width sink — a
+  database integer column or a JS `number` — where an unbounded
+  bignum surfaces as a driver crash or a silent precision loss
+  rather than as a clear `CodecError`. The error contract is
+  otherwise identical: `InvalidLength(0)` for empty input,
+  `InvalidCharacter` for alphabet violations, then `Overflow` last
+  if the value parsed cleanly but exceeds the cap. (#28)
+
 ## [0.6.0] - 2026-04-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ Available: `encode_int_base32_rfc4648`, `encode_int_base32_crockford`, `encode_i
 
 `encode_int_*` emits canonical form. `decode_int_*` is tolerant of leading zero characters (`decode_int_base58("0042")` and `decode_int_base58("42")` return the same `Int`). Negative inputs are normalized via `int.absolute_value` before encoding.
 
+`decode_int_*` accepts inputs of any length, so the decoded `Int` is an unbounded Erlang bignum. If the value flows into a fixed-width sink (SQLite `INTEGER`, Postgres `bigserial`, MySQL `BIGINT`, or a JS `number`), use the matching `decode_int_*_bounded(input:, max:)` to get `Error(Overflow)` instead of a downstream crash. Common caps are exported as `intid.int64_max` (signed 64-bit, `2^63 - 1`) and `intid.int53_max` (`Number.MAX_SAFE_INTEGER`).
+
+```gleam
+import yabase/intid
+
+pub fn lookup(public_id: String) -> Bool {
+  case intid.decode_int_base58_bounded(input: public_id, max: intid.int64_max) {
+    // Bind `_internal_id` to `sqlight.int(_)` etc.; the value fits BIGINT.
+    Ok(_internal_id) -> True
+    // Respond 404/400; input was malformed or numerically out of range.
+    Error(_) -> False
+  }
+}
+```
+
 ## Supported encodings
 
 ### Core

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -27,6 +27,23 @@
 //// Negative inputs are normalized to `int.absolute_value` before
 //// encoding — the magnitude is what gets stored. The decode side
 //// always returns a non-negative `Int`.
+////
+//// ## Bounded decode
+////
+//// `decode_int_*` accepts inputs of any length, so the decoded
+//// `Int` can exceed any fixed integer width — Erlang `Int` is a
+//// bignum. Realistic backing stores cap IDs at 64 bits (SQLite
+//// `INTEGER`, Postgres `bigserial`, MySQL `BIGINT`), so feeding an
+//// unbounded `decode_int_*` result into one of those columns
+//// crashes the driver as soon as a user supplies a slightly-too-long
+//// string. For the same reason, JavaScript-target callers cap at
+//// 53 bits (`Number.MAX_SAFE_INTEGER`).
+////
+//// Use `decode_int_*_bounded(input:, max:)` whenever the decoded value
+//// flows into a fixed-width sink. The bounded variants return
+//// `Error(Overflow)` if the decoded `Int` exceeds `max`. Common caps
+//// are exported as `int64_max` (signed 64-bit, `2^63 - 1`) and
+//// `int53_max` (JS-safe integer, `2^53 - 1`).
 
 import gleam/bool
 import gleam/int
@@ -38,8 +55,21 @@ import yabase/base36
 import yabase/base58/bitcoin as base58_bitcoin
 import yabase/base58/flickr as base58_flickr
 import yabase/base62
-import yabase/core/encoding.{type CodecError, InvalidLength}
+import yabase/core/encoding.{type CodecError, InvalidLength, Overflow}
 import yabase/internal/bignum
+
+/// Largest value that fits in a signed 64-bit integer (`2^63 - 1`).
+/// Use as the `max` argument to `decode_int_*_bounded` when the
+/// decoded value flows into a column declared `BIGINT` (Postgres,
+/// MySQL) or `INTEGER` (SQLite).
+pub const int64_max: Int = 9_223_372_036_854_775_807
+
+/// Largest value that round-trips losslessly through a JavaScript
+/// `number` (`2^53 - 1`, `Number.MAX_SAFE_INTEGER`). Use as the
+/// `max` argument to `decode_int_*_bounded` when the decoded value
+/// is passed across a JS-target boundary or serialized as JSON for
+/// a JavaScript consumer.
+pub const int53_max: Int = 9_007_199_254_740_991
 
 /// Encode a non-negative `Int` as a Base32 (RFC 4648) string.
 pub fn encode_int_base32_rfc4648(value: Int) -> String {
@@ -51,6 +81,16 @@ pub fn decode_int_base32_rfc4648(input: String) -> Result(Int, CodecError) {
   use input <- result.try(reject_empty(input))
   base32_rfc4648.decode(input)
   |> result.map(bytes_to_int)
+}
+
+/// Decode a Base32 (RFC 4648) string back to an `Int`, rejecting
+/// values greater than `max` with `Error(Overflow)`.
+pub fn decode_int_base32_rfc4648_bounded(
+  input input: String,
+  max max: Int,
+) -> Result(Int, CodecError) {
+  use value <- result.try(decode_int_base32_rfc4648(input))
+  bound_check(value, max)
 }
 
 /// Encode a non-negative `Int` as a Crockford Base32 string.
@@ -65,6 +105,16 @@ pub fn decode_int_base32_crockford(input: String) -> Result(Int, CodecError) {
   |> result.map(bytes_to_int)
 }
 
+/// Decode a Crockford Base32 string back to an `Int`, rejecting
+/// values greater than `max` with `Error(Overflow)`.
+pub fn decode_int_base32_crockford_bounded(
+  input input: String,
+  max max: Int,
+) -> Result(Int, CodecError) {
+  use value <- result.try(decode_int_base32_crockford(input))
+  bound_check(value, max)
+}
+
 /// Encode a non-negative `Int` as a Base36 string.
 pub fn encode_int_base36(value: Int) -> String {
   base36.encode(int_to_bytes_be(value))
@@ -75,6 +125,16 @@ pub fn decode_int_base36(input: String) -> Result(Int, CodecError) {
   use input <- result.try(reject_empty(input))
   base36.decode(input)
   |> result.map(bytes_to_int)
+}
+
+/// Decode a Base36 string back to an `Int`, rejecting values
+/// greater than `max` with `Error(Overflow)`.
+pub fn decode_int_base36_bounded(
+  input input: String,
+  max max: Int,
+) -> Result(Int, CodecError) {
+  use value <- result.try(decode_int_base36(input))
+  bound_check(value, max)
 }
 
 /// Encode a non-negative `Int` as a Base58 (Bitcoin alphabet) string.
@@ -89,6 +149,16 @@ pub fn decode_int_base58(input: String) -> Result(Int, CodecError) {
   |> result.map(bytes_to_int)
 }
 
+/// Decode a Base58 (Bitcoin alphabet) string back to an `Int`,
+/// rejecting values greater than `max` with `Error(Overflow)`.
+pub fn decode_int_base58_bounded(
+  input input: String,
+  max max: Int,
+) -> Result(Int, CodecError) {
+  use value <- result.try(decode_int_base58(input))
+  bound_check(value, max)
+}
+
 /// Encode a non-negative `Int` as a Base58 (Flickr alphabet) string.
 pub fn encode_int_base58_flickr(value: Int) -> String {
   base58_flickr.encode(int_to_bytes_be(value))
@@ -99,6 +169,16 @@ pub fn decode_int_base58_flickr(input: String) -> Result(Int, CodecError) {
   use input <- result.try(reject_empty(input))
   base58_flickr.decode(input)
   |> result.map(bytes_to_int)
+}
+
+/// Decode a Base58 (Flickr alphabet) string back to an `Int`,
+/// rejecting values greater than `max` with `Error(Overflow)`.
+pub fn decode_int_base58_flickr_bounded(
+  input input: String,
+  max max: Int,
+) -> Result(Int, CodecError) {
+  use value <- result.try(decode_int_base58_flickr(input))
+  bound_check(value, max)
 }
 
 /// Encode a non-negative `Int` as a Base62 string.
@@ -113,6 +193,16 @@ pub fn decode_int_base62(input: String) -> Result(Int, CodecError) {
   |> result.map(bytes_to_int)
 }
 
+/// Decode a Base62 string back to an `Int`, rejecting values
+/// greater than `max` with `Error(Overflow)`.
+pub fn decode_int_base62_bounded(
+  input input: String,
+  max max: Int,
+) -> Result(Int, CodecError) {
+  use value <- result.try(decode_int_base62(input))
+  bound_check(value, max)
+}
+
 // `decode_int_*` rejects the empty string so callers can distinguish
 // "no input" from a zero-valued ID. The byte-oriented decoders keep
 // their `Ok(<<>>)` semantics for round-tripping empty inputs.
@@ -122,6 +212,11 @@ fn reject_empty(input: String) -> Result(String, CodecError) {
     return: Error(InvalidLength(0)),
   )
   Ok(input)
+}
+
+fn bound_check(value: Int, max: Int) -> Result(Int, CodecError) {
+  use <- bool.guard(when: value > max, return: Error(Overflow))
+  Ok(value)
 }
 
 fn int_to_bytes_be(value: Int) -> BitArray {

--- a/test/intid_test.gleam
+++ b/test/intid_test.gleam
@@ -1,4 +1,4 @@
-import yabase/core/encoding.{InvalidCharacter, InvalidLength}
+import yabase/core/encoding.{InvalidCharacter, InvalidLength, Overflow}
 import yabase/intid
 
 // === Base32 (RFC 4648) ===
@@ -193,4 +193,162 @@ pub fn encode_int_base58_negative_normalized_test() -> Nil {
 
 pub fn encode_int_base62_negative_normalized_test() -> Nil {
   assert intid.encode_int_base62(-1) == intid.encode_int_base62(1)
+}
+
+// === Bounded decode: cap constants ===
+
+pub fn int64_max_constant_test() -> Nil {
+  // 2^63 - 1
+  assert intid.int64_max == 9_223_372_036_854_775_807
+}
+
+pub fn int53_max_constant_test() -> Nil {
+  // 2^53 - 1, JavaScript Number.MAX_SAFE_INTEGER
+  assert intid.int53_max == 9_007_199_254_740_991
+}
+
+// === Bounded decode: Base58 (Bitcoin) ===
+
+pub fn decode_int_base58_bounded_within_test() -> Nil {
+  let encoded = intid.encode_int_base58(42)
+  assert intid.decode_int_base58_bounded(input: encoded, max: intid.int64_max)
+    == Ok(42)
+}
+
+pub fn decode_int_base58_bounded_at_cap_test() -> Nil {
+  let encoded = intid.encode_int_base58(intid.int64_max)
+  assert intid.decode_int_base58_bounded(input: encoded, max: intid.int64_max)
+    == Ok(intid.int64_max)
+}
+
+pub fn decode_int_base58_bounded_above_cap_test() -> Nil {
+  // 58^12 - 1 = "zzzzzzzzzzzz" (12 z's) ≈ 1.5e21, well above int64_max.
+  // This is the exact reproduction case from the issue: an attacker
+  // (or honest user typing a wrong URL) supplies 12 z's and the
+  // unbounded decoder would return a bignum that crashes int64-bound
+  // sinks (sqlite/postgres bigserial/mysql bigint).
+  assert intid.decode_int_base58_bounded(
+      input: "zzzzzzzzzzzz",
+      max: intid.int64_max,
+    )
+    == Error(Overflow)
+}
+
+pub fn decode_int_base58_bounded_just_above_cap_test() -> Nil {
+  let encoded = intid.encode_int_base58(intid.int64_max + 1)
+  assert intid.decode_int_base58_bounded(input: encoded, max: intid.int64_max)
+    == Error(Overflow)
+}
+
+pub fn decode_int_base58_bounded_int53_cap_test() -> Nil {
+  let encoded = intid.encode_int_base58(intid.int53_max + 1)
+  assert intid.decode_int_base58_bounded(input: encoded, max: intid.int53_max)
+    == Error(Overflow)
+}
+
+pub fn decode_int_base58_bounded_empty_test() -> Nil {
+  // Bounded variant defers empty-input rejection to the underlying
+  // decoder so the error contract is identical.
+  assert intid.decode_int_base58_bounded(input: "", max: intid.int64_max)
+    == Error(InvalidLength(0))
+}
+
+pub fn decode_int_base58_bounded_invalid_char_test() -> Nil {
+  // Decoder errors propagate through the bounded variant unchanged.
+  assert intid.decode_int_base58_bounded(input: "0", max: intid.int64_max)
+    == Error(InvalidCharacter("0", 0))
+}
+
+// === Bounded decode: Base58 (Flickr) ===
+
+pub fn decode_int_base58_flickr_bounded_within_test() -> Nil {
+  let encoded = intid.encode_int_base58_flickr(1234)
+  assert intid.decode_int_base58_flickr_bounded(
+      input: encoded,
+      max: intid.int64_max,
+    )
+    == Ok(1234)
+}
+
+pub fn decode_int_base58_flickr_bounded_above_cap_test() -> Nil {
+  let encoded = intid.encode_int_base58_flickr(intid.int64_max + 1)
+  assert intid.decode_int_base58_flickr_bounded(
+      input: encoded,
+      max: intid.int64_max,
+    )
+    == Error(Overflow)
+}
+
+// === Bounded decode: Base62 ===
+
+pub fn decode_int_base62_bounded_within_test() -> Nil {
+  let encoded = intid.encode_int_base62(2_147_483_647)
+  assert intid.decode_int_base62_bounded(input: encoded, max: intid.int64_max)
+    == Ok(2_147_483_647)
+}
+
+pub fn decode_int_base62_bounded_above_cap_test() -> Nil {
+  let encoded = intid.encode_int_base62(intid.int64_max + 1)
+  assert intid.decode_int_base62_bounded(input: encoded, max: intid.int64_max)
+    == Error(Overflow)
+}
+
+pub fn decode_int_base62_bounded_int53_within_test() -> Nil {
+  let encoded = intid.encode_int_base62(intid.int53_max)
+  assert intid.decode_int_base62_bounded(input: encoded, max: intid.int53_max)
+    == Ok(intid.int53_max)
+}
+
+// === Bounded decode: Base36 ===
+
+pub fn decode_int_base36_bounded_within_test() -> Nil {
+  let encoded = intid.encode_int_base36(8_675_309)
+  assert intid.decode_int_base36_bounded(input: encoded, max: intid.int64_max)
+    == Ok(8_675_309)
+}
+
+pub fn decode_int_base36_bounded_above_cap_test() -> Nil {
+  let encoded = intid.encode_int_base36(intid.int64_max + 1)
+  assert intid.decode_int_base36_bounded(input: encoded, max: intid.int64_max)
+    == Error(Overflow)
+}
+
+// === Bounded decode: Base32 (RFC 4648) ===
+
+pub fn decode_int_base32_rfc4648_bounded_within_test() -> Nil {
+  let encoded = intid.encode_int_base32_rfc4648(1_234_567)
+  assert intid.decode_int_base32_rfc4648_bounded(
+      input: encoded,
+      max: intid.int64_max,
+    )
+    == Ok(1_234_567)
+}
+
+pub fn decode_int_base32_rfc4648_bounded_above_cap_test() -> Nil {
+  let encoded = intid.encode_int_base32_rfc4648(intid.int64_max + 1)
+  assert intid.decode_int_base32_rfc4648_bounded(
+      input: encoded,
+      max: intid.int64_max,
+    )
+    == Error(Overflow)
+}
+
+// === Bounded decode: Base32 (Crockford) ===
+
+pub fn decode_int_base32_crockford_bounded_within_test() -> Nil {
+  let encoded = intid.encode_int_base32_crockford(987_654)
+  assert intid.decode_int_base32_crockford_bounded(
+      input: encoded,
+      max: intid.int64_max,
+    )
+    == Ok(987_654)
+}
+
+pub fn decode_int_base32_crockford_bounded_above_cap_test() -> Nil {
+  let encoded = intid.encode_int_base32_crockford(intid.int64_max + 1)
+  assert intid.decode_int_base32_crockford_bounded(
+      input: encoded,
+      max: intid.int64_max,
+    )
+    == Error(Overflow)
 }


### PR DESCRIPTION
## Summary

Adds a `decode_int_*_bounded(input:, max:)` family to `yabase/intid` so callers can reject decoded values that exceed a fixed-width sink (database `BIGINT` column, JS `number`, etc.) with `Error(Overflow)` instead of letting an Erlang bignum reach the boundary and crash the driver. Two cap constants are exported for the common ceilings: `int64_max` (`2^63 - 1`) and `int53_max` (`Number.MAX_SAFE_INTEGER`).

## Changes

- `src/yabase/intid.gleam` — six new `decode_int_*_bounded` functions (rfc4648, crockford, base36, base58, base58_flickr, base62) plus `int64_max` / `int53_max` constants. New module-level docstring section "Bounded decode" explains when to reach for the bounded variants.
- `test/intid_test.gleam` — new test cases covering each bounded variant: within-cap, at-cap, just-above-cap, the issue's reproduction case (`"zzzzzzzzzzzz"` in Base58, ≈ 1.5e21), and propagation of underlying decoder errors (`InvalidLength(0)` / `InvalidCharacter`).
- `README.md` — "Integer IDs" section gains a paragraph + compile-checked example for the bounded API and the cap constants.
- `CHANGELOG.md` — `[Unreleased] / Added` entry.

## Design Decisions

- **Reuse `CodecError.Overflow`** rather than introducing a new variant: `Overflow` already documents "Decoded value overflows the expected range", which fits exactly. Keeps the public error surface unchanged.
- **Bounded variants wrap, not replace.** The existing unbounded `decode_int_*` is correct in isolation (Erlang `Int` is the right return type when the caller stays inside the BEAM). Splitting bounded out as a sibling preserves backward compatibility and lets the caller pick the contract that matches their sink.
- **Labelled args (`input:`, `max:`)** make call sites read like the doc — `decode_int_base58_bounded(input: public_id, max: int64_max)` — and pass glinter's `label_possible` rule that fires on multi-arg public functions.
- **Caps as `pub const`, not magic numbers** so the call site reads as intent (`max: intid.int64_max`) rather than `9_223_372_036_854_775_807`. Both names match well-known platform ceilings, so no surprise for callers familiar with the underlying constraint.

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded integer decoding functions for all supported bases (Base32 RFC4648, Base32 Crockford, Base36, Base58 Bitcoin, Base58 Flickr, Base62) that enforce maximum value limits and return overflow errors when exceeded.
  * Introduced `int64_max` and `int53_max` constants for common numeric boundaries.

* **Documentation**
  * Updated README and CHANGELOG with bounded decoding examples and guidance for preventing downstream overflow in fixed-width database columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->