### PR TITLE
feat(encoding): add smart constructors for the Encoding ADT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- 25 smart constructors on `yabase/core/encoding` — one per existing
+  `Encoding` variant: `base2/0`, `base8/0`, `base10/0`, `base16/0`,
+  `base32_rfc4648/0`, `base32_hex/0`, `base32_crockford/0`,
+  `base32_crockford_check/0`, `base32_clockwork/0`,
+  `base32_z_base32/0`, `base36/0`, `base45/0`, `base58_bitcoin/0`,
+  `base58_flickr/0`, `base62/0`, `base64_standard/0`,
+  `base64_url_safe/0`, `base64_no_padding/0`,
+  `base64_url_safe_no_padding/0`, `base64_dq/0`, `base85_btoa/0`,
+  `base85_adobe/0`, `base85_rfc1924/0`, `base85_z85/0`, `base91/0`.
+  Each returns the same `Encoding` value as the matching ADT
+  constructor (`encoding.base32_rfc4648() == Base32(RFC4648)`), but
+  the smart-constructor signature stays stable across releases even
+  if the underlying variant ADT changes shape. New 25-test smoke
+  module pins that equivalence so a future opaque migration can
+  refactor the ADT freely. (#32, partial)
+
+### Notes
+
+- This is the non-breaking first half of #32. The full plan is to
+  promote `Encoding` (and `Base32Variant` / `Base58Variant` /
+  `Base64Variant` / `Base85Variant`) to `pub opaque type` so external
+  callers cannot pattern-match on the constructor list at all. That
+  step is BREAKING for any caller that today writes
+  `case enc { Base64(_) -> ... }` outside the package, and it
+  requires moving the dispatcher and multibase-prefix tables out of
+  the `core/dispatcher` and `core/multibase` modules into the type's
+  defining module (so the pattern match stays inside the opaque
+  boundary). Tracked as a follow-up — landing the smart constructors
+  first lets external callers migrate their construction sites
+  (`Base32(RFC4648)` → `encoding.base32_rfc4648()`) on the current
+  release without waiting for the bigger refactor.
+
 ## [0.8.0] - 2026-04-28
 
 ### Added

--- a/src/yabase/core/encoding.gleam
+++ b/src/yabase/core/encoding.gleam
@@ -105,3 +105,141 @@ pub type CodecError {
   /// Invalid human-readable part in Bech32/Bech32m.
   InvalidHrp(reason: String)
 }
+
+// ---------------------------------------------------------------------------
+// Smart constructors.
+//
+// These are the recommended way to construct `Encoding` values. They
+// mirror the existing variants — `base32_rfc4648/0` for
+// `Base32(RFC4648)`, `base64_standard/0` for `Base64(Standard)`, etc. —
+// and stay stable across releases even when the variant ADTs change
+// shape. The constructor list is still public for now (so existing
+// `Base32(RFC4648)` call sites keep working unchanged); promoting the
+// types to `pub opaque type` for full constructor hiding is tracked
+// as a separate larger refactor (see #32 follow-up notes).
+// ---------------------------------------------------------------------------
+
+/// Binary (base-2) encoding.
+pub fn base2() -> Encoding {
+  Base2
+}
+
+/// Octal (base-8) encoding.
+pub fn base8() -> Encoding {
+  Base8
+}
+
+/// Decimal (base-10) encoding.
+pub fn base10() -> Encoding {
+  Base10
+}
+
+/// Hexadecimal (base-16) encoding.
+pub fn base16() -> Encoding {
+  Base16
+}
+
+/// RFC 4648 standard Base32.
+pub fn base32_rfc4648() -> Encoding {
+  Base32(RFC4648)
+}
+
+/// RFC 4648 Base32 with extended hex alphabet.
+pub fn base32_hex() -> Encoding {
+  Base32(Hex)
+}
+
+/// Crockford's Base32.
+pub fn base32_crockford() -> Encoding {
+  Base32(Crockford)
+}
+
+/// Crockford's Base32 with mod-37 check symbol.
+pub fn base32_crockford_check() -> Encoding {
+  Base32(CrockfordCheck)
+}
+
+/// Clockwork Base32 (human-friendly, no padding).
+pub fn base32_clockwork() -> Encoding {
+  Base32(Clockwork)
+}
+
+/// z-base-32 (human-oriented, no padding).
+pub fn base32_z_base32() -> Encoding {
+  Base32(ZBase32)
+}
+
+/// Base36 encoding.
+pub fn base36() -> Encoding {
+  Base36
+}
+
+/// Base45 encoding (RFC 9285).
+pub fn base45() -> Encoding {
+  Base45
+}
+
+/// Base58 with the Bitcoin alphabet.
+pub fn base58_bitcoin() -> Encoding {
+  Base58(Bitcoin)
+}
+
+/// Base58 with the Flickr alphabet.
+pub fn base58_flickr() -> Encoding {
+  Base58(Flickr)
+}
+
+/// Base62 encoding.
+pub fn base62() -> Encoding {
+  Base62
+}
+
+/// RFC 4648 standard Base64 (with padding).
+pub fn base64_standard() -> Encoding {
+  Base64(Standard)
+}
+
+/// URL-safe Base64 with padding (RFC 4648 section 5).
+pub fn base64_url_safe() -> Encoding {
+  Base64(UrlSafe)
+}
+
+/// Standard Base64 without padding.
+pub fn base64_no_padding() -> Encoding {
+  Base64(NoPadding)
+}
+
+/// URL-safe Base64 without padding.
+pub fn base64_url_safe_no_padding() -> Encoding {
+  Base64(UrlSafeNoPadding)
+}
+
+/// Dragon Quest revival password style Base64 (hiragana).
+pub fn base64_dq() -> Encoding {
+  Base64(DQ)
+}
+
+/// btoa-style Ascii85.
+pub fn base85_btoa() -> Encoding {
+  Base85(Btoa)
+}
+
+/// Adobe Ascii85 with `<~` `~>` delimiters.
+pub fn base85_adobe() -> Encoding {
+  Base85(Adobe)
+}
+
+/// RFC 1924 Base85.
+pub fn base85_rfc1924() -> Encoding {
+  Base85(Rfc1924)
+}
+
+/// ZeroMQ Z85 Base85.
+pub fn base85_z85() -> Encoding {
+  Base85(Z85)
+}
+
+/// Base91 encoding.
+pub fn base91() -> Encoding {
+  Base91
+}

--- a/test/smart_constructors_test.gleam
+++ b/test/smart_constructors_test.gleam
@@ -1,0 +1,112 @@
+//// Smoke test for the `core/encoding` smart constructors. Each
+//// constructor returns the same `Encoding` value as the direct ADT
+//// constructor — the test pins that equivalence so a future refactor
+//// to `pub opaque type` can keep external callers on the smart
+//// constructor path with no behavioural change.
+
+import yabase/core/encoding.{
+  Adobe, Base10, Base16, Base2, Base32, Base36, Base45, Base58, Base62, Base64,
+  Base8, Base85, Base91, Bitcoin, Btoa, Clockwork, Crockford, CrockfordCheck, DQ,
+  Flickr, Hex, NoPadding, RFC4648, Rfc1924, Standard, UrlSafe, UrlSafeNoPadding,
+  Z85, ZBase32,
+}
+
+pub fn base2_smart_constructor_test() -> Nil {
+  assert encoding.base2() == Base2
+}
+
+pub fn base8_smart_constructor_test() -> Nil {
+  assert encoding.base8() == Base8
+}
+
+pub fn base10_smart_constructor_test() -> Nil {
+  assert encoding.base10() == Base10
+}
+
+pub fn base16_smart_constructor_test() -> Nil {
+  assert encoding.base16() == Base16
+}
+
+pub fn base32_rfc4648_smart_constructor_test() -> Nil {
+  assert encoding.base32_rfc4648() == Base32(RFC4648)
+}
+
+pub fn base32_hex_smart_constructor_test() -> Nil {
+  assert encoding.base32_hex() == Base32(Hex)
+}
+
+pub fn base32_crockford_smart_constructor_test() -> Nil {
+  assert encoding.base32_crockford() == Base32(Crockford)
+}
+
+pub fn base32_crockford_check_smart_constructor_test() -> Nil {
+  assert encoding.base32_crockford_check() == Base32(CrockfordCheck)
+}
+
+pub fn base32_clockwork_smart_constructor_test() -> Nil {
+  assert encoding.base32_clockwork() == Base32(Clockwork)
+}
+
+pub fn base32_z_base32_smart_constructor_test() -> Nil {
+  assert encoding.base32_z_base32() == Base32(ZBase32)
+}
+
+pub fn base36_smart_constructor_test() -> Nil {
+  assert encoding.base36() == Base36
+}
+
+pub fn base45_smart_constructor_test() -> Nil {
+  assert encoding.base45() == Base45
+}
+
+pub fn base58_bitcoin_smart_constructor_test() -> Nil {
+  assert encoding.base58_bitcoin() == Base58(Bitcoin)
+}
+
+pub fn base58_flickr_smart_constructor_test() -> Nil {
+  assert encoding.base58_flickr() == Base58(Flickr)
+}
+
+pub fn base62_smart_constructor_test() -> Nil {
+  assert encoding.base62() == Base62
+}
+
+pub fn base64_standard_smart_constructor_test() -> Nil {
+  assert encoding.base64_standard() == Base64(Standard)
+}
+
+pub fn base64_url_safe_smart_constructor_test() -> Nil {
+  assert encoding.base64_url_safe() == Base64(UrlSafe)
+}
+
+pub fn base64_no_padding_smart_constructor_test() -> Nil {
+  assert encoding.base64_no_padding() == Base64(NoPadding)
+}
+
+pub fn base64_url_safe_no_padding_smart_constructor_test() -> Nil {
+  assert encoding.base64_url_safe_no_padding() == Base64(UrlSafeNoPadding)
+}
+
+pub fn base64_dq_smart_constructor_test() -> Nil {
+  assert encoding.base64_dq() == Base64(DQ)
+}
+
+pub fn base85_btoa_smart_constructor_test() -> Nil {
+  assert encoding.base85_btoa() == Base85(Btoa)
+}
+
+pub fn base85_adobe_smart_constructor_test() -> Nil {
+  assert encoding.base85_adobe() == Base85(Adobe)
+}
+
+pub fn base85_rfc1924_smart_constructor_test() -> Nil {
+  assert encoding.base85_rfc1924() == Base85(Rfc1924)
+}
+
+pub fn base85_z85_smart_constructor_test() -> Nil {
+  assert encoding.base85_z85() == Base85(Z85)
+}
+
+pub fn base91_smart_constructor_test() -> Nil {
+  assert encoding.base91() == Base91
+}


### PR DESCRIPTION
## Summary

Add 25 smart constructors to \`yabase/core/encoding\`, one per existing
variant — \`base32_rfc4648/0\` for \`Base32(RFC4648)\`, \`base64_standard/0\`
for \`Base64(Standard)\`, etc. The smart-constructor signature is the
piece that stays stable across releases even when the underlying
variant ADT changes shape, so external callers that construct via
\`encoding.base32_rfc4648()\` get insulation from variant-list changes
that would otherwise force a SemVer-major. Closes the non-breaking
first half of #32; the opaque migration is queued as follow-up.

## Changes

- \`src/yabase/core/encoding.gleam\`: add 25 \`pub fn\` smart constructors
  alongside the existing \`pub type Encoding\` definition. Naming
  follows the variant: bare-Encoding cases get bare names
  (\`base2/0\`, \`base16/0\`, \`base91/0\`), wrapped-variant cases get the
  flattened form (\`base32_rfc4648/0\`, \`base64_url_safe_no_padding/0\`,
  \`base85_z85/0\`).
- \`test/smart_constructors_test.gleam\`: new 25-test smoke module that
  pins each constructor's equivalence to the underlying ADT
  constructor (\`encoding.base32_rfc4648() == Base32(RFC4648)\`).
- \`CHANGELOG.md\`: \`### Added\` entry under \`[Unreleased]\` plus a
  \`### Notes\` paragraph documenting why the opaque migration is
  separate.

## Design Decisions

- **Smart constructors first, opacity later.** The full plan in #32
  is to promote \`Encoding\` and the four variant ADTs (\`Base32Variant\`,
  \`Base58Variant\`, \`Base64Variant\`, \`Base85Variant\`) to
  \`pub opaque type\`. That step is BREAKING for any caller that today
  writes \`case enc { Base64(_) -> ... }\` outside the package, and it
  requires moving the dispatcher pattern match and the multibase
  prefix table out of \`core/dispatcher\` / \`core/multibase\` into the
  type's defining module so the pattern match stays inside the opaque
  boundary. Landing the smart constructors as a non-breaking minor
  first means external callers can migrate their construction sites
  on the current release without waiting for the bigger refactor.
- **Equivalence pinned in tests.** When the opaque migration lands,
  the smart-constructor test becomes the regression gate — if any
  constructor accidentally drifts shape, the smoke test catches it.
- **Naming follows the existing constructor names.** \`base32_rfc4648/0\`
  rather than \`rfc4648_base32/0\` so the file is grep-able from the
  variant the user already sees in their codebase.

## Limitations

- Variant ADTs (\`Base32Variant\`, \`Base58Variant\`, \`Base64Variant\`,
  \`Base85Variant\`) and \`Encoding\` are still \`pub type\` (not
  \`pub opaque\`). External callers that pattern-match on the
  constructor list still compile — the BREAKING half of #32 is
  follow-up work.