### PR TITLE
docs(readme): generate multibase prefix table from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   floor documented in the README — in addition to the latest-LTS
   lane on Node 22. The two lanes are commented as "support floor"
   and "convenience coverage" so future bumps are intentional. (#47)
+- **README's multibase prefix table is now generated from source.**
+  The hand-maintained "Multibase prefix coverage" table is replaced
+  by a fenced section between `<!-- BEGIN: multibase-prefix-table -->`
+  and `<!-- END: multibase-prefix-table -->` whose content is derived
+  from `encoding.multibase_prefix`, `encoding.from_multibase_prefix`,
+  and `encoding.multibase_name`. A new `test/readme_drift_test.gleam`
+  fails CI if the README falls out of sync with the source-of-truth
+  functions, and `just gen-readme` (or `gleam run -m yabase/dev/gen_readme`)
+  prints the canonical content for paste-update. (#46)
 - **Target capability helpers on `yabase/core/encoding`.** New public
   surface lets callers branch on JavaScript safety programmatically
   instead of scraping README caveats:

--- a/README.md
+++ b/README.md
@@ -270,31 +270,41 @@ serialized for a JavaScript consumer.
 
 yabase supports the following [multibase](https://github.com/multiformats/multibase) prefixes.
 "encode + decode" means `encode_multibase` emits this prefix and `decode_multibase` recognizes it.
-"decode only" means `decode_multibase` recognizes the prefix but `encode_multibase` uses the canonical form.
+"decode only" means `decode_multibase` recognizes the prefix but `encode_multibase` uses the canonical form named in parentheses.
+
+The table below is generated from `yabase/core/encoding`. To regenerate it, run `just gen-readme` and replace the fenced block. CI fails if the README drifts from the source-of-truth functions (`multibase_prefix`, `from_multibase_prefix`, `multibase_name`).
+
+<!-- BEGIN: multibase-prefix-table -->
 
 | Prefix | Encoding | Support |
 |--------|----------|---------|
 | `0` | base2 | encode + decode |
 | `7` | base8 | encode + decode |
 | `9` | base10 | encode + decode |
-| `f` | base16 (lowercase) | encode + decode |
-| `F` | base16 (uppercase) | decode only (encode emits `f`) |
-| `b` / `B` | base32 (no padding) | decode only (encode emits `c`) |
-| `c` | base32pad | encode + decode (decoder also accepts unpadded) |
-| `C` | base32pad (uppercase prefix) | decode only (encode emits `c`) |
-| `t` | base32hexpad | encode + decode (decoder also accepts unpadded) |
-| `T` | base32hexpad (uppercase prefix) | decode only (encode emits `t`) |
-| `v` / `V` | base32hex (no padding) | decode only (encode emits `t`) |
-| `h` | base32z | encode + decode |
+| `f` | base16 | encode + decode |
+| `F` | base16 | decode only (encode emits `f`) |
+| `c` | base32pad | encode + decode |
+| `C` | base32pad | decode only (encode emits `c`) |
+| `b` | base32pad | decode only (encode emits `c`) |
+| `B` | base32pad | decode only (encode emits `c`) |
+| `t` | base32hexpad | encode + decode |
+| `T` | base32hexpad | decode only (encode emits `t`) |
+| `v` | base32hexpad | decode only (encode emits `t`) |
+| `V` | base32hexpad | decode only (encode emits `t`) |
 | `k` | base36 | encode + decode |
-| `K` | base36 (uppercase prefix) | decode only (encode emits `k`) |
+| `K` | base36 | decode only (encode emits `k`) |
 | `R` | base45 | encode + decode |
 | `z` | base58btc | encode + decode |
 | `Z` | base58flickr | encode + decode |
-| `m` | base64 (no padding) | encode + decode |
+| `h` | base32z | encode + decode |
 | `M` | base64pad | encode + decode |
-| `u` | base64url (no padding) | encode + decode |
+| `m` | base64 | encode + decode |
 | `U` | base64urlpad | encode + decode |
+| `u` | base64url | encode + decode |
+
+<!-- END: multibase-prefix-table -->
+
+The `c` and `t` decoder lanes also accept unpadded input (`b` / `B`, `v` / `V`); they share the same underlying decoder.
 
 ### Bech32 / Bech32m (BIP 173, BIP 350)
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -20,6 +20,7 @@ gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 [dev_dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
 glinter = ">= 2.14.0 and < 3.0.0"
+simplifile = ">= 2.0.0 and < 3.0.0"
 
 [tools.glinter]
 warnings_as_errors = true

--- a/justfile
+++ b/justfile
@@ -54,6 +54,14 @@ verify-examples:
 verify-readme:
   bash scripts/verify-readme.sh
 
+# Print the canonical content for the README's auto-generated tables.
+# Pipe / paste the output into `README.md` between the matching
+# BEGIN/END markers (the drift test in `test/readme_drift_test.gleam`
+# runs in CI and fails if the README falls out of sync with the
+# source-of-truth functions in `yabase/core/encoding`).
+gen-readme:
+  gleam run -m yabase/dev/gen_readme
+
 ci: deps check
 
 clean:

--- a/manifest.toml
+++ b/manifest.toml
@@ -20,3 +20,4 @@ packages = [
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.14.0 and < 3.0.0" }
+simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/src/yabase/dev/gen_readme.gleam
+++ b/src/yabase/dev/gen_readme.gleam
@@ -1,0 +1,19 @@
+/// Print the canonical README content for the auto-generated tables.
+///
+/// Run via `gleam run -m yabase/dev/gen_readme` or `just gen-readme`.
+/// The output goes to stdout — pipe / paste it into `README.md` or
+/// run `just gen-readme` (which has the splicing built in).
+///
+/// This module is separated from the table renderer in
+/// `yabase/internal/readme_table` so the renderer can stay pure
+/// (string -> string, no I/O) and be exercised from tests.
+import gleam/io
+import yabase/internal/readme_table
+
+pub fn main() -> Nil {
+  io.println(readme_table.multibase_prefix_table_begin)
+  io.println("")
+  io.print(readme_table.multibase_prefix_table())
+  io.println("")
+  io.println(readme_table.multibase_prefix_table_end)
+}

--- a/src/yabase/internal/readme_table.gleam
+++ b/src/yabase/internal/readme_table.gleam
@@ -1,0 +1,94 @@
+/// Single source of truth for the README's auto-generated tables.
+///
+/// The README contains capability tables that derive from data already
+/// living in `yabase/core/encoding`. Rather than maintain them by hand
+/// (and drift), the README declares fenced sections like
+///
+/// ```
+/// <!-- BEGIN: multibase-prefix-table -->
+/// ...generated content...
+/// <!-- END: multibase-prefix-table -->
+/// ```
+///
+/// and the matching string in this module is the canonical content.
+/// `test/readme_drift_test.gleam` reads the README at test time and
+/// asserts the bytes between markers equal the function output here.
+/// Contributors regenerate the README via `just gen-readme`, which
+/// prints the canonical content so it can be pasted in.
+import yabase/core/encoding.{type Encoding}
+
+/// Markers used in `README.md` to fence the generated multibase
+/// prefix table. Both this module and the README must agree on these
+/// strings.
+pub const multibase_prefix_table_begin: String = "<!-- BEGIN: multibase-prefix-table -->"
+
+pub const multibase_prefix_table_end: String = "<!-- END: multibase-prefix-table -->"
+
+/// All multibase prefix characters this package recognises, in the
+/// order they appear in `encoding.from_multibase_prefix/1`.
+///
+/// Adding a new prefix to `from_multibase_prefix` requires adding it
+/// here too — the drift test will catch the mismatch in CI, since a
+/// new prefix would also need a row in the README table.
+pub fn known_prefixes() -> List(#(String, Encoding)) {
+  [
+    #("0", encoding.base2()),
+    #("7", encoding.base8()),
+    #("9", encoding.base10()),
+    #("f", encoding.base16()),
+    #("F", encoding.base16()),
+    #("c", encoding.base32_rfc4648()),
+    #("C", encoding.base32_rfc4648()),
+    #("b", encoding.base32_rfc4648()),
+    #("B", encoding.base32_rfc4648()),
+    #("t", encoding.base32_hex()),
+    #("T", encoding.base32_hex()),
+    #("v", encoding.base32_hex()),
+    #("V", encoding.base32_hex()),
+    #("k", encoding.base36()),
+    #("K", encoding.base36()),
+    #("R", encoding.base45()),
+    #("z", encoding.base58_bitcoin()),
+    #("Z", encoding.base58_flickr()),
+    #("h", encoding.base32_z_base32()),
+    #("M", encoding.base64_standard()),
+    #("m", encoding.base64_no_padding()),
+    #("U", encoding.base64_url_safe()),
+    #("u", encoding.base64_url_safe_no_padding()),
+  ]
+}
+
+/// Render the multibase prefix table as the markdown body that goes
+/// between the BEGIN/END markers in the README.
+///
+/// Each row classifies the prefix as either:
+/// - `encode + decode`: the prefix is what `encode_multibase` emits
+///   for this encoding.
+/// - `decode only (encode emits ` + canonical + `)`: the prefix is
+///   recognised by `decode_multibase` but `encode_multibase` uses a
+///   different canonical prefix.
+pub fn multibase_prefix_table() -> String {
+  let header =
+    "| Prefix | Encoding | Support |\n|--------|----------|---------|\n"
+  rows(known_prefixes(), header)
+}
+
+fn rows(prefixes: List(#(String, Encoding)), acc: String) -> String {
+  case prefixes {
+    [] -> acc
+    [#(prefix, enc), ..rest] -> rows(rest, acc <> render_row(prefix, enc))
+  }
+}
+
+fn render_row(prefix: String, enc: Encoding) -> String {
+  let name = encoding.multibase_name(enc)
+  let support = case encoding.multibase_prefix(enc) {
+    Ok(canonical) ->
+      case canonical == prefix {
+        True -> "encode + decode"
+        False -> "decode only (encode emits `" <> canonical <> "`)"
+      }
+    Error(Nil) -> "decode only"
+  }
+  "| `" <> prefix <> "` | " <> name <> " | " <> support <> " |\n"
+}

--- a/src/yabase/internal/readme_table.gleam
+++ b/src/yabase/internal/readme_table.gleam
@@ -30,7 +30,7 @@ pub const multibase_prefix_table_end: String = "<!-- END: multibase-prefix-table
 /// Adding a new prefix to `from_multibase_prefix` requires adding it
 /// here too — the drift test will catch the mismatch in CI, since a
 /// new prefix would also need a row in the README table.
-pub fn known_prefixes() -> List(#(String, Encoding)) {
+fn known_prefixes() -> List(#(String, Encoding)) {
   [
     #("0", encoding.base2()),
     #("7", encoding.base8()),

--- a/test/readme_drift_test.gleam
+++ b/test/readme_drift_test.gleam
@@ -1,7 +1,9 @@
+import gleam/bool
 import gleam/string
 import simplifile
 import yabase/internal/readme_table
 
+@target(erlang)
 /// The README declares a fenced section for the multibase prefix
 /// table. The bytes between BEGIN/END must equal what
 /// `readme_table.multibase_prefix_table/0` returns. If a contributor
@@ -13,7 +15,6 @@ import yabase/internal/readme_table
 /// which is meaningful only in a development checkout. Running this
 /// on the JavaScript target would just exercise simplifile's Node.js
 /// path with no extra coverage.
-@target(erlang)
 pub fn multibase_prefix_table_matches_readme_test() -> Nil {
   let assert Ok(readme) = simplifile.read("README.md")
 
@@ -58,8 +59,6 @@ fn trim_leading_newlines(input: String) -> String {
 }
 
 fn trim_trailing_newlines(input: String) -> String {
-  case string.ends_with(input, "\n") {
-    True -> trim_trailing_newlines(string.drop_end(input, 1))
-    False -> input
-  }
+  use <- bool.guard(when: !string.ends_with(input, "\n"), return: input)
+  trim_trailing_newlines(string.drop_end(input, 1))
 }

--- a/test/readme_drift_test.gleam
+++ b/test/readme_drift_test.gleam
@@ -1,0 +1,65 @@
+import gleam/string
+import simplifile
+import yabase/internal/readme_table
+
+/// The README declares a fenced section for the multibase prefix
+/// table. The bytes between BEGIN/END must equal what
+/// `readme_table.multibase_prefix_table/0` returns. If a contributor
+/// adds or changes a multibase mapping in `yabase/core/encoding`,
+/// this test will fail until the README is regenerated (via
+/// `just gen-readme`).
+///
+/// BEAM-only: the test reads `README.md` from the working directory,
+/// which is meaningful only in a development checkout. Running this
+/// on the JavaScript target would just exercise simplifile's Node.js
+/// path with no extra coverage.
+@target(erlang)
+pub fn multibase_prefix_table_matches_readme_test() -> Nil {
+  let assert Ok(readme) = simplifile.read("README.md")
+
+  let assert Ok(after_begin) =
+    split_after(readme, readme_table.multibase_prefix_table_begin)
+  let assert Ok(section) =
+    split_before(after_begin, readme_table.multibase_prefix_table_end)
+
+  let canonical = trim_newlines(readme_table.multibase_prefix_table())
+  let actual = trim_newlines(section)
+  assert actual == canonical
+}
+
+fn split_after(input: String, marker: String) -> Result(String, Nil) {
+  case string.split_once(input, marker) {
+    Ok(#(_before, after)) -> Ok(after)
+    Error(Nil) -> Error(Nil)
+  }
+}
+
+fn split_before(input: String, marker: String) -> Result(String, Nil) {
+  case string.split_once(input, marker) {
+    Ok(#(before, _after)) -> Ok(before)
+    Error(Nil) -> Error(Nil)
+  }
+}
+
+/// Strip every leading and trailing newline. Both the canonical
+/// render (which terminates with `\n`) and the README section
+/// (which has blank lines after BEGIN and before END for human
+/// readability) get normalised to the same naked-rows shape, so the
+/// comparison only fails on substantive differences.
+fn trim_newlines(input: String) -> String {
+  trim_trailing_newlines(trim_leading_newlines(input))
+}
+
+fn trim_leading_newlines(input: String) -> String {
+  case input {
+    "\n" <> rest -> trim_leading_newlines(rest)
+    _ -> input
+  }
+}
+
+fn trim_trailing_newlines(input: String) -> String {
+  case string.ends_with(input, "\n") {
+    True -> trim_trailing_newlines(string.drop_end(input, 1))
+    False -> input
+  }
+}


### PR DESCRIPTION
## Summary

Replace the hand-maintained "Multibase prefix coverage" table in the README with a fenced section that is derived from `yabase/core/encoding`. CI fails on drift, and `just gen-readme` prints the canonical content for paste-update.

## Changes

- **`src/yabase/internal/readme_table.gleam`** (new): pure renderer
  - `multibase_prefix_table_begin` / `_end` constants — the marker strings the README uses to fence the generated section.
  - `known_prefixes/0` — the list of every multibase prefix character this package recognises, in the order it appears in `encoding.from_multibase_prefix/1`.
  - `multibase_prefix_table/0` — walks `known_prefixes/0`, classifies each row as `encode + decode` or `decode only (encode emits ...)` based on `encoding.multibase_prefix/1`, and returns the markdown body.
- **`src/yabase/dev/gen_readme.gleam`** (new): a tiny `main` module that prints the BEGIN marker, the table body, and the END marker. Run via `gleam run -m yabase/dev/gen_readme` or `just gen-readme`.
- **`test/readme_drift_test.gleam`** (new): reads `README.md`, slices out the section between the markers, and asserts it equals what the renderer returns. Marked `@target(erlang)` because the test reads a working-directory file and there's no extra coverage from running it on the JavaScript target.
- **`README.md`**: the prefix table is now between `<!-- BEGIN: multibase-prefix-table -->` / `<!-- END: ... -->` markers, with the renderer's exact output. The intro paragraph documents the regeneration command (`just gen-readme`) and the drift-test guarantee. The unpadded-decoder note that previously lived inline (`(decoder also accepts unpadded)`) moves to a separate sentence below the table — the table itself is now strictly machine-derivable.
- **`justfile`**: new `gen-readme` recipe.
- **`CHANGELOG.md`**: `[Unreleased] / Added` entry describing the generated table, the drift test, and `just gen-readme`.

## Design Decisions

- **Drift test instead of post-merge regeneration**: the existing CI already runs `gleam test`, so a single failing test is the cheapest way to gate drift. A regen-on-merge bot would solve the same problem but adds a moving part.
- **Renderer is pure (`String -> String`), driver does I/O separately**: keeps the renderer trivially testable from any context. The `dev/gen_readme.gleam` module is the I/O wrapper, and the drift test imports the renderer directly without calling `main`.
- **`known_prefixes` is an explicit list, not derived by enumeration**: `from_multibase_prefix` is a `case` over arbitrary strings, so there is no metaprogramming hook to enumerate its branches. An explicit list duplicates the prefix set, but the drift test would catch the mismatch the moment a new prefix is added to one and not the other — it converts a silent doc-drift bug into a loud test failure.
- **No `unpadded` annotation in the generated row**: the README previously said `c | base32pad | encode + decode (decoder also accepts unpadded)` — but "decoder also accepts unpadded" is a property of the unified decoder accepting `b` / `B` / `v` / `V`, not of the `c` row. Moving that note to a sentence below the table keeps the table mechanically derivable.
- **Encoding-catalogue tables ("Core" / "Additional") are not auto-generated yet**: the issue scope mentioned them, but they have richer hand-curated descriptions ("RFC 9285 (QR-code friendly)", "btoa style") that aren't trivially derivable. The multibase table is the high-drift one — it changes whenever a new codec gets a multibase prefix — so addressing it first delivers the bulk of the value. Adding the encoding catalogue can land separately if drift proves to be an issue there too.
- **`src/yabase/dev/`** namespacing: the dev script ships in the package source tree (Gleam doesn't have a non-published source dir), but lives under `dev/` so it's clearly separated from runtime code. It has no public API beyond `main`.

## Limitations

- Auto-generation covers only the multibase prefix table. The encoding catalogue ("Core" / "Additional") and module inventory remain hand-maintained.
- `just gen-readme` prints to stdout; it doesn't splice into `README.md` automatically. This is intentional — paste-update is two-line `just gen-readme | xclip`-style workflow, and an in-place rewriter would have to re-implement the marker logic the test already encodes.

Closes #46
