### PR TITLE
fix(base91, ascii85): skip ASCII whitespace in decode (#59, #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **base91**: `decode` now silently ignores ASCII whitespace
+  (` `, `\t`, `\n`, `\r`, and the CR+LF cluster) instead of
+  rejecting it as `InvalidCharacter`. The basE91 reference
+  implementation is explicitly lenient about non-alphabet bytes,
+  and the reference encoder wraps long output at 76 chars, so any
+  caller piping wrapped text used to need a hand-rolled
+  `string.replace` shim. (#60)
+- **ascii85**: `decode` now skips ASCII whitespace at group
+  boundaries and inside groups, mirroring the existing
+  `adobe_ascii85` posture (and the historical btoa reference
+  decoders, which all ignore whitespace). Production btoa emitters
+  routinely wrap output at column 76; rejecting whitespace forced
+  every caller to strip it first. (#59)
+
 ## [0.13.0] - 2026-05-04
 
 ### Documentation

--- a/src/yabase/ascii85.gleam
+++ b/src/yabase/ascii85.gleam
@@ -91,6 +91,18 @@ fn decode_groups(
 ) -> Result(BitArray, CodecError) {
   case string.pop_grapheme(input) {
     Error(Nil) -> Ok(acc)
+    // Skip whitespace at group boundaries to mirror `adobe_ascii85`
+    // and the historical btoa reference. Most production btoa
+    // emitters wrap output at column 76; rejecting whitespace
+    // forced every caller to write a `string.replace` shim.
+    // `string.pop_grapheme` returns CR+LF as a single `"\r\n"`
+    // cluster, so handle that one too. (#59)
+    Ok(#(" ", rest)) -> decode_groups(rest, acc, pos + 1)
+    Ok(#("\t", rest)) -> decode_groups(rest, acc, pos + 1)
+    Ok(#("\n", rest)) -> decode_groups(rest, acc, pos + 1)
+    Ok(#("\r", rest)) -> decode_groups(rest, acc, pos + 1)
+    Ok(#("\r\n", rest)) -> decode_groups(rest, acc, pos + 1)
+    Ok(#("\u{000C}", rest)) -> decode_groups(rest, acc, pos + 1)
     Ok(#("z", rest)) ->
       decode_groups(rest, bit_array.append(acc, <<0:32>>), pos + 1)
     Ok(#("y", rest)) ->
@@ -155,6 +167,14 @@ fn collect_group(
   )
   case string.pop_grapheme(input) {
     Error(Nil) -> Ok(#(list.reverse(acc), count, ""))
+    // Skip whitespace inside a group as well, matching adobe_ascii85.
+    // (#59)
+    Ok(#(" ", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#("\t", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#("\n", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#("\r", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#("\r\n", rest)) -> collect_group(rest, acc, count, pos + 1)
+    Ok(#("\u{000C}", rest)) -> collect_group(rest, acc, count, pos + 1)
     Ok(#(c, rest)) ->
       case char_to_ascii85_value(c) {
         Error(Nil) -> Error(InvalidCharacter(c, pos))

--- a/src/yabase/base91.gleam
+++ b/src/yabase/base91.gleam
@@ -97,6 +97,20 @@ fn decode_loop(
       }
       Ok(list_to_bit_array(list.reverse(final_acc), <<>>))
     }
+    [c, ..rest]
+      if c == " " || c == "\t" || c == "\n" || c == "\r" || c == "\r\n"
+    ->
+      // basE91 reference: "the decoder simply ignores characters not in
+      // the alphabet". The reference encoder wraps long output at 76
+      // chars, so any caller who pipes wrapped text through us would
+      // otherwise need a hand-rolled `string.replace(_, "\n", "")`
+      // shim. Skip ASCII whitespace silently and keep the position
+      // counter advancing so error offsets remain meaningful.
+      //
+      // `string.to_graphemes` collapses CR+LF into a single `"\r\n"`
+      // grapheme cluster, so handle that cluster as one token here.
+      // (#60)
+      decode_loop(rest, val, queue, nbits, acc, pos + 1)
     [c, ..rest] ->
       case char_index(c) {
         Error(Nil) -> Error(InvalidCharacter(c, pos))

--- a/test/ascii85_test.gleam
+++ b/test/ascii85_test.gleam
@@ -129,3 +129,33 @@ pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0xfd, 0xfc>>
   assert ascii85.decode(ascii85.encode(data)) == Ok(data)
 }
+
+// --- Whitespace tolerance (#59) ---
+//
+// Mirror `adobe_ascii85`'s posture: skip ASCII whitespace inside the
+// payload so wrapped btoa output round-trips without a hand-rolled
+// `string.replace` shim on the caller side.
+
+pub fn decode_skips_space_test() -> Nil {
+  // 'y' is the four-spaces shortcut. Surrounding whitespace must be
+  // ignored.
+  assert ascii85.decode(" y ") == Ok(<<0x20, 0x20, 0x20, 0x20>>)
+}
+
+pub fn decode_skips_newline_test() -> Nil {
+  assert ascii85.decode("9jqo^\n") == Ok(<<"Man ":utf8>>)
+}
+
+pub fn decode_skips_carriage_return_test() -> Nil {
+  assert ascii85.decode("9jqo^\r\n") == Ok(<<"Man ":utf8>>)
+}
+
+pub fn decode_skips_tab_test() -> Nil {
+  assert ascii85.decode("\t9jqo^\t") == Ok(<<"Man ":utf8>>)
+}
+
+pub fn decode_skips_whitespace_inside_group_test() -> Nil {
+  // Whitespace must also be skipped between characters of a single
+  // 5-char group.
+  assert ascii85.decode("9j\nqo^") == Ok(<<"Man ":utf8>>)
+}

--- a/test/base91_test.gleam
+++ b/test/base91_test.gleam
@@ -110,11 +110,11 @@ pub fn roundtrip_all_ff_32_test() -> Nil {
 
 // --- Error cases ---
 
-pub fn decode_invalid_char_space_test() -> Nil {
-  assert case base91.decode(" ") {
-    Error(InvalidCharacter(" ", 0)) -> True
-    _ -> False
-  }
+pub fn decode_only_space_is_empty_test() -> Nil {
+  // basE91 reference treats whitespace as ignorable. A whitespace-
+  // only input therefore decodes to the empty bit array, not an
+  // InvalidCharacter error. (#60)
+  assert base91.decode(" ") == Ok(<<>>)
 }
 
 pub fn decode_invalid_char_dash_test() -> Nil {
@@ -125,9 +125,36 @@ pub fn decode_invalid_char_dash_test() -> Nil {
 }
 
 pub fn decode_invalid_char_embedded_test() -> Nil {
-  // Valid chars around an invalid one
-  assert case base91.decode("fP KNd") {
-    Error(InvalidCharacter(" ", _)) -> True
+  // Valid chars around an invalid (non-alphabet, non-whitespace) one
+  assert case base91.decode("fP\u{0007}KNd") {
+    Error(InvalidCharacter(_, _)) -> True
     _ -> False
   }
+}
+
+// --- Whitespace tolerance (#60) ---
+
+pub fn decode_skips_space_test() -> Nil {
+  // basE91 reference: "the decoder simply ignores characters not in
+  // the alphabet". The reference encoder also wraps long output at
+  // 76 chars, so wrapped text must round-trip.
+  assert base91.decode("fP NKd") == Ok(<<"test":utf8>>)
+}
+
+pub fn decode_skips_newline_test() -> Nil {
+  assert base91.decode("fPNKd\n") == Ok(<<"test":utf8>>)
+}
+
+pub fn decode_skips_carriage_return_test() -> Nil {
+  assert base91.decode("fPNKd\r\n") == Ok(<<"test":utf8>>)
+}
+
+pub fn decode_skips_tab_test() -> Nil {
+  assert base91.decode("\tfPNKd\t") == Ok(<<"test":utf8>>)
+}
+
+pub fn decode_skips_mixed_whitespace_test() -> Nil {
+  // Hello World encoding ">OwJh>Io0Tv!lE" with whitespace injected
+  // throughout (simulates wrapped + tab-indented transport).
+  assert base91.decode(">OwJh\n>Io0\tTv!lE\r\n") == Ok(<<"Hello World":utf8>>)
 }


### PR DESCRIPTION
## Summary

Fixes #59 and #60 — `ascii85.decode` and `base91.decode` rejected ASCII
whitespace inside the payload, even though the basE91 reference
implementation explicitly ignores non-alphabet bytes and the historical
btoa decoders (and our own `adobe_ascii85`) skip whitespace. Wrapped
output (76-char column wrap is the de-facto encoder default) therefore
needed a hand-rolled `string.replace` shim on the caller side.

## Approach

Skip ASCII whitespace silently in both decoders:

- `base91.decode_loop` matches `" "`, `"\t"`, `"\n"`, `"\r"`, and the
  `"\r\n"` grapheme cluster (which `string.to_graphemes` produces for
  CRLF) with a guard, advancing the position counter for diagnostics.
- `ascii85.decode_groups` and `ascii85.collect_group` match the same
  set plus `"\u{000C}"` (form feed), mirroring the existing
  `adobe_ascii85` shape.

## Tests

- Updated `decode_invalid_char_space_test` (base91) and
  `decode_invalid_char_embedded_test` (base91), which had pinned the
  old "reject whitespace" behaviour.
- Added positive whitespace-tolerance tests for both decoders covering
  space / tab / LF / CRLF / mixed-injection cases, plus a
  within-group whitespace case for ascii85.

## Test plan

- [x] `just check` (683 tests pass on Erlang)
- [ ] CI green on Erlang and JavaScript lanes
