### PR TITLE
refactor(encoding)!: opaque-ify Decoded and add accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   intentionally excluded on JavaScript, where 53-bit `Number`
   precision cannot represent the inputs. The README "Supported
   targets" section documents this policy. (#42)
+- **`Decoded` is now `pub opaque type` (BREAKING)**. The
+  `multibase.decode/1` (and `yabase.decode_multibase/1`) result is
+  still a `Decoded` value, but external callers can no longer pattern
+  match on the `Decoded(encoding:, data:)` constructor. Use the new
+  accessors instead:
+  - `encoding.decoded_encoding(decoded: Decoded) -> Encoding`
+  - `encoding.decoded_data(decoded: Decoded) -> BitArray`
+  Code that previously wrote
+  `let assert Ok(Decoded(encoding: enc, data: payload)) = decode_multibase(...)`
+  becomes
+  `let assert Ok(d) = decode_multibase(...); let enc = encoding.decoded_encoding(d); let payload = encoding.decoded_data(d)`.
+  Tests that only consume the bytes can use `multibase.decode_bytes/1`,
+  which returns `Result(BitArray, CodecError)` directly. README and
+  `examples/multibase_auto_detect.gleam` are updated. (#45)
 
 ## [0.11.0] - 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -206,19 +206,20 @@ Prefix-based encoding and auto-detection:
 
 ```gleam
 import yabase
-import yabase/core/encoding.{Decoded}
+import yabase/core/encoding
 
 // Encode with multibase prefix
 let assert Ok(prefixed) =
   yabase.encode_multibase(encoding.base16(), <<"Hello":utf8>>)
 // "f48656c6c6f"
 
-// Decode with auto-detection. The opaque `Encoding` value is bound
-// directly; compare against a smart constructor or use
-// `encoding.multibase_name/1` if you need to label it.
-let assert Ok(Decoded(encoding: enc, data: _data)) =
-  yabase.decode_multibase(prefixed)
-let assert True = enc == encoding.base16()
+// Decode with auto-detection. The result is an opaque `Decoded` value
+// — use `encoding.decoded_encoding/1` and `encoding.decoded_data/1`
+// to inspect it, and `encoding.multibase_name/1` if you need to
+// label the detected codec.
+let assert Ok(d) = yabase.decode_multibase(prefixed)
+let assert True = encoding.decoded_encoding(d) == encoding.base16()
+let _data = encoding.decoded_data(d)
 ```
 
 ### Selecting codecs by target
@@ -229,7 +230,7 @@ auto-detection, user-configurable codec choice, or any list-of-options
 UI — can branch on JavaScript safety without scraping the README.
 
 ```gleam
-import yabase/core/encoding.{type Decoded, Decoded}
+import yabase/core/encoding.{type Decoded}
 import yabase/core/multibase
 
 pub fn safe_decode_for_javascript(
@@ -237,7 +238,8 @@ pub fn safe_decode_for_javascript(
 ) -> Result(Decoded, Nil) {
   let js = encoding.target_javascript()
   case multibase.decode(prefixed) {
-    Ok(Decoded(encoding: enc, data: _) as decoded) ->
+    Ok(decoded) -> {
+      let enc = encoding.decoded_encoding(decoded)
       case encoding.supports_target(enc, js) {
         True -> Ok(decoded)
         // Auto-detected codec (e.g. base58btc, base36) is bignum-backed
@@ -246,6 +248,7 @@ pub fn safe_decode_for_javascript(
         // corrupt payload.
         False -> Error(Nil)
       }
+    }
     Error(_) -> Error(Nil)
   }
 }

--- a/examples/multibase_auto_detect.gleam
+++ b/examples/multibase_auto_detect.gleam
@@ -6,7 +6,7 @@
 import gleam/bit_array
 import gleam/io
 import yabase
-import yabase/core/encoding.{Decoded}
+import yabase/core/encoding
 
 pub fn main() -> Nil {
   let data = <<"Hello, multibase!":utf8>>
@@ -20,13 +20,15 @@ pub fn main() -> Nil {
   io.println("Base58:  " <> b58)
   io.println("Base64:  " <> b64)
 
-  // Auto-detect and decode. `encoding.multibase_name/1` is the
-  // public way to label the detected encoding now that the variants
-  // are opaque — no pattern match required.
+  // Auto-detect and decode. The result is an opaque `Decoded` value
+  // — use `encoding.decoded_encoding/1` and `encoding.decoded_data/1`
+  // to inspect it, and `encoding.multibase_name/1` to label the
+  // detected codec.
   [hex, b58, b64]
   |> list_each(fn(encoded) {
-    let assert Ok(Decoded(encoding: enc, data: decoded)) =
-      yabase.decode_multibase(encoded)
+    let assert Ok(d) = yabase.decode_multibase(encoded)
+    let enc = encoding.decoded_encoding(d)
+    let decoded = encoding.decoded_data(d)
     let assert Ok(text) = bit_array.to_string(decoded)
     io.println("Detected " <> encoding.multibase_name(enc) <> " -> " <> text)
   })

--- a/src/yabase.gleam
+++ b/src/yabase.gleam
@@ -26,7 +26,9 @@ pub fn encode_multibase(
 }
 
 /// Decode a multibase-prefixed string, auto-detecting encoding.
-/// Returns Decoded(encoding, data) where data is the decoded BitArray.
+/// Inspect the result with `encoding.decoded_encoding/1` and
+/// `encoding.decoded_data/1` — the `Decoded` type is opaque so its
+/// representation can evolve without breaking external pattern matches.
 pub fn decode_multibase(value: String) -> Result(Decoded, CodecError) {
   multibase.decode(value)
 }

--- a/src/yabase/core/encoding.gleam
+++ b/src/yabase/core/encoding.gleam
@@ -95,9 +95,32 @@ pub opaque type Encoding {
   Base91
 }
 
-/// A decoded value tagged with its detected encoding.
-pub type Decoded {
+/// A decoded value tagged with its detected encoding. Use
+/// `decoded_encoding/1` and `decoded_data/1` to inspect the
+/// contents — the constructor is package-private so the
+/// representation can evolve (e.g. add a multibase prefix field)
+/// without breaking external pattern matches.
+pub opaque type Decoded {
   Decoded(encoding: Encoding, data: BitArray)
+}
+
+/// Build a `Decoded` value. Package-internal; multibase decoders use
+/// this to tag their result. External callers receive a `Decoded`
+/// from `multibase.decode/1` and inspect it with `decoded_encoding`
+/// / `decoded_data`.
+@internal
+pub fn make_decoded(encoding: Encoding, data: BitArray) -> Decoded {
+  Decoded(encoding: encoding, data: data)
+}
+
+/// The encoding that was auto-detected when this value was decoded.
+pub fn decoded_encoding(decoded: Decoded) -> Encoding {
+  decoded.encoding
+}
+
+/// The decoded raw bytes.
+pub fn decoded_data(decoded: Decoded) -> BitArray {
+  decoded.data
 }
 
 // ---------------------------------------------------------------------------

--- a/src/yabase/core/multibase.gleam
+++ b/src/yabase/core/multibase.gleam
@@ -8,7 +8,7 @@
 /// `Error(UnsupportedMultibaseEncoding)` from `encode_with_prefix`.
 import gleam/result
 import gleam/string
-import yabase/core/encoding.{type Decoded, type Encoding, Decoded}
+import yabase/core/encoding.{type Decoded, type Encoding}
 import yabase/core/error.{
   type CodecError, UnsupportedMultibaseEncoding, UnsupportedPrefix,
 }
@@ -38,7 +38,7 @@ pub fn decode(value: String) -> Result(Decoded, CodecError) {
         Error(Nil) -> Error(UnsupportedPrefix(prefix))
         Ok(enc) ->
           encoding.decode_as(enc, rest)
-          |> result.map(fn(data) { Decoded(encoding: enc, data: data) })
+          |> result.map(fn(data) { encoding.make_decoded(enc, data) })
       }
   }
 }

--- a/test/multibase_test.gleam
+++ b/test/multibase_test.gleam
@@ -1,5 +1,5 @@
 import gleam/string
-import yabase/core/encoding.{Decoded}
+import yabase/core/encoding
 import yabase/core/error.{
   InvalidCharacter, UnsupportedMultibaseEncoding, UnsupportedPrefix,
 }
@@ -11,7 +11,7 @@ pub fn registry_0_base2_test() -> Nil {
   let data = <<"Hi":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(encoding.base2(), data)
   assert encoded == "00100100001101001"
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -22,7 +22,7 @@ pub fn registry_7_base8_test() -> Nil {
     "7" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -33,7 +33,7 @@ pub fn registry_9_base10_test() -> Nil {
     "9" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -41,13 +41,12 @@ pub fn registry_f_base16_test() -> Nil {
   let data = <<"yes mani !":utf8>>
   let assert Ok(encoded) = multibase.encode_with_prefix(encoding.base16(), data)
   assert encoded == "f796573206d616e692021"
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
 pub fn registry_upper_f_base16_decode_test() -> Nil {
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    multibase.decode("F796573206D616E692021")
+  let assert Ok(decoded) = multibase.decode_bytes("F796573206D616E692021")
   assert decoded == <<"yes mani !":utf8>>
 }
 
@@ -59,7 +58,7 @@ pub fn registry_c_base32pad_test() -> Nil {
     "c" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -71,7 +70,7 @@ pub fn registry_t_base32hexpad_test() -> Nil {
     "t" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -83,7 +82,7 @@ pub fn registry_h_base32z_test() -> Nil {
     "h" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -95,7 +94,7 @@ pub fn registry_k_base36_test() -> Nil {
     "k" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -108,7 +107,7 @@ pub fn registry_z_base58btc_test() -> Nil {
     "z" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -121,7 +120,7 @@ pub fn registry_upper_z_base58flickr_test() -> Nil {
     "Z" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -130,7 +129,7 @@ pub fn registry_upper_m_base64pad_test() -> Nil {
   let assert Ok(encoded) =
     multibase.encode_with_prefix(encoding.base64_standard(), data)
   assert encoded == "MeWVzIG1hbmkgIQ=="
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -139,7 +138,7 @@ pub fn registry_lower_m_base64_test() -> Nil {
   let assert Ok(encoded) =
     multibase.encode_with_prefix(encoding.base64_no_padding(), data)
   assert encoded == "meWVzIG1hbmkgIQ"
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -151,7 +150,7 @@ pub fn registry_upper_u_base64urlpad_test() -> Nil {
     "U" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -163,7 +162,7 @@ pub fn registry_lower_u_base64url_nopad_test() -> Nil {
     "u" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
@@ -194,12 +193,12 @@ pub fn registry_upper_r_base45_test() -> Nil {
     "R" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode(encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(encoded)
   assert decoded == data
 }
 
 pub fn registry_upper_b_base32upper_decode_test() -> Nil {
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode("BMY")
+  let assert Ok(decoded) = multibase.decode_bytes("BMY")
   assert decoded == <<"f":utf8>>
 }
 
@@ -303,14 +302,14 @@ pub fn multibase_u_rejects_padded_input_test() -> Nil {
 pub fn decode_base32pad_accepts_unpadded_test() -> Nil {
   let data = <<"f":utf8>>
   // "cMY======" is canonical padded; "cMY" is unpadded
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode("cMY")
+  let assert Ok(decoded) = multibase.decode_bytes("cMY")
   assert decoded == data
 }
 
 pub fn decode_base32hexpad_accepts_unpadded_test() -> Nil {
   let data = <<"f":utf8>>
   // "tCO======" is canonical padded; "tCO" is unpadded
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode("tCO")
+  let assert Ok(decoded) = multibase.decode_bytes("tCO")
   assert decoded == data
 }
 
@@ -321,14 +320,13 @@ pub fn decode_alias_upper_c_base32pad_test() -> Nil {
     multibase.encode_with_prefix(encoding.base32_rfc4648(), data)
   // Replace lowercase c prefix with uppercase C
   let alias_encoded = "C" <> string.drop_start(canonical, 1)
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    multibase.decode(alias_encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(alias_encoded)
   assert decoded == data
 }
 
 pub fn decode_alias_lowercase_b_base32_nopad_test() -> Nil {
   // b = base32 no-padding (lowercase); maps to RFC4648 codec
-  let assert Ok(Decoded(encoding: _, data: decoded)) = multibase.decode("bMY")
+  let assert Ok(decoded) = multibase.decode_bytes("bMY")
   assert decoded == <<"f":utf8>>
 }
 
@@ -338,8 +336,7 @@ pub fn decode_alias_upper_t_base32hexpad_test() -> Nil {
   let assert Ok(canonical) =
     multibase.encode_with_prefix(encoding.base32_hex(), data)
   let alias_encoded = "T" <> string.drop_start(canonical, 1)
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    multibase.decode(alias_encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(alias_encoded)
   assert decoded == data
 }
 
@@ -351,8 +348,7 @@ pub fn decode_alias_lowercase_v_base32hex_nopad_test() -> Nil {
   // Strip t prefix, strip trailing padding, prepend v
   let body = string.drop_start(canonical, 1) |> string.replace("=", "")
   let alias_encoded = "v" <> body
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    multibase.decode(alias_encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(alias_encoded)
   assert decoded == data
 }
 
@@ -362,8 +358,7 @@ pub fn decode_alias_upper_v_base32hex_nopad_test() -> Nil {
     multibase.encode_with_prefix(encoding.base32_hex(), data)
   let body = string.drop_start(canonical, 1) |> string.replace("=", "")
   let alias_encoded = "V" <> body
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    multibase.decode(alias_encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(alias_encoded)
   assert decoded == data
 }
 
@@ -373,8 +368,7 @@ pub fn decode_alias_upper_k_base36_test() -> Nil {
   let assert Ok(canonical) =
     multibase.encode_with_prefix(encoding.base36(), data)
   let alias_encoded = "K" <> string.drop_start(canonical, 1)
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    multibase.decode(alias_encoded)
+  let assert Ok(decoded) = multibase.decode_bytes(alias_encoded)
   assert decoded == data
 }
 
@@ -384,136 +378,118 @@ pub fn decode_alias_upper_k_base36_test() -> Nil {
 // basic.csv: "yes mani !"
 pub fn spec_basic_base16_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("f796573206d616e692021")
+  let assert Ok(d) = multibase.decode_bytes("f796573206d616e692021")
   assert d == data
 }
 
 pub fn spec_basic_base32pad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("cpfsxgidnmfxgsibb")
+  let assert Ok(d) = multibase.decode_bytes("cpfsxgidnmfxgsibb")
   assert d == data
 }
 
 pub fn spec_basic_base32z_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("hxf1zgedpcfzg1ebb")
+  let assert Ok(d) = multibase.decode_bytes("hxf1zgedpcfzg1ebb")
   assert d == data
 }
 
 @target(erlang)
 pub fn spec_basic_base36_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("k2lcpzo5yikidynfl")
+  let assert Ok(d) = multibase.decode_bytes("k2lcpzo5yikidynfl")
   assert d == data
 }
 
 @target(erlang)
 pub fn spec_basic_base58btc_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("z7paNL19xttacUY")
+  let assert Ok(d) = multibase.decode_bytes("z7paNL19xttacUY")
   assert d == data
 }
 
 @target(erlang)
 pub fn spec_basic_base58flickr_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("Z7Pznk19XTTzBtx")
+  let assert Ok(d) = multibase.decode_bytes("Z7Pznk19XTTzBtx")
   assert d == data
 }
 
 pub fn spec_basic_base64_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("meWVzIG1hbmkgIQ")
+  let assert Ok(d) = multibase.decode_bytes("meWVzIG1hbmkgIQ")
   assert d == data
 }
 
 pub fn spec_basic_base64pad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("MeWVzIG1hbmkgIQ==")
+  let assert Ok(d) = multibase.decode_bytes("MeWVzIG1hbmkgIQ==")
   assert d == data
 }
 
 pub fn spec_basic_base64url_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("ueWVzIG1hbmkgIQ")
+  let assert Ok(d) = multibase.decode_bytes("ueWVzIG1hbmkgIQ")
   assert d == data
 }
 
 pub fn spec_basic_base64urlpad_test() -> Nil {
   let data = <<"yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("UeWVzIG1hbmkgIQ==")
+  let assert Ok(d) = multibase.decode_bytes("UeWVzIG1hbmkgIQ==")
   assert d == data
 }
 
 // leading_zero.csv: "\x00yes mani !"
 pub fn spec_leading_zero_base16_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("f00796573206d616e692021")
+  let assert Ok(d) = multibase.decode_bytes("f00796573206d616e692021")
   assert d == data
 }
 
 @target(erlang)
 pub fn spec_leading_zero_base36_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("k02lcpzo5yikidynfl")
+  let assert Ok(d) = multibase.decode_bytes("k02lcpzo5yikidynfl")
   assert d == data
 }
 
 @target(erlang)
 pub fn spec_leading_zero_base58btc_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("z17paNL19xttacUY")
+  let assert Ok(d) = multibase.decode_bytes("z17paNL19xttacUY")
   assert d == data
 }
 
 @target(erlang)
 pub fn spec_leading_zero_base58flickr_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("Z17Pznk19XTTzBtx")
+  let assert Ok(d) = multibase.decode_bytes("Z17Pznk19XTTzBtx")
   assert d == data
 }
 
 pub fn spec_leading_zero_base64pad_test() -> Nil {
   let data = <<0, "yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("MAHllcyBtYW5pICE=")
+  let assert Ok(d) = multibase.decode_bytes("MAHllcyBtYW5pICE=")
   assert d == data
 }
 
 // two_leading_zeros.csv: "\x00\x00yes mani !"
 pub fn spec_two_leading_zeros_base16_test() -> Nil {
   let data = <<0, 0, "yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("f0000796573206d616e692021")
+  let assert Ok(d) = multibase.decode_bytes("f0000796573206d616e692021")
   assert d == data
 }
 
 @target(erlang)
 pub fn spec_two_leading_zeros_base58btc_test() -> Nil {
   let data = <<0, 0, "yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("z117paNL19xttacUY")
+  let assert Ok(d) = multibase.decode_bytes("z117paNL19xttacUY")
   assert d == data
 }
 
 @target(erlang)
 pub fn spec_two_leading_zeros_base36_test() -> Nil {
   let data = <<0, 0, "yes mani !":utf8>>
-  let assert Ok(Decoded(encoding: _, data: d)) =
-    multibase.decode("k002lcpzo5yikidynfl")
+  let assert Ok(d) = multibase.decode_bytes("k002lcpzo5yikidynfl")
   assert d == data
 }

--- a/test/yabase_test.gleam
+++ b/test/yabase_test.gleam
@@ -1,6 +1,6 @@
 import gleeunit
 import yabase
-import yabase/core/encoding.{Decoded}
+import yabase/core/encoding
 import yabase/core/error.{
   InvalidCharacter, UnsupportedMultibaseEncoding, UnsupportedPrefix,
 }
@@ -36,8 +36,8 @@ pub fn encode_decode_base32_test() -> Nil {
 pub fn multibase_roundtrip_base16_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(prefixed) = yabase.encode_multibase(encoding.base16(), data)
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    yabase.decode_multibase(prefixed)
+  let assert Ok(d) = yabase.decode_multibase(prefixed)
+  let decoded = encoding.decoded_data(d)
   assert decoded == data
 }
 
@@ -45,8 +45,8 @@ pub fn multibase_roundtrip_base58_bitcoin_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(prefixed) =
     yabase.encode_multibase(encoding.base58_bitcoin(), data)
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    yabase.decode_multibase(prefixed)
+  let assert Ok(d) = yabase.decode_multibase(prefixed)
+  let decoded = encoding.decoded_data(d)
   assert decoded == data
 }
 
@@ -58,8 +58,8 @@ pub fn multibase_roundtrip_base58_flickr_test() -> Nil {
     "Z" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    yabase.decode_multibase(prefixed)
+  let assert Ok(d) = yabase.decode_multibase(prefixed)
+  let decoded = encoding.decoded_data(d)
   assert decoded == data
 }
 
@@ -67,8 +67,8 @@ pub fn multibase_roundtrip_base64_nopad_test() -> Nil {
   let data = <<"Hello":utf8>>
   let assert Ok(prefixed) =
     yabase.encode_multibase(encoding.base64_no_padding(), data)
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    yabase.decode_multibase(prefixed)
+  let assert Ok(d) = yabase.decode_multibase(prefixed)
+  let decoded = encoding.decoded_data(d)
   assert decoded == data
 }
 
@@ -114,8 +114,8 @@ pub fn multibase_roundtrip_urlsafe_nopadding_test() -> Nil {
     "u" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    yabase.decode_multibase(prefixed)
+  let assert Ok(d) = yabase.decode_multibase(prefixed)
+  let decoded = encoding.decoded_data(d)
   assert decoded == data
 }
 
@@ -134,7 +134,7 @@ pub fn multibase_roundtrip_base45_test() -> Nil {
     "R" <> _ -> True
     _ -> False
   }
-  let assert Ok(Decoded(encoding: _, data: decoded)) =
-    yabase.decode_multibase(prefixed)
+  let assert Ok(d) = yabase.decode_multibase(prefixed)
+  let decoded = encoding.decoded_data(d)
   assert decoded == data
 }


### PR DESCRIPTION
## Summary

`Decoded` was the last transparent public type in `yabase/core/encoding` — `Encoding` and every variant ADT are already opaque (v0.10.0). Make `Decoded` opaque too and add explicit accessors so the representation can evolve (a future `multibase_prefix` field, a `is_canonical_form` flag, etc.) without breaking external pattern matches.

## Changes

- **`src/yabase/core/encoding.gleam`**:
  - `Decoded` is now `pub opaque type`. Constructor still takes `encoding:` and `data:` labels but is package-internal.
  - New public accessors:
    - `decoded_encoding(decoded: Decoded) -> Encoding`
    - `decoded_data(decoded: Decoded) -> BitArray`
  - New `@internal make_decoded(Encoding, BitArray) -> Decoded` so the multibase decoder (in a different module) can still construct values without exposing the constructor externally.
- **`src/yabase/core/multibase.gleam`**: `decode/1` now uses `encoding.make_decoded` instead of the literal `Decoded(...)` constructor.
- **`src/yabase.gleam`**: doc comment on `decode_multibase/1` points callers at the accessors.
- **`README.md`**:
  - "Multibase support" snippet uses `encoding.decoded_encoding` / `encoding.decoded_data` instead of pattern matching on `Decoded(...)`.
  - "Selecting codecs by target" snippet (added in #43) updated to the same accessor pattern.
- **`examples/multibase_auto_detect.gleam`**: walks the result with the accessors.
- **`test/yabase_test.gleam`**: 6 multibase roundtrip tests bind `Decoded` and read it via `encoding.decoded_data`.
- **`test/multibase_test.gleam`**: ~50 tests previously did `let assert Ok(Decoded(encoding: _, data: <var>)) = multibase.decode(...)`. Since none of them actually used the detected encoding, they switch to `multibase.decode_bytes(...)` which returns just `BitArray` — same code path, no `Decoded` value involved.
- **`CHANGELOG.md`**: `[Unreleased] / Changed` entry tagged BREAKING with a before/after migration snippet.

## Design Decisions

- **Accessors over a `let assert Ok(Decoded(encoding:, data:))` shim**: Gleam's opaque types intentionally block external pattern matching. Re-exporting the constructor as an alias would defeat the point. Two trivial accessor functions are the standard Gleam idiom (mirroring how `Encoding` exposes `multibase_prefix` and `multibase_name` instead of the underlying tag).
- **`@internal make_decoded` rather than promoting `Decoded` to a re-exported alias from `multibase`**: keeps the constructor in one place. The multibase module is the only legitimate constructor site inside the package, and external callers receive `Decoded` values, never construct them.
- **`multibase_test.gleam` uses `decode_bytes` instead of accessors**: those tests don't assert anything about the detected encoding (every pattern was `encoding: _`). `decode_bytes` is the smaller call, exercises the same internal path, and the test reads more directly.
- **`yabase_test.gleam` uses accessors**: the tests there call `yabase.decode_multibase` (top-level facade), and the facade returns `Decoded` for symmetry with the encode side. Routing those tests through the lower-level `multibase.decode_bytes` would be a different conversation; using the accessors keeps the test surface honest.

## Limitations

- This bumps the SemVer-major surface. Callers with `let assert Ok(Decoded(encoding: enc, data: payload)) = decode_multibase(...)` will fail to compile and need to migrate to the accessors. The CHANGELOG entry is explicit and includes the before/after.
- I considered adding `decode_multibase_bytes` to `yabase.gleam` to mirror `multibase.decode_bytes`. Skipped — that's an additive convenience that can land separately if usage demands it; doing it here would pile a new public function on top of a breaking refactor.

Closes #45
