### PR TITLE
feat(encoding): expose target capability helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   floor documented in the README — in addition to the latest-LTS
   lane on Node 22. The two lanes are commented as "support floor"
   and "convenience coverage" so future bumps are intentional. (#47)
+- **Target capability helpers on `yabase/core/encoding`.** New public
+  surface lets callers branch on JavaScript safety programmatically
+  instead of scraping README caveats:
+  - `Target` opaque type with `target_erlang/0` and
+    `target_javascript/0` smart constructors
+  - `is_javascript_safe(enc: Encoding) -> Bool` — `False` for the
+    bignum-backed codecs (`base8`, `base10`, `base32` Crockford /
+    CrockfordCheck, `base36`, `base58` Bitcoin / Flickr, `base62`)
+    that lose precision past `Number.MAX_SAFE_INTEGER`, `True` for
+    every other encoding
+  - `supports_target(enc: Encoding, target: Target) -> Bool` —
+    always `True` for `target_erlang()`, delegates to
+    `is_javascript_safe` for `target_javascript()`
+  Useful after `multibase.decode` auto-detects an `Encoding` from a
+  prefix supplied by an untrusted source: callers can reject codecs
+  the JavaScript target cannot represent without listing them by
+  hand. README has a worked dynamic-selection example. (#43)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,48 @@ let assert Ok(Decoded(encoding: enc, data: _data)) =
 let assert True = enc == encoding.base16()
 ```
 
+### Selecting codecs by target
+
+`yabase/core/encoding` exposes machine-readable target capability
+helpers so callers that pick an encoding at runtime — multibase
+auto-detection, user-configurable codec choice, or any list-of-options
+UI — can branch on JavaScript safety without scraping the README.
+
+```gleam
+import yabase/core/encoding.{type Decoded, Decoded}
+import yabase/core/multibase
+
+pub fn safe_decode_for_javascript(
+  prefixed: String,
+) -> Result(Decoded, Nil) {
+  let js = encoding.target_javascript()
+  case multibase.decode(prefixed) {
+    Ok(Decoded(encoding: enc, data: _) as decoded) ->
+      case encoding.supports_target(enc, js) {
+        True -> Ok(decoded)
+        // Auto-detected codec (e.g. base58btc, base36) is bignum-backed
+        // and may produce wrong output past Number.MAX_SAFE_INTEGER on
+        // the JavaScript target — reject rather than return a silently
+        // corrupt payload.
+        False -> Error(Nil)
+      }
+    Error(_) -> Error(Nil)
+  }
+}
+```
+
+On the BEAM target every encoding is supported, so
+`encoding.supports_target(_, encoding.target_erlang())` is always
+`True`. The boolean only narrows on `target_javascript()`. The
+matching `encoding.is_javascript_safe/1` is the same check as a
+direct `Bool` if you do not need a `Target` value.
+
+For `intid` callers who decode an `Int` rather than a `BitArray`,
+use `intid.decode_int_*_bounded(..., max: intid.int53_max)` when the
+value is going to flow into a JavaScript `number`. The unbounded
+decoders return Erlang bignums, which silently lose precision once
+serialized for a JavaScript consumer.
+
 ### Multibase prefix coverage
 
 yabase supports the following [multibase](https://github.com/multiformats/multibase) prefixes.

--- a/src/yabase/core/encoding.gleam
+++ b/src/yabase/core/encoding.gleam
@@ -205,6 +205,80 @@ pub fn base91() -> Encoding {
 }
 
 // ---------------------------------------------------------------------------
+// Target capabilities.
+//
+// Some encodings produce correct results regardless of compilation
+// target; others rely on arbitrary-precision integer arithmetic and
+// cannot represent inputs larger than `Number.MAX_SAFE_INTEGER` on
+// JavaScript. The README explains the underlying constraint, but
+// callers that need to *select* an encoding at runtime (multibase
+// auto-detection, user-configurable codec choice) must be able to
+// branch on this property programmatically.
+// ---------------------------------------------------------------------------
+
+/// A Gleam compilation target. Construct with `target_erlang/0` or
+/// `target_javascript/0` and pass to `supports_target/2`.
+pub opaque type Target {
+  Erlang
+  JavaScript
+}
+
+/// The Erlang/BEAM target.
+pub fn target_erlang() -> Target {
+  Erlang
+}
+
+/// The JavaScript target (Node.js or browser).
+pub fn target_javascript() -> Target {
+  JavaScript
+}
+
+/// True if the encoding produces correct results on the JavaScript
+/// target for inputs of any size.
+///
+/// Encodings whose internals rely on arbitrary-precision integer
+/// arithmetic (`base8`, `base10`, `base32` Crockford / CrockfordCheck,
+/// `base36`, `base58` Bitcoin / Flickr, `base62`) inherit JavaScript's
+/// `Number.MAX_SAFE_INTEGER` (2^53 - 1) ceiling and may produce
+/// incorrect output for inputs that represent integers above that
+/// bound — this returns `False` for them.
+///
+/// Byte-oriented encodings (`base2`, `base16`, `base32` RFC4648 /
+/// Hex / Clockwork / ZBase32, `base45`, `base64` *, `base85` *,
+/// `base91`) are correct on both targets — this returns `True` for
+/// them.
+pub fn is_javascript_safe(enc: Encoding) -> Bool {
+  case enc {
+    Base2 | Base16 | Base45 | Base91 -> True
+    Base8 | Base10 | Base36 | Base62 -> False
+    Base32(variant) ->
+      case variant {
+        RFC4648 | Hex | Clockwork | ZBase32 -> True
+        Crockford | CrockfordCheck -> False
+      }
+    Base58(_) -> False
+    Base64(_) -> True
+    Base85(_) -> True
+  }
+}
+
+/// True if the encoding works correctly on the given target.
+///
+/// All encodings work on the Erlang target (BEAM has bignum
+/// integers). On JavaScript, this delegates to `is_javascript_safe/1`.
+///
+/// Useful for filtering an `Encoding` value picked at runtime — for
+/// example, after `multibase.decode` auto-detects the encoding from
+/// a prefix supplied by an untrusted source — before running the
+/// decoded payload through downstream logic.
+pub fn supports_target(enc: Encoding, target: Target) -> Bool {
+  case target {
+    Erlang -> True
+    JavaScript -> is_javascript_safe(enc)
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Dispatch.
 // ---------------------------------------------------------------------------
 

--- a/test/target_capability_test.gleam
+++ b/test/target_capability_test.gleam
@@ -1,0 +1,139 @@
+import yabase/core/encoding
+
+// === is_javascript_safe ===
+
+pub fn js_safe_byte_oriented_codecs_test() -> Nil {
+  // Byte-oriented codecs are correct on both targets.
+  assert encoding.is_javascript_safe(encoding.base2()) == True
+  assert encoding.is_javascript_safe(encoding.base16()) == True
+  assert encoding.is_javascript_safe(encoding.base45()) == True
+  assert encoding.is_javascript_safe(encoding.base91()) == True
+}
+
+pub fn js_safe_base32_byte_variants_test() -> Nil {
+  assert encoding.is_javascript_safe(encoding.base32_rfc4648()) == True
+  assert encoding.is_javascript_safe(encoding.base32_hex()) == True
+  assert encoding.is_javascript_safe(encoding.base32_clockwork()) == True
+  assert encoding.is_javascript_safe(encoding.base32_z_base32()) == True
+}
+
+pub fn js_safe_base64_all_variants_test() -> Nil {
+  assert encoding.is_javascript_safe(encoding.base64_standard()) == True
+  assert encoding.is_javascript_safe(encoding.base64_url_safe()) == True
+  assert encoding.is_javascript_safe(encoding.base64_no_padding()) == True
+  assert encoding.is_javascript_safe(encoding.base64_url_safe_no_padding())
+    == True
+  assert encoding.is_javascript_safe(encoding.base64_dq()) == True
+}
+
+pub fn js_safe_base85_all_variants_test() -> Nil {
+  assert encoding.is_javascript_safe(encoding.base85_btoa()) == True
+  assert encoding.is_javascript_safe(encoding.base85_adobe()) == True
+  assert encoding.is_javascript_safe(encoding.base85_rfc1924()) == True
+  assert encoding.is_javascript_safe(encoding.base85_z85()) == True
+}
+
+pub fn js_unsafe_bignum_codecs_test() -> Nil {
+  // Bignum-backed codecs lose precision past Number.MAX_SAFE_INTEGER
+  // on JavaScript.
+  assert encoding.is_javascript_safe(encoding.base8()) == False
+  assert encoding.is_javascript_safe(encoding.base10()) == False
+  assert encoding.is_javascript_safe(encoding.base36()) == False
+  assert encoding.is_javascript_safe(encoding.base62()) == False
+}
+
+pub fn js_unsafe_base32_crockford_variants_test() -> Nil {
+  assert encoding.is_javascript_safe(encoding.base32_crockford()) == False
+  assert encoding.is_javascript_safe(encoding.base32_crockford_check()) == False
+}
+
+pub fn js_unsafe_base58_variants_test() -> Nil {
+  assert encoding.is_javascript_safe(encoding.base58_bitcoin()) == False
+  assert encoding.is_javascript_safe(encoding.base58_flickr()) == False
+}
+
+// === supports_target ===
+
+pub fn supports_erlang_for_every_encoding_test() -> Nil {
+  // BEAM has arbitrary-precision integers, so every encoding is
+  // supported on the Erlang target.
+  let erlang = encoding.target_erlang()
+  assert encoding.supports_target(encoding.base2(), erlang) == True
+  assert encoding.supports_target(encoding.base8(), erlang) == True
+  assert encoding.supports_target(encoding.base58_bitcoin(), erlang) == True
+  assert encoding.supports_target(encoding.base32_crockford(), erlang) == True
+  assert encoding.supports_target(encoding.base91(), erlang) == True
+}
+
+pub fn supports_javascript_byte_oriented_test() -> Nil {
+  let js = encoding.target_javascript()
+  assert encoding.supports_target(encoding.base16(), js) == True
+  assert encoding.supports_target(encoding.base32_rfc4648(), js) == True
+  assert encoding.supports_target(encoding.base64_standard(), js) == True
+  assert encoding.supports_target(encoding.base85_z85(), js) == True
+  assert encoding.supports_target(encoding.base91(), js) == True
+}
+
+pub fn supports_javascript_rejects_bignum_codecs_test() -> Nil {
+  let js = encoding.target_javascript()
+  assert encoding.supports_target(encoding.base8(), js) == False
+  assert encoding.supports_target(encoding.base10(), js) == False
+  assert encoding.supports_target(encoding.base36(), js) == False
+  assert encoding.supports_target(encoding.base62(), js) == False
+  assert encoding.supports_target(encoding.base58_bitcoin(), js) == False
+  assert encoding.supports_target(encoding.base58_flickr(), js) == False
+  assert encoding.supports_target(encoding.base32_crockford(), js) == False
+  assert encoding.supports_target(encoding.base32_crockford_check(), js)
+    == False
+}
+
+// === supports_target / is_javascript_safe agreement ===
+
+pub fn supports_javascript_matches_is_javascript_safe_test() -> Nil {
+  // For every encoding, supports_target(_, javascript) must match
+  // is_javascript_safe.
+  let js = encoding.target_javascript()
+  let encs = [
+    encoding.base2(),
+    encoding.base8(),
+    encoding.base10(),
+    encoding.base16(),
+    encoding.base32_rfc4648(),
+    encoding.base32_hex(),
+    encoding.base32_crockford(),
+    encoding.base32_crockford_check(),
+    encoding.base32_clockwork(),
+    encoding.base32_z_base32(),
+    encoding.base36(),
+    encoding.base45(),
+    encoding.base58_bitcoin(),
+    encoding.base58_flickr(),
+    encoding.base62(),
+    encoding.base64_standard(),
+    encoding.base64_url_safe(),
+    encoding.base64_no_padding(),
+    encoding.base64_url_safe_no_padding(),
+    encoding.base64_dq(),
+    encoding.base85_btoa(),
+    encoding.base85_adobe(),
+    encoding.base85_rfc1924(),
+    encoding.base85_z85(),
+    encoding.base91(),
+  ]
+  let agreement =
+    list_all(encs, fn(enc) {
+      encoding.supports_target(enc, js) == encoding.is_javascript_safe(enc)
+    })
+  assert agreement == True
+}
+
+fn list_all(items: List(a), pred: fn(a) -> Bool) -> Bool {
+  case items {
+    [] -> True
+    [x, ..rest] ->
+      case pred(x) {
+        True -> list_all(rest, pred)
+        False -> False
+      }
+  }
+}


### PR DESCRIPTION
## Summary

Expose machine-readable target capability helpers on `yabase/core/encoding` so callers that pick an `Encoding` at runtime — multibase auto-detection, configuration-driven codec choice, list-of-options UIs — can branch on JavaScript safety programmatically instead of scraping README caveats.

## Changes

- **`src/yabase/core/encoding.gleam`**: new public surface
  - `pub opaque type Target` with `target_erlang/0` and `target_javascript/0` smart constructors. Opaque so future targets (WASM? AtomVM?) can be added without breaking callers.
  - `is_javascript_safe(enc: Encoding) -> Bool` — `False` for the bignum-backed codecs that inherit `Number.MAX_SAFE_INTEGER` (`base8`, `base10`, `base32` Crockford / CrockfordCheck, `base36`, `base58` Bitcoin / Flickr, `base62`); `True` for byte-oriented codecs.
  - `supports_target(enc: Encoding, target: Target) -> Bool` — always `True` on `target_erlang()`; delegates to `is_javascript_safe` on `target_javascript()`.
- **`test/target_capability_test.gleam`**: 11 test functions cover every encoding and both targets, plus an "agreement" test that loops every smart constructor and asserts `supports_target(_, javascript) == is_javascript_safe(_)` so the two helpers cannot drift if a future contributor adds a codec.
- **`README.md`**: new "Selecting codecs by target" subsection under "Multibase support" with a worked dynamic-selection example that wraps `multibase.decode` with a `supports_target` guard. The snippet is a real `pub fn` and is verified by the existing `verify-readme.sh` CI step.
- **`CHANGELOG.md`**: `[Unreleased] / Added` entry covering the new surface and its motivation.

## Design Decisions

- **`is_javascript_safe` returns a static yes/no per codec, not "yes for inputs ≤ N bytes"**. The acceptance criterion is "callers can branch programmatically", not "predict precision per input". A static answer matches what the README already documents and avoids exposing internal radix sizes through the API.
- **`Target` is opaque, with smart constructors**, mirroring `Encoding` and the variant ADTs in this module. Future variants (a hypothetical WASM target, AtomVM, etc.) become a non-breaking addition.
- **No new error variant**: I considered adding `TargetUnsupported` to `CodecError` for a runtime-checked decode helper, but the AC explicitly says "callers can branch programmatically" — a `Bool` is the smaller, less-coupled answer. Callers compose `multibase.decode` + `supports_target` themselves (as the README example shows). A typed-error variant can be added later if usage demands it.
- **`is_javascript_safe` is exposed alongside `supports_target` rather than only behind it.** Callers that already have a `Target` use `supports_target`; callers that only want a `Bool` ("is this codec JS-safe?" — a documentation/UI use case) use `is_javascript_safe` directly without constructing a `Target` value.
- **Agreement test loops every smart constructor explicitly**, not via reflection. Gleam has no reflective enumeration; an explicit list is the only way to assert "all variants are covered". When a new smart constructor is added, the agreement test will fail to type-check until the new codec is listed, which is the desired pressure.

## Limitations

- The helpers describe codec-level capability, not per-input capability. A `base58` encode of a 4-byte input fits inside 53 bits and would round-trip correctly even on JS — `is_javascript_safe(base58_bitcoin())` still returns `False` because the codec *can* fail for larger inputs, and a static "this codec is safe for this input size" check is not part of this issue's scope.
- `intid.int53_max` already exists for callers passing `Int` values across a JS boundary; this PR does not add a new helper there. The README explicitly cross-references the existing `decode_int_*_bounded(..., max: int53_max)` pattern.

Closes #43
