### PR TITLE
ci(javascript): run full test suite on Node 18 and 22 (#42, #47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,13 @@ jobs:
       - run: gleam deps download
       - run: gleam test
 
-  build-javascript:
-    name: Build (JavaScript)
+  test-javascript:
+    name: Test (JavaScript, Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["18", "22"]
     steps:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
@@ -74,6 +78,6 @@ jobs:
           gleam-version: "1.15"
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node-version }}
       - run: gleam deps download
-      - run: gleam build --target javascript
+      - run: gleam test --target javascript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **ci(javascript)**: The JavaScript CI lane now runs the full test
+  suite (`gleam test --target javascript`) instead of build-only, and
+  exercises both Node 18 (the documented support floor) and Node 22.
+  Closes the gap where JavaScript-target regressions in the public
+  codec surface could ship without being caught. (#42, #47)
+
 ## [0.11.0] - 2026-04-30
 
 ### Added


### PR DESCRIPTION
## Summary

Run the full Gleam test suite on the JavaScript target instead of just building it, and exercise both Node 18 (the documented support floor) and Node 22. Closes #42 (test-only → test) and #47 (Node 18 lane).

## Changes

- `.github/workflows/ci.yml`
  - rename the `build-javascript` job to `test-javascript`
  - convert the single-runner job into a `node-version` matrix over `["18", "22"]` with `fail-fast: false`
  - replace `gleam build --target javascript` with `gleam test --target javascript` so the public codec surface is actually exercised on the JS target
- `CHANGELOG.md` — `[Unreleased]` entry.

## Design Decisions

- Combined #42 (test-only → test) and #47 (Node 18 matrix) into a single PR. The acceptance criteria of #47 explicitly says it lands "after #42 upgrades the JavaScript lane from build-only to real tests"; doing both together avoids a redundant intermediate state where build-only Node 18 coverage exists but proves nothing (a build pass does not exercise Node).
- Kept Node 22 as part of the matrix instead of replacing it, so the upper bound stays exercised.
- `fail-fast: false` so a regression on either lane stays visible — matching the same pattern recently adopted in dataprep CI.
- Did not change the existing Erlang `test` matrix (OTP 26/27/28). That matrix is unrelated to the JavaScript-lane gap this PR addresses.

Closes #42
Closes #47
