### PR TITLE
ci(javascript): test the documented minimum supported Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,18 @@ jobs:
       - run: gleam test
 
   test-javascript:
+    # Two lanes:
+    #   - "18" is the documented minimum supported Node version (see README).
+    #     Failures here mean we have to either fix the code or update the
+    #     stated support floor — they must not be silently dropped.
+    #   - "22" is current latest-LTS coverage for general confidence.
     name: Test (JavaScript / Node ${{ matrix.node }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         node:
+          - "18"
           - "22"
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,18 @@ permissions:
 
 jobs:
   test-javascript:
-    name: Test (JavaScript / Node 22)
+    # Mirrors the CI test-javascript matrix:
+    #   - "18" is the documented minimum supported Node version.
+    #   - "22" is latest-LTS coverage.
+    # If either lane regresses, publishing is blocked.
+    name: Test (JavaScript / Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - "18"
+          - "22"
     steps:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
@@ -20,7 +30,7 @@ jobs:
           gleam-version: "1.15"
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node }}
       - run: gleam deps download
       - run: gleam build --target javascript
       - run: gleam test --target javascript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   surface on JS instead of merely confirming it compiles. The release
   workflow runs the same JS test step before publishing to Hex so the
   release matrix matches CI. (#42)
+- **Minimum-supported Node compatibility lane.** The CI and release
+  JavaScript matrix now also runs against Node 18 — the support
+  floor documented in the README — in addition to the latest-LTS
+  lane on Node 22. The two lanes are commented as "support floor"
+  and "convenience coverage" so future bumps are intentional. (#47)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ that exercise the bignum-backed codecs above are isolated with
 covered on BEAM, but are intentionally skipped on JS rather than
 silently passing or failing.
 
+The JavaScript lane runs on two Node versions:
+
+- **Node 18** — the documented minimum supported version. This is
+  the support floor: the package is required to work here, and
+  regressions on this lane block release.
+- **Node 22** — latest-LTS coverage for general confidence.
+
+The release workflow runs the same matrix; both lanes must pass
+before `gleam publish` runs.
+
 ## Install
 
 ```sh


### PR DESCRIPTION
## Summary

Add a Node 18 lane to the JavaScript test matrix in both CI and the release workflow so the support floor documented in the README is exercised by automation, not just claimed in prose.

## Changes

- **`.github/workflows/ci.yml`**: `test-javascript` matrix now expands to `["18", "22"]`. The matrix has a leading comment explaining each lane's role (Node 18 = support floor, Node 22 = latest-LTS coverage) so future bumps are intentional.
- **`.github/workflows/release.yml`**: same matrix shape mirrors CI. Both lanes must pass before the `publish` job runs, so a Node 18 regression blocks release.
- **README "Supported targets"**: documents the two-lane policy and which lane is the support floor versus convenience coverage.
- **CHANGELOG.md**: `[Unreleased]` entry under "Added" describing the new floor lane.

## Design Decisions

- **`fail-fast: false` is preserved**: a Node 18 failure should not mask a Node 22 failure or vice versa — both signals are independently useful when triaging a regression.
- **Commented matrix over a separate workflow file**: a single matrix with explicit role comments is easier to keep in sync between `ci.yml` and `release.yml` than two parallel workflows. The CI cost is one extra runner per lane.
- **No version-floor abstraction in YAML**: the support floor lives in the README and surfaces here as a literal `"18"`. Adding a `min-supported-node` env var or input would be over-engineering for a single value referenced in two places.

## Limitations

- Node 18 reached upstream end-of-life in April 2025, so users on Node 18 do not receive security updates from the runtime itself. This PR doesn't change the README's stated minimum — that's a deliberate policy question outside this Issue's scope. Bumping the floor (with the matching CI matrix change) would be a separate Issue.

Closes #47


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Node 18 to JavaScript test matrix alongside Node 22 for expanded version coverage.

* **Documentation**
  * Updated README and changelog to document the two-version Node.js test matrix and release requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->