### PR TITLE
feat: support JavaScript target compilation (no FFI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,18 @@ jobs:
           gleam-version: ${{ matrix.gleam }}
       - run: gleam deps download
       - run: gleam test
+
+  build-javascript:
+    name: Build (JavaScript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.15"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: gleam deps download
+      - run: gleam build --target javascript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- JavaScript target compilation. `gleam.toml` no longer pins
+  `target = "erlang"`, so the package compiles for both Erlang and
+  JavaScript. The four `@external(erlang, "erlang", ...)` calls in
+  `base91.gleam` were replaced with the cross-target `gleam/int`
+  bitwise helpers (no FFI remains in `src/`). CI now runs a
+  `Build (JavaScript)` job that verifies the package compiles
+  cleanly under `gleam build --target javascript`. (#31)
+
+### Notes
+
+- The Erlang test suite (647 tests) is unaffected. A subset of the
+  encodings (base32 Crockford, base58, base36 — anything that uses
+  arbitrary-precision integer arithmetic for the bignum-style codecs)
+  rely on BEAM bignum semantics and produce wrong values when run
+  on JavaScript past `Number.MAX_SAFE_INTEGER`. Those modules still
+  compile on JavaScript but their tests are not yet wired into a
+  cross-target test run; partitioning the test suite (or porting the
+  bignum codecs to a JS-safe representation) is a separate piece of
+  follow-up work. base16, base64, base91, base32 RFC4648 and ascii85
+  remain JavaScript-safe.
+
 ## [0.7.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Yet Another Base -- a unified, type-safe interface for multiple binary-to-text e
 
 - Gleam 1.15 or later
 - Erlang/OTP 26 or later (CI tests OTP 26, 27, 28)
+- Node.js 18 or later (when targeting JavaScript)
+
+## Supported targets
+
+- Erlang (BEAM) — full encoding catalogue.
+- JavaScript — the package compiles for the JavaScript target with
+  no FFI. Encodings whose internals rely on arbitrary-precision
+  integer arithmetic (base32 Crockford, base58, base36 — used in
+  multibase too) inherit JavaScript's `Number.MAX_SAFE_INTEGER`
+  ceiling and may produce incorrect output for inputs that overflow
+  53-bit integers. base16, base64, base91, base32 RFC4648 and
+  ascii85 are JavaScript-safe.
 
 ## Install
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,5 @@
 name = "yabase"
 version = "0.7.0"
-target = "erlang"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }

--- a/src/yabase/base91.gleam
+++ b/src/yabase/base91.gleam
@@ -2,11 +2,12 @@
 /// Uses 91 printable ASCII characters for efficient binary-to-text encoding.
 /// More space-efficient than Base64 (roughly 23% overhead vs 33%).
 ///
-/// Based on the algorithm by Joachim Henke.
-/// Uses Erlang bitwise operations via BitArray patterns to match
-/// the C reference implementation's unsigned integer semantics.
+/// Based on the algorithm by Joachim Henke. The bitwise queue arithmetic
+/// uses `gleam/int.bitwise_*` so the implementation runs identically on
+/// Erlang and JavaScript targets.
 import gleam/bit_array
 import gleam/bool
+import gleam/int
 import gleam/list
 import gleam/string
 import yabase/core/encoding.{type CodecError, InvalidCharacter}
@@ -132,18 +133,22 @@ fn extract_bytes_from_queue(queue: Int, nbits: Int, acc: List(Int)) -> List(Int)
   extract_bytes_from_queue(bsr(queue, 8), nbits - 8, [band(queue, 255), ..acc])
 }
 
-// Erlang bitwise operations (exact unsigned semantics)
-@external(erlang, "erlang", "bor")
-fn bor(a: Int, b: Int) -> Int
+// Cross-target bitwise wrappers around gleam/int.
+fn bor(a: Int, b: Int) -> Int {
+  int.bitwise_or(a, b)
+}
 
-@external(erlang, "erlang", "band")
-fn band(a: Int, b: Int) -> Int
+fn band(a: Int, b: Int) -> Int {
+  int.bitwise_and(a, b)
+}
 
-@external(erlang, "erlang", "bsl")
-fn bsl(a: Int, b: Int) -> Int
+fn bsl(a: Int, b: Int) -> Int {
+  int.bitwise_shift_left(a, b)
+}
 
-@external(erlang, "erlang", "bsr")
-fn bsr(a: Int, b: Int) -> Int
+fn bsr(a: Int, b: Int) -> Int {
+  int.bitwise_shift_right(a, b)
+}
 
 fn char_at(index: Int) -> String {
   case string.drop_start(alphabet, index) |> string.pop_grapheme {


### PR DESCRIPTION
## Summary

Drop the `target = \"erlang\"` constraint from `gleam.toml` and replace the
four `@external(erlang, \"erlang\", \"bor\"/\"band\"/\"bsl\"/\"bsr\")` calls in
`base91.gleam` with the cross-target `gleam/int` bitwise helpers. After
this change the package contains zero FFI and compiles cleanly under
`gleam build --target javascript`. Closes #31.

## Changes

- `gleam.toml` — drop `target = \"erlang\"`.
- `src/yabase/base91.gleam` — replace the four \`bor / band / bsl /
  bsr\` Erlang FFIs with thin wrappers over `int.bitwise_or` /
  `int.bitwise_and` / `int.bitwise_shift_left` /
  `int.bitwise_shift_right`. Public API and Erlang behaviour
  unchanged.
- `.github/workflows/ci.yml` — add `Build (JavaScript)` job that runs
  `gleam build --target javascript` on Node 22.
- `README.md` — add a \"Supported targets\" section.
- `CHANGELOG.md` — `[Unreleased]` entry covering the change and the
  follow-up scope.

## Design Decisions

- **JS test step deferred to follow-up.** A subset of the encodings
  (base32 Crockford, base58, base36 — the bignum-style codecs) rely
  on BEAM arbitrary-precision integer arithmetic. They compile on
  JavaScript but produce incorrect output past
  `Number.MAX_SAFE_INTEGER` (verified: ~35 of 647 tests fail when
  the existing suite runs unchanged under
  `gleam test --target javascript`). Wiring a partitioned JS test
  run, or porting those codecs to a JS-safe representation, is its
  own piece of work and shouldn't block this PR. The CI step in this
  PR is `gleam build --target javascript` (build verification only),
  which proves the package compiles cleanly without forcing a test
  partition right now. base16, base64, base91, base32 RFC4648 and
  ascii85 remain JavaScript-safe.
- **Wrapper functions over inlined `int.bitwise_*`** — keeps the
  base91 hot loop call sites unchanged (12 sites use `bor` / `band`
  / `bsl` / `bsr`) and isolates the FFI removal to a single
  4-function block at the bottom of the module.

## Limitations

- Bignum-style encodings (base32 Crockford, base58, base36) compile
  on JavaScript but produce wrong output for inputs that overflow
  53-bit integers. The CHANGELOG and README both document this.
- A follow-up Issue should partition the test suite so a JS test run
  can be wired into CI for the cross-target-safe modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JavaScript compilation support alongside Erlang.

* **Documentation**
  * Updated environment requirements to include Node.js for JavaScript builds.
  * Added "Supported targets" section documenting platform capabilities and known limitations for large-number encodings on JavaScript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->