### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-04-30
+
 ### Added
 
 - **JavaScript-target test lane in CI.** CI now runs `gleam test

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.11.0"
+version = "0.12.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Added

- **JavaScript-target test lane in CI.** CI now runs `gleam test
  --target javascript` against Node.js, exercising the public codec
  surface on JS instead of merely confirming it compiles. The release
  workflow runs the same JS test step before publishing to Hex so the
  release matrix matches CI. (#42)
- **Minimum-supported Node compatibility lane.** The CI and release
  JavaScript matrix now also runs against Node 18 — the support
  floor documented in the README — in addition to the latest-LTS
  lane on Node 22. The two lanes are commented as "support floor"
  and "convenience coverage" so future bumps are intentional. (#47)
- **README's multibase prefix table is now generated from source.**
  The hand-maintained "Multibase prefix coverage" table is replaced
  by a fenced section between `<!-- BEGIN: multibase-prefix-table -->`
  and `<!-- END: multibase-prefix-table -->` whose content is derived
  from `encoding.multibase_prefix`, `encoding.from_multibase_prefix`,
  and `encoding.multibase_name`. A new `test/readme_drift_test.gleam`
  fails CI if the README falls out of sync with the source-of-truth
  functions, and `just gen-readme` (or `gleam run -m yabase/dev/gen_readme`)
  prints the canonical content for paste-update. (#46)
- **Target capability helpers on `yabase/core/encoding`.** New public
  surface lets callers branch on JavaScript safety programmatically
  instead of scraping README caveats:
  - `Target` opaque type with `target_erlang/0` and
    `target_javascript/0` smart constructors
  - `is_javascript_safe(enc: Encoding) -> Bool` — `False` for the
    bignum-backed codecs (`base8`, `base10`, `base32` Crockford /
    CrockfordCheck, `base36`, `base58` Bitcoin / Flickr, `base62`)
    that lose precision past `Number.MAX_SAFE_INTEGER`, `True` for
    every other encoding
  - `supports_target(enc: Encoding, target: Target) -> Bool` —
    always `True` for `target_erlang()`, delegates to
    `is_javascript_safe` for `target_javascript()`
  Useful after `multibase.decode` auto-detects an `Encoding` from a
  prefix supplied by an untrusted source: callers can reject codecs
  the JavaScript target cannot represent without listing them by
  hand. README has a worked dynamic-selection example. (#43)

### Changed

- **JS-target-limited tests are explicitly isolated**, not silently
  skipped. Tests that exercise codecs whose internals rely on
  arbitrary-precision integer arithmetic (base32 Crockford, base58,
  base58check, base36, and the matching multibase prefixes) and
  the `intid` `*_above_cap_test` variants on `int64_max + 1` are
  marked `@target(erlang)`. They remain covered on BEAM and are
  intentionally excluded on JavaScript, where 53-bit `Number`
  precision cannot represent the inputs. The README "Supported
  targets" section documents this policy. (#42)
- **`Decoded` is now `pub opaque type` (BREAKING)**. The
  `multibase.decode/1` (and `yabase.decode_multibase/1`) result is
  still a `Decoded` value, but external callers can no longer pattern
  match on the `Decoded(encoding:, data:)` constructor. Use the new
  accessors instead:
  - `encoding.decoded_encoding(decoded: Decoded) -> Encoding`
  - `encoding.decoded_data(decoded: Decoded) -> BitArray`
  Code that previously wrote
  `let assert Ok(Decoded(encoding: enc, data: payload)) = decode_multibase(...)`
  becomes
  `let assert Ok(d) = decode_multibase(...); let enc = encoding.decoded_encoding(d); let payload = encoding.decoded_data(d)`.
  Tests that only consume the bytes can use `multibase.decode_bytes/1`,
  which returns `Result(BitArray, CodecError)` directly. README and
  `examples/multibase_auto_detect.gleam` are updated. (#45)
