### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-06
+
 ### Fixed
 
 - **base91**: `decode` now silently ignores ASCII whitespace

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.13.0"
+version = "0.14.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Fixed

- **base91**: `decode` now silently ignores ASCII whitespace
  (` `, `\t`, `\n`, `\r`, and the CR+LF cluster) instead of
  rejecting it as `InvalidCharacter`. The basE91 reference
  implementation is explicitly lenient about non-alphabet bytes,
  and the reference encoder wraps long output at 76 chars, so any
  caller piping wrapped text used to need a hand-rolled
  `string.replace` shim. (#60)
- **ascii85**: `decode` now skips ASCII whitespace at group
  boundaries and inside groups, mirroring the existing
  `adobe_ascii85` posture (and the historical btoa reference
  decoders, which all ignore whitespace). Production btoa emitters
  routinely wrap output at column 76; rejecting whitespace forced
  every caller to strip it first. (#59)
