### PR TITLE
ci(javascript): test the public codec surface, not build-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,14 @@ jobs:
       - run: gleam deps download
       - run: gleam test
 
-  build-javascript:
-    name: Build (JavaScript)
+  test-javascript:
+    name: Test (JavaScript / Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - "22"
     steps:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
@@ -74,6 +79,7 @@ jobs:
           gleam-version: "1.15"
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node }}
       - run: gleam deps download
       - run: gleam build --target javascript
+      - run: gleam test --target javascript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,26 @@ permissions:
   contents: write
 
 jobs:
+  test-javascript:
+    name: Test (JavaScript / Node 22)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.15"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: gleam deps download
+      - run: gleam build --target javascript
+      - run: gleam test --target javascript
+
   publish:
     name: Publish to Hex
     runs-on: ubuntu-latest
+    needs: test-javascript
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **JavaScript-target test lane in CI.** CI now runs `gleam test
+  --target javascript` against Node.js, exercising the public codec
+  surface on JS instead of merely confirming it compiles. The release
+  workflow runs the same JS test step before publishing to Hex so the
+  release matrix matches CI. (#42)
+
+### Changed
+
+- **JS-target-limited tests are explicitly isolated**, not silently
+  skipped. Tests that exercise codecs whose internals rely on
+  arbitrary-precision integer arithmetic (base32 Crockford, base58,
+  base58check, base36, and the matching multibase prefixes) and
+  the `intid` `*_above_cap_test` variants on `int64_max + 1` are
+  marked `@target(erlang)`. They remain covered on BEAM and are
+  intentionally excluded on JavaScript, where 53-bit `Number`
+  precision cannot represent the inputs. The README "Supported
+  targets" section documents this policy. (#42)
+
 ## [0.11.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Yet Another Base -- a unified, type-safe interface for multiple binary-to-text e
   53-bit integers. base16, base64, base91, base32 RFC4648 and
   ascii85 are JavaScript-safe.
 
+CI runs `gleam test --target javascript` against Node.js to catch
+JavaScript-target regressions on the public codec surface. Tests
+that exercise the bignum-backed codecs above are isolated with
+`@target(erlang)` so they do not run on JavaScript — they remain
+covered on BEAM, but are intentionally skipped on JS rather than
+silently passing or failing.
+
 ## Install
 
 ```sh

--- a/test/base32_test.gleam
+++ b/test/base32_test.gleam
@@ -225,6 +225,7 @@ pub fn crockford_encode_numeric_1023_test() -> Nil {
   assert crockford.encode(<<3, 255>>) == "ZZ"
 }
 
+@target(erlang)
 pub fn crockford_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert crockford.decode(crockford.encode(data)) == Ok(data)

--- a/test/base58_test.gleam
+++ b/test/base58_test.gleam
@@ -8,6 +8,7 @@ pub fn bitcoin_encode_empty_test() -> Nil {
   assert bitcoin.encode(<<>>) == ""
 }
 
+@target(erlang)
 pub fn bitcoin_encode_hello_test() -> Nil {
   assert bitcoin.encode(<<"Hello World":utf8>>) == "JxF12TrwUP45BMd"
 }
@@ -20,6 +21,7 @@ pub fn bitcoin_decode_empty_test() -> Nil {
   assert bitcoin.decode("") == Ok(<<>>)
 }
 
+@target(erlang)
 pub fn bitcoin_decode_hello_test() -> Nil {
   assert bitcoin.decode("JxF12TrwUP45BMd") == Ok(<<"Hello World":utf8>>)
 }
@@ -44,6 +46,7 @@ pub fn bitcoin_decode_invalid_char_l_test() -> Nil {
   assert bitcoin.decode("l") == Error(InvalidCharacter("l", 0))
 }
 
+@target(erlang)
 pub fn bitcoin_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert bitcoin.decode(bitcoin.encode(data)) == Ok(data)
@@ -73,12 +76,14 @@ pub fn flickr_encode_empty_test() -> Nil {
   assert flickr.encode(<<>>) == ""
 }
 
+@target(erlang)
 pub fn flickr_encode_hello_test() -> Nil {
   let encoded = flickr.encode(<<"Hello World":utf8>>)
   // Flickr swaps upper/lowercase relative to Bitcoin
   assert encoded == "iXf12sRWto45bmC"
 }
 
+@target(erlang)
 pub fn flickr_decode_hello_test() -> Nil {
   assert flickr.decode("iXf12sRWto45bmC") == Ok(<<"Hello World":utf8>>)
 }
@@ -87,6 +92,7 @@ pub fn flickr_decode_invalid_char_zero_test() -> Nil {
   assert flickr.decode("0") == Error(InvalidCharacter("0", 0))
 }
 
+@target(erlang)
 pub fn flickr_roundtrip_test() -> Nil {
   let data = <<"Hello, World!":utf8>>
   assert flickr.decode(flickr.encode(data)) == Ok(data)
@@ -126,11 +132,13 @@ pub fn bitcoin_flickr_same_data_test() -> Nil {
 
 // === Cross-reference vectors (paulmillr/scure-base) ===
 
+@target(erlang)
 pub fn scure_hello_world_test() -> Nil {
   assert bitcoin.encode(<<"hello world":utf8>>) == "StV1DL6CwTryKyV"
   assert bitcoin.decode("StV1DL6CwTryKyV") == Ok(<<"hello world":utf8>>)
 }
 
+@target(erlang)
 pub fn scure_hello_world_excl_test() -> Nil {
   assert bitcoin.encode(<<"Hello World!":utf8>>) == "2NEpo7TZRRrLZSi2U"
   assert bitcoin.decode("2NEpo7TZRRrLZSi2U") == Ok(<<"Hello World!":utf8>>)
@@ -141,6 +149,7 @@ pub fn scure_leading_zeros_test() -> Nil {
   assert bitcoin.decode("11233QC4") == Ok(<<0, 0, 0x28, 0x7f, 0xb4, 0xcd>>)
 }
 
+@target(erlang)
 pub fn scure_quick_brown_fox_test() -> Nil {
   let data = <<"The quick brown fox jumps over the lazy dog.":utf8>>
   assert bitcoin.encode(data)
@@ -152,6 +161,7 @@ pub fn scure_short_bytes_test() -> Nil {
   assert bitcoin.decode("ABnLTmg") == Ok(<<0x51, 0x6b, 0x6f, 0xcd, 0x0f>>)
 }
 
+@target(erlang)
 pub fn scure_leading_zeros_hello_test() -> Nil {
   assert bitcoin.encode(<<0, 0, "hello world":utf8>>) == "11StV1DL6CwTryKyV"
   assert bitcoin.decode("11StV1DL6CwTryKyV") == Ok(<<0, 0, "hello world":utf8>>)

--- a/test/base58check_test.gleam
+++ b/test/base58check_test.gleam
@@ -5,6 +5,7 @@ import yabase/core/error.{
 
 // --- Roundtrip ---
 
+@target(erlang)
 pub fn roundtrip_version0_test() -> Nil {
   let payload = <<1, 2, 3, 4, 5>>
   let assert Ok(encoded) = base58check.encode(0, payload)
@@ -13,6 +14,7 @@ pub fn roundtrip_version0_test() -> Nil {
   assert decoded.payload == payload
 }
 
+@target(erlang)
 pub fn roundtrip_version5_test() -> Nil {
   let payload = <<0xde, 0xad, 0xbe, 0xef>>
   let assert Ok(encoded) = base58check.encode(5, payload)
@@ -72,6 +74,7 @@ pub fn encode_version_256_same_as_0_prevented_test() -> Nil {
 //   payload = 0x010966776006953D5567439E5E39F86A0D273BEE
 // This verifies SHA-256 double-hash correctness against an external reference.
 
+@target(erlang)
 pub fn bitcoin_wiki_vector_decode_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM")
@@ -135,6 +138,7 @@ pub fn decode_invalid_char_middle_test() -> Nil {
 // === Cross-reference: bitcoinjs/bs58check fixtures ===
 // Source: https://github.com/bitcoinjs/bs58check
 
+@target(erlang)
 pub fn bs58check_vector_1agn_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i")
@@ -164,6 +168,7 @@ pub fn bs58check_vector_1agn_test() -> Nil {
     >>
 }
 
+@target(erlang)
 pub fn bs58check_vector_3cmn_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("3CMNFxN1oHBc4R1EpboAL5yzHGgE611Xou")
@@ -193,12 +198,14 @@ pub fn bs58check_vector_3cmn_test() -> Nil {
     >>
 }
 
+@target(erlang)
 pub fn bs58check_vector_mo9n_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs")
   assert decoded.version == 0x6f
 }
 
+@target(erlang)
 pub fn bs58check_vector_1ax4_test() -> Nil {
   let assert Ok(decoded) =
     base58check.decode("1Ax4gZtb7gAit2TivwejZHYtNNLT18PUXJ")

--- a/test/intid_test.gleam
+++ b/test/intid_test.gleam
@@ -234,6 +234,7 @@ pub fn decode_int_base58_bounded_above_cap_test() -> Nil {
     == Error(Overflow)
 }
 
+@target(erlang)
 pub fn decode_int_base58_bounded_just_above_cap_test() -> Nil {
   let encoded = intid.encode_int_base58(intid.int64_max + 1)
   assert intid.decode_int_base58_bounded(input: encoded, max: intid.int64_max)
@@ -270,6 +271,7 @@ pub fn decode_int_base58_flickr_bounded_within_test() -> Nil {
     == Ok(1234)
 }
 
+@target(erlang)
 pub fn decode_int_base58_flickr_bounded_above_cap_test() -> Nil {
   let encoded = intid.encode_int_base58_flickr(intid.int64_max + 1)
   assert intid.decode_int_base58_flickr_bounded(
@@ -287,6 +289,7 @@ pub fn decode_int_base62_bounded_within_test() -> Nil {
     == Ok(2_147_483_647)
 }
 
+@target(erlang)
 pub fn decode_int_base62_bounded_above_cap_test() -> Nil {
   let encoded = intid.encode_int_base62(intid.int64_max + 1)
   assert intid.decode_int_base62_bounded(input: encoded, max: intid.int64_max)
@@ -307,6 +310,7 @@ pub fn decode_int_base36_bounded_within_test() -> Nil {
     == Ok(8_675_309)
 }
 
+@target(erlang)
 pub fn decode_int_base36_bounded_above_cap_test() -> Nil {
   let encoded = intid.encode_int_base36(intid.int64_max + 1)
   assert intid.decode_int_base36_bounded(input: encoded, max: intid.int64_max)
@@ -324,6 +328,7 @@ pub fn decode_int_base32_rfc4648_bounded_within_test() -> Nil {
     == Ok(1_234_567)
 }
 
+@target(erlang)
 pub fn decode_int_base32_rfc4648_bounded_above_cap_test() -> Nil {
   let encoded = intid.encode_int_base32_rfc4648(intid.int64_max + 1)
   assert intid.decode_int_base32_rfc4648_bounded(
@@ -344,6 +349,7 @@ pub fn decode_int_base32_crockford_bounded_within_test() -> Nil {
     == Ok(987_654)
 }
 
+@target(erlang)
 pub fn decode_int_base32_crockford_bounded_above_cap_test() -> Nil {
   let encoded = intid.encode_int_base32_crockford(intid.int64_max + 1)
   assert intid.decode_int_base32_crockford_bounded(

--- a/test/multibase_test.gleam
+++ b/test/multibase_test.gleam
@@ -87,6 +87,7 @@ pub fn registry_h_base32z_test() -> Nil {
   assert decoded == data
 }
 
+@target(erlang)
 pub fn registry_k_base36_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(encoding.base36(), data)
@@ -98,6 +99,7 @@ pub fn registry_k_base36_test() -> Nil {
   assert decoded == data
 }
 
+@target(erlang)
 pub fn registry_z_base58btc_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) =
@@ -110,6 +112,7 @@ pub fn registry_z_base58btc_test() -> Nil {
   assert decoded == data
 }
 
+@target(erlang)
 pub fn registry_upper_z_base58flickr_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) =
@@ -400,6 +403,7 @@ pub fn spec_basic_base32z_test() -> Nil {
   assert d == data
 }
 
+@target(erlang)
 pub fn spec_basic_base36_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: _, data: d)) =
@@ -407,6 +411,7 @@ pub fn spec_basic_base36_test() -> Nil {
   assert d == data
 }
 
+@target(erlang)
 pub fn spec_basic_base58btc_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: _, data: d)) =
@@ -414,6 +419,7 @@ pub fn spec_basic_base58btc_test() -> Nil {
   assert d == data
 }
 
+@target(erlang)
 pub fn spec_basic_base58flickr_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(Decoded(encoding: _, data: d)) =
@@ -457,6 +463,7 @@ pub fn spec_leading_zero_base16_test() -> Nil {
   assert d == data
 }
 
+@target(erlang)
 pub fn spec_leading_zero_base36_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: _, data: d)) =
@@ -464,6 +471,7 @@ pub fn spec_leading_zero_base36_test() -> Nil {
   assert d == data
 }
 
+@target(erlang)
 pub fn spec_leading_zero_base58btc_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: _, data: d)) =
@@ -471,6 +479,7 @@ pub fn spec_leading_zero_base58btc_test() -> Nil {
   assert d == data
 }
 
+@target(erlang)
 pub fn spec_leading_zero_base58flickr_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: _, data: d)) =
@@ -493,6 +502,7 @@ pub fn spec_two_leading_zeros_base16_test() -> Nil {
   assert d == data
 }
 
+@target(erlang)
 pub fn spec_two_leading_zeros_base58btc_test() -> Nil {
   let data = <<0, 0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: _, data: d)) =
@@ -500,6 +510,7 @@ pub fn spec_two_leading_zeros_base58btc_test() -> Nil {
   assert d == data
 }
 
+@target(erlang)
 pub fn spec_two_leading_zeros_base36_test() -> Nil {
   let data = <<0, 0, "yes mani !":utf8>>
   let assert Ok(Decoded(encoding: _, data: d)) =


### PR DESCRIPTION
## Summary

Run `gleam test --target javascript` in CI and the release workflow, upgrading the JavaScript lane from build-only verification. JS-target-limited tests are explicitly isolated with `@target(erlang)` and documented, rather than silently passing or failing.

## Changes

- **`.github/workflows/ci.yml`**: replaced the `build-javascript` job with `test-javascript` that builds AND runs `gleam test --target javascript` on Node 22. Job uses a matrix shape so a minimum-supported-Node lane (#47) can be added without restructuring.
- **`.github/workflows/release.yml`**: added a `test-javascript` job that `publish` depends on. The release matrix now matches CI — JS regressions block the publish step.
- **35 tests marked `@target(erlang)`** across `base32_test.gleam`, `base58_test.gleam`, `base58check_test.gleam`, `intid_test.gleam`, and `multibase_test.gleam`. These exercise codecs whose internals use arbitrary-precision integer arithmetic (base32 Crockford, base58, base58check, base36, and matching multibase prefixes) and `intid` bounded variants on `int64_max + 1` — JavaScript `Number` (53-bit) cannot represent these inputs losslessly. Each test still runs on BEAM.
- **README "Supported targets"**: documents the test isolation policy so contributors and consumers can see what is and isn't exercised on JS.
- **CHANGELOG.md**: entry under `[Unreleased]` describing the new JS test lane and the isolation policy.

## Design Decisions

- **`@target(erlang)` over a separate `_jssafe` test file**: the annotation keeps each test next to its peers so future contributors writing a new bignum-backed test don't accidentally write a JS-failing test in a "JS-safe" file. The cost is one annotation per test.
- **No `--warnings-as-errors` on the JS test job**: `intid.int64_max` legitimately exceeds JS's safe integer range and is intentionally exposed to callers. The constant carries a JS-precision warning that doesn't represent a bug — exporting `int64_max` as a `pub const` is the documented contract for `decode_int_*_bounded` callers.
- **Release-workflow ordering**: `test-javascript` runs as a `needs:` dependency for `publish` rather than alongside it. JS regressions should block `gleam publish`, not race against it.

## Limitations

- The new JS lane runs on Node 22 only. A min-supported-Node lane (Node 18, per the README) is tracked in #47 and lands separately to keep that change focused on the version-floor question rather than mixed in with the test-isolation work here.

Closes #42
