### PR TITLE
feat(base64,base32): add decode_strict variants for RFC 4648 §3.5 canonical encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Strict-canonical decoders for base64 and base32**, opting into the
+  RFC 4648 §3.5 rejection of non-canonical encodings (where pad bits
+  in a final partial block are non-zero). New surface:
+  - `yabase/base64/standard.decode_strict/1` — same shape as `decode/1`
+    but returns `Error(NonCanonical)` when the trailing pad bits are
+    set
+  - `yabase/base32/rfc4648.decode_strict/1` — same shape, with the
+    canonical re-encoding compared case-insensitively
+  - `yabase/facade.decode_base64_strict/1` and `decode_base32_strict/1`
+    re-export the above on the high-level API
+  - new `NonCanonical` variant on `CodecError` (minor API
+    addition — exhaustive case statements over `CodecError` need a new
+    arm)
+  Useful for signature verification, content-addressable storage, and
+  any audit-style use case where the wire encoding's uniqueness is
+  part of the contract. The lenient `decode/1` paths are unchanged
+  for backwards compatibility. (#39)
+
 ## [0.10.0] - 2026-04-28
 
 ### Changed

--- a/src/yabase/base32/rfc4648.gleam
+++ b/src/yabase/base32/rfc4648.gleam
@@ -3,7 +3,9 @@ import gleam/bit_array
 import gleam/bool
 import gleam/list
 import gleam/string
-import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/error.{
+  type CodecError, InvalidCharacter, InvalidLength, NonCanonical,
+}
 
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
 
@@ -52,6 +54,30 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
   case validate_alphabet(upper, 0) {
     Error(e) -> Error(e)
     Ok(Nil) -> decode_validated(upper)
+  }
+}
+
+/// Decode `input` and additionally reject non-canonical encodings
+/// per RFC 4648 §3.5: the trailing pad bits in a final block of
+/// fewer than 5 bytes must be zero. Useful for signature
+/// verification and content-addressable storage, where the wire
+/// encoding's uniqueness is part of the contract.
+///
+/// Returns `Error(NonCanonical)` when the input decodes to bytes
+/// whose canonical re-encoding (uppercase alphabet, padded) differs
+/// from the input. The check is case-insensitive and tolerates
+/// already-padded vs unpadded input — the canonical form is the
+/// uppercase, padded shape produced by `encode/1`. Other failure
+/// modes (`InvalidCharacter`, `InvalidLength`) are surfaced
+/// unchanged from `decode/1`.
+pub fn decode_strict(input: String) -> Result(BitArray, CodecError) {
+  case decode(input) {
+    Error(e) -> Error(e)
+    Ok(bytes) ->
+      case encode(bytes) == string.uppercase(input) {
+        True -> Ok(bytes)
+        False -> Error(NonCanonical)
+      }
   }
 }
 

--- a/src/yabase/base64/standard.gleam
+++ b/src/yabase/base64/standard.gleam
@@ -3,7 +3,9 @@ import gleam/bit_array
 import gleam/bool
 import gleam/list
 import gleam/string
-import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/error.{
+  type CodecError, InvalidCharacter, InvalidLength, NonCanonical,
+}
 
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
@@ -48,6 +50,27 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
         _ -> Error(InvalidLength(len))
       }
     }
+  }
+}
+
+/// Decode `input` and additionally reject non-canonical encodings
+/// per RFC 4648 §3.5: the trailing pad bits in a 1- or 2-byte final
+/// block must be zero. Useful for signature verification and
+/// content-addressable storage, where the wire encoding's uniqueness
+/// is part of the contract.
+///
+/// Returns `Error(NonCanonical)` when the input decodes to bytes
+/// whose canonical re-encoding differs from the original input.
+/// Other failure modes (`InvalidCharacter`, `InvalidLength`) are
+/// surfaced unchanged from `decode/1`.
+pub fn decode_strict(input: String) -> Result(BitArray, CodecError) {
+  case decode(input) {
+    Error(e) -> Error(e)
+    Ok(bytes) ->
+      case encode(bytes) == input {
+        True -> Ok(bytes)
+        False -> Error(NonCanonical)
+      }
   }
 }
 

--- a/src/yabase/core/error.gleam
+++ b/src/yabase/core/error.gleam
@@ -21,6 +21,14 @@ pub type CodecError {
   InvalidChecksum
   /// Invalid human-readable part in Bech32/Bech32m.
   InvalidHrp(reason: String)
+  /// The decoded bytes are valid but the wire encoding is not the
+  /// canonical form. Per RFC 4648 §3.5, the pad bits in base32 /
+  /// base64 must be zero on the encoder side; decoders MAY reject
+  /// non-canonical input. The strict-variant decoders surface this
+  /// rejection so callers that need wire-form uniqueness (signature
+  /// verification, content-addressable storage, audit comparisons)
+  /// can opt into it.
+  NonCanonical
 }
 
 /// Bech32 encoding variant.

--- a/src/yabase/facade.gleam
+++ b/src/yabase/facade.gleam
@@ -101,6 +101,15 @@ pub fn decode_base32(input: String) -> Result(BitArray, CodecError) {
   rfc4648.decode(input)
 }
 
+/// Decode a Base32 (RFC 4648) string and additionally reject
+/// non-canonical encodings per §3.5 — the trailing pad bits in a
+/// final block of fewer than 5 bytes must be zero. Returns
+/// `Error(NonCanonical)` for inputs whose pad bits are set. See
+/// `yabase/base32/rfc4648.decode_strict` for the full contract.
+pub fn decode_base32_strict(input: String) -> Result(BitArray, CodecError) {
+  rfc4648.decode_strict(input)
+}
+
 /// Encode a BitArray to Base32 Hex (extended hex alphabet, RFC 4648) with padding.
 pub fn encode_base32_hex(data: BitArray) -> String {
   base32_hex.encode(data)
@@ -221,6 +230,15 @@ pub fn encode_base64(data: BitArray) -> String {
 /// Decode a standard Base64 string to a BitArray.
 pub fn decode_base64(input: String) -> Result(BitArray, CodecError) {
   standard.decode(input)
+}
+
+/// Decode a standard Base64 string and additionally reject
+/// non-canonical encodings per RFC 4648 §3.5 — the trailing pad
+/// bits in a 1- or 2-byte final block must be zero. Returns
+/// `Error(NonCanonical)` for inputs whose pad bits are set. See
+/// `yabase/base64/standard.decode_strict` for the full contract.
+pub fn decode_base64_strict(input: String) -> Result(BitArray, CodecError) {
+  standard.decode_strict(input)
 }
 
 /// Encode a BitArray to URL-safe Base64 (- instead of +, _ instead of /) with padding.

--- a/test/base32_test.gleam
+++ b/test/base32_test.gleam
@@ -3,7 +3,9 @@ import yabase/base32/clockwork
 import yabase/base32/crockford
 import yabase/base32/hex as base32_hex
 import yabase/base32/rfc4648
-import yabase/core/error.{InvalidCharacter, InvalidChecksum, InvalidLength}
+import yabase/core/error.{
+  InvalidCharacter, InvalidChecksum, InvalidLength, NonCanonical,
+}
 
 // ===== RFC4648 =====
 
@@ -393,4 +395,31 @@ pub fn clockwork_decode_i_l_as_one_test() -> Nil {
   let encoded = clockwork.encode(data)
   let with_l = string.replace(encoded, "1", "L")
   assert clockwork.decode(with_l) == Ok(data)
+}
+
+// ===== rfc4648.decode_strict (RFC 4648 §3.5 canonical-encoding) =====
+
+pub fn rfc4648_decode_strict_canonical_passes_test() -> Nil {
+  // Canonical encoding of "f" is "MY======" — pad bits zero.
+  assert rfc4648.decode_strict("MY======") == Ok(<<"f":utf8>>)
+}
+
+pub fn rfc4648_decode_strict_non_canonical_rejected_test() -> Nil {
+  // Non-canonical: "MB======" decodes to a one-byte value but the
+  // last alphabet character ('B') has non-zero bits in the
+  // pad-bit positions. Canonical for one byte uses only A/I/Q/Y as
+  // the second character (depending on first), making the trailing
+  // 2 bits zero.
+  assert rfc4648.decode_strict("MB======") == Error(NonCanonical)
+}
+
+pub fn rfc4648_decode_strict_full_block_passes_test() -> Nil {
+  // Full-block encodings have no pad bits to non-canonicalise.
+  assert rfc4648.decode_strict("MZXW6YTBOI======") == Ok(<<"foobar":utf8>>)
+}
+
+pub fn rfc4648_decode_strict_lowercase_canonical_passes_test() -> Nil {
+  // Strict accepts case-insensitive input but compares against the
+  // uppercase canonical form.
+  assert rfc4648.decode_strict("my======") == Ok(<<"f":utf8>>)
 }

--- a/test/base64_test.gleam
+++ b/test/base64_test.gleam
@@ -3,7 +3,7 @@ import yabase/base64/nopadding
 import yabase/base64/standard
 import yabase/base64/urlsafe
 import yabase/base64/urlsafe_nopadding
-import yabase/core/error.{InvalidCharacter, InvalidLength}
+import yabase/core/error.{InvalidCharacter, InvalidLength, NonCanonical}
 
 // ===== Standard =====
 
@@ -461,6 +461,50 @@ pub fn dq_decode_stray_char_in_middle_test() -> Nil {
   // 4-char aligned input with invalid first char
   assert case dq.decode("Xいうえ") {
     Error(InvalidCharacter("X", 0)) -> True
+    _ -> False
+  }
+}
+
+// ===== decode_strict (RFC 4648 §3.5 canonical-encoding check) =====
+
+pub fn standard_decode_strict_canonical_passes_test() -> Nil {
+  // Canonical encoding of "f" — pad bits in 'g' are zero.
+  assert standard.decode_strict("Zg==") == Ok(<<"f":utf8>>)
+}
+
+pub fn standard_decode_strict_non_canonical_rejected_test() -> Nil {
+  // Non-canonical: "Zh==" decodes to <<0x66>> too, but the pad bits
+  // in 'h' are non-zero (canonical form is "Zg==").
+  assert standard.decode_strict("Zh==") == Error(NonCanonical)
+}
+
+pub fn standard_decode_strict_one_pad_non_canonical_rejected_test() -> Nil {
+  // Non-canonical 2-byte input with 1 pad char: "Zm9=" decodes to
+  // "fo" the same as the canonical "Zm8=", but the trailing 2 bits
+  // of '9' (value 61 = 111101) are non-zero. The canonical form
+  // ends in '8' (value 60 = 111100).
+  assert standard.decode_strict("Zm9=") == Error(NonCanonical)
+}
+
+pub fn standard_decode_strict_full_block_passes_test() -> Nil {
+  // Full-block encodings (no padding) cannot be non-canonical —
+  // every bit is data, no pad bits exist.
+  assert standard.decode_strict("Zm9v") == Ok(<<"foo":utf8>>)
+}
+
+pub fn standard_decode_strict_propagates_invalid_character_test() -> Nil {
+  // Strict mode should still surface alphabet-validation errors
+  // unchanged.
+  assert case standard.decode_strict("Z!==") {
+    Error(InvalidCharacter("!", 1)) -> True
+    _ -> False
+  }
+}
+
+pub fn standard_decode_strict_propagates_invalid_length_test() -> Nil {
+  // Strict mode should still surface length errors unchanged.
+  assert case standard.decode_strict("Zg=") {
+    Error(InvalidLength(_)) -> True
     _ -> False
   }
 }

--- a/test/facade_test.gleam
+++ b/test/facade_test.gleam
@@ -1,4 +1,4 @@
-import yabase/core/error.{InvalidLength}
+import yabase/core/error.{InvalidLength, NonCanonical}
 import yabase/facade
 
 // Thin wiring tests: verify each facade function delegates correctly.
@@ -161,4 +161,24 @@ pub fn rfc1924_base85_roundtrip_test() -> Nil {
   let data = <<1, 2, 3, 4>>
   let assert Ok(encoded) = facade.encode_rfc1924_base85(data)
   assert facade.decode_rfc1924_base85(encoded) == Ok(data)
+}
+
+// --- decode_strict facade wiring ---
+
+pub fn decode_base64_strict_canonical_test() -> Nil {
+  // Canonical encoding of "f" — passes strict.
+  assert facade.decode_base64_strict("Zg==") == Ok(<<"f":utf8>>)
+}
+
+pub fn decode_base64_strict_non_canonical_test() -> Nil {
+  // Non-canonical (pad bits non-zero) — rejected by strict.
+  assert facade.decode_base64_strict("Zh==") == Error(NonCanonical)
+}
+
+pub fn decode_base32_strict_canonical_test() -> Nil {
+  assert facade.decode_base32_strict("MY======") == Ok(<<"f":utf8>>)
+}
+
+pub fn decode_base32_strict_non_canonical_test() -> Nil {
+  assert facade.decode_base32_strict("MB======") == Error(NonCanonical)
 }


### PR DESCRIPTION
## Summary

Add strict-canonical decoders for base64 and base32 that reject non-canonical encodings per RFC 4648 §3.5. The lenient `decode/1` paths are unchanged for backwards compatibility; callers that need wire-form uniqueness (signature verification, content-addressable storage, audit comparisons) can opt into the strict variant.

## Changes

- `src/yabase/core/error.gleam`: new `NonCanonical` variant on `CodecError` for the rejection signal
- `src/yabase/base64/standard.gleam`: new `decode_strict/1` — round-trips the result through `encode/1` and rejects when the canonical encoding differs from the input
- `src/yabase/base32/rfc4648.gleam`: new `decode_strict/1` — same shape, comparison runs against `string.uppercase(input)` so case-insensitive input is still accepted
- `src/yabase/facade.gleam`: re-exports both as `decode_base64_strict/1` and `decode_base32_strict/1`
- `test/base64_test.gleam`, `test/base32_test.gleam`, `test/facade_test.gleam`: cover canonical, non-canonical (`Zh==`, `Zm9=` for base64; `MB======` for base32), full-block, lowercase-canonical (base32), and error-passthrough cases
- `CHANGELOG.md`: `Added` entry under `[Unreleased]`

## Design Decisions

1. **Round-trip-and-compare** rather than re-implementing decode with a strict-pad-bit check inline. Pros: zero risk of duplicating decoder logic, easy to audit, naturally handles every edge case (padding length, alphabet, etc.). Cons: an extra encode pass — acceptable for the explicitly opt-in "strict" path.
2. **Case-insensitive base32**: the RFC 4648 base32 decoder already accepts mixed case, and the canonical form is uppercase. `decode_strict` compares the input against `string.uppercase(input)` so a lowercase-but-otherwise-canonical input is accepted (the round-tripped uppercase form matches `string.uppercase` of the lowercase input).
3. **`NonCanonical` is a new `CodecError` variant**. Adding a variant is a minor API change for callers that pattern-match exhaustively over `CodecError`, but it's the right shape: the alternative (overloading `InvalidCharacter` or `InvalidLength`) would be misleading.
4. **Only base64-standard and base32-rfc4648 in this PR**. URL-safe base64, no-padding variants, base32-hex / Crockford / Clockwork all have analogous canonicality concerns; they're left for follow-up to keep the diff focused. The same `round-trip-and-compare` pattern transfers cleanly when the time comes.

Closes #39
