### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-30
+
 ### Added
 
 - **Strict-canonical decoders for base64 and base32**, opting into the

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.10.0"
+version = "0.11.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Added

- **Strict-canonical decoders for base64 and base32**, opting into the
  RFC 4648 §3.5 rejection of non-canonical encodings (where pad bits
  in a final partial block are non-zero). New surface:
  - `yabase/base64/standard.decode_strict/1` — same shape as `decode/1`
    but returns `Error(NonCanonical)` when the trailing pad bits are
    set
  - `yabase/base32/rfc4648.decode_strict/1` — same shape, with the
    canonical re-encoding compared case-insensitively
  - `yabase/facade.decode_base64_strict/1` and `decode_base32_strict/1`
    re-export the above on the high-level API
  - new `NonCanonical` variant on `CodecError` (minor API
    addition — exhaustive case statements over `CodecError` need a new
    arm)
  Useful for signature verification, content-addressable storage, and
  any audit-style use case where the wire encoding's uniqueness is
  part of the contract. The lenient `decode/1` paths are unchanged
  for backwards compatibility. (#39)
