### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-04
+
+### Documentation
+
+- **readme**: Quick start now ends at the facade encode + decode happy
+  path with a single sentence pointing at a new "Notes for production
+  code" section near the bottom of the README. The prior `let assert` /
+  glinter `assert_ok_pattern = "error"` explanation, and the pointer
+  to the `Result`-shaped unified `yabase.encode`, are moved verbatim
+  into that later section so first-time readers see the facade success
+  path before the policy detail. (#55)
+
 ## [0.12.0] - 2026-04-30
 
 ### Added

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.12.0"
+version = "0.13.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Documentation

- **readme**: Quick start now ends at the facade encode + decode happy
  path with a single sentence pointing at a new "Notes for production
  code" section near the bottom of the README. The prior `let assert` /
  glinter `assert_ok_pattern = "error"` explanation, and the pointer
  to the `Result`-shaped unified `yabase.encode`, are moved verbatim
  into that later section so first-time readers see the facade success
  path before the policy detail. (#55)
