### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-04-28
+
 ### Changed
 
 - **`Encoding` and variant ADTs are now `pub opaque type` (BREAKING)**.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.9.0"
+version = "0.10.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Changed

- **`Encoding` and variant ADTs are now `pub opaque type` (BREAKING)**.
  `Encoding`, `Base32Variant`, `Base58Variant`, `Base64Variant`, and
  `Base85Variant` no longer expose their constructors to package-
  external callers. Code that previously wrote `Base32(RFC4648)` or
  pattern-matched `case enc { Base64(_) -> ... }` will not compile;
  switch construction sites to the smart constructors added in
  v0.9.0 (`encoding.base32_rfc4648()`, `encoding.base64_standard()`,
  …) and replace pattern matches with field access on `Decoded`
  (the `encoding` and `data` fields stay public). Adding a new
  alphabet is now a non-breaking minor instead of a SemVer-major.
  (#32)
- **`yabase/core/dispatcher` removed**. Its `encode/2` and
  `decode_as/2` move into `yabase/core/encoding` (and stay reachable
  via the existing top-level `yabase.encode/2` / `yabase.decode/2`
  facade). External callers using the top-level facade are
  unaffected; callers that imported `yabase/core/dispatcher` directly
  switch to `yabase/core/encoding`. (#32)
- **`CodecError` and Bech32 / Base58Check result types moved to
  `yabase/core/error`**. `import yabase/core/encoding.{type CodecError}`
  keeps working through a type alias, but the constructor
  short-imports (`InvalidCharacter`, `InvalidLength`, `Overflow`,
  `Bech32Decoded`, …) only resolve from `yabase/core/error` now.
  Update import lines accordingly. (#32)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.10.0
  * Release documentation updated with version date

<!-- end of auto-generated comment: release notes by coderabbit.ai -->