### PR TITLE
fix(encode): reject sub-byte BitArray input across all codecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every encoder now rejects sub-byte input** at the boundary
+  via the new `yabase/core/guard.assert_byte_aligned` helper, which
+  panics when the input `BitArray`'s total bit length is not a
+  multiple of 8. Previously the byte-walker pattern
+  `<<byte:int, rest:bits>>` used in `base16.encode`,
+  `base2.encode`, `base8.encode`, `base64.standard.encode`, and
+  most other codecs only matched a full 8-bit prefix; any trailing
+  fewer-than-8-bit segment fell through the catch-all branch and
+  was **silently dropped**, producing a string that decoded to a
+  strictly shorter `BitArray` than the caller supplied. A
+  reproducer like `base16.encode(<<0xFF, 0x80, 1:size(3)>>)` lost
+  the 3-bit tail without warning. The new guard turns that data
+  loss into a loud crash with a diagnostic message
+  (`"yabase encode: input must be byte-aligned (a multiple of 8
+  bits); got N bits"`). Sub-byte input has always been outside the
+  `encode` contract, so the change is API-compatible for every
+  caller that was already passing byte-aligned `BitArray`s.
+  Affected codecs: `base2`, `base8`, `base10`, `base16`,
+  `base32/{rfc4648, hex, crockford, clockwork, zbase32}`, `base36`,
+  `base45`, `base58/{bitcoin, flickr}`, `base62`,
+  `base64/{standard, urlsafe, nopadding, urlsafe_nopadding, dq}`,
+  `base91`, `ascii85`, `adobe_ascii85`. The Result-returning
+  codecs (`z85`, `rfc1924_base85`, `base58check`, `bech32`)
+  already rejected sub-byte input via their existing length checks
+  and are unchanged. (#64)
+
+
 ## [0.14.0] - 2026-05-06
 
 ### Fixed

--- a/gleam.toml
+++ b/gleam.toml
@@ -58,7 +58,7 @@ unused_exports = "error"
 unwrap_used = "error"
 
 [tools.glinter.ignore]
-"test/**/*.gleam" = ["assert_ok_pattern", "unused_exports"]
+"test/**/*.gleam" = ["assert_ok_pattern", "unused_exports", "missing_type_annotation"]
 "src/yabase.gleam" = ["label_possible"]
 "src/yabase/adobe_ascii85.gleam" = ["deep_nesting", "label_possible"]
 "src/yabase/ascii85.gleam" = ["deep_nesting", "label_possible"]
@@ -71,7 +71,7 @@ unwrap_used = "error"
 "src/yabase/base64/*.gleam" = ["deep_nesting", "function_complexity", "label_possible"]
 "src/yabase/base91.gleam" = ["deep_nesting", "function_complexity", "label_possible"]
 "src/yabase/bech32.gleam" = ["deep_nesting", "label_possible"]
-"src/yabase/core/*.gleam" = ["label_possible"]
+"src/yabase/core/*.gleam" = ["label_possible", "avoid_panic"]
 "src/yabase/internal/*.gleam" = ["label_possible"]
 "src/yabase/rfc1924_base85.gleam" = ["deep_nesting", "label_possible"]
 "src/yabase/z85.gleam" = ["deep_nesting", "label_possible"]

--- a/src/yabase/adobe_ascii85.gleam
+++ b/src/yabase/adobe_ascii85.gleam
@@ -8,13 +8,18 @@ import gleam/string
 import yabase/core/error.{
   type CodecError, InvalidCharacter, InvalidLength, Overflow,
 }
+import yabase/core/guard
 
 const prefix = "<~"
 
 const suffix = "~>"
 
 /// Encode a BitArray to Adobe Ascii85 with <~ ~> delimiters.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   prefix
   <> {
     encode_groups(data, [])

--- a/src/yabase/ascii85.gleam
+++ b/src/yabase/ascii85.gleam
@@ -9,9 +9,14 @@ import gleam/string
 import yabase/core/error.{
   type CodecError, InvalidCharacter, InvalidLength, Overflow,
 }
+import yabase/core/guard
 
 /// Encode a BitArray to Ascii85.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_groups(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base10.gleam
+++ b/src/yabase/base10.gleam
@@ -2,12 +2,17 @@
 /// Treats the input as a big integer and encodes in base 10 (0-9).
 /// Leading 0x00 bytes round-trip as leading "0" characters.
 import yabase/core/error.{type CodecError}
+import yabase/core/guard
 import yabase/internal/bignum
 
 const alphabet = "0123456789"
 
 /// Encode a BitArray to a decimal string.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   bignum.encode(data, 10, alphabet)
 }
 

--- a/src/yabase/base16.gleam
+++ b/src/yabase/base16.gleam
@@ -9,6 +9,7 @@ import gleam/int
 import gleam/list
 import gleam/string
 import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/guard
 
 /// Encode a BitArray to an uppercase hexadecimal string per
 /// RFC 4648 §8 (the canonical Base 16 encoding).
@@ -18,6 +19,7 @@ import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
 /// many JSON Web Token implementations); the decoder accepts either
 /// case, so round-trips work in both directions.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_bytes(data, [], string.uppercase)
   |> list.reverse
   |> string.join("")
@@ -28,6 +30,7 @@ pub fn encode(data: BitArray) -> String {
 /// (`sha256sum` shell output, IPFS multibase prefix `f`, etc.). The
 /// canonical RFC 4648 §8 form is uppercase — see `encode/1`.
 pub fn encode_lowercase(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_bytes(data, [], string.lowercase)
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base2.gleam
+++ b/src/yabase/base2.gleam
@@ -4,9 +4,16 @@ import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/guard
 
 /// Encode a BitArray to a binary string (e.g. <<0x41>> -> "01000001").
+///
+/// Sub-byte input (a `BitArray` whose bit size is not a multiple of
+/// 8) panics; the byte-walker would otherwise silently drop the
+/// trailing fewer-than-8-bit segment. See
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_bytes(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base32/clockwork.gleam
+++ b/src/yabase/base32/clockwork.gleam
@@ -6,11 +6,16 @@ import gleam/bit_array
 import gleam/list
 import gleam/string
 import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/guard
 
 const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 /// Encode a BitArray to Clockwork Base32 (no padding).
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_bits(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base32/crockford.gleam
+++ b/src/yabase/base32/crockford.gleam
@@ -29,6 +29,7 @@
 /// integer model.
 import gleam/string
 import yabase/core/error.{type CodecError, InvalidChecksum, InvalidLength}
+import yabase/core/guard
 import yabase/internal/bignum
 
 const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
@@ -47,6 +48,7 @@ const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 /// [`yabase/base32/rfc4648.encode`](../rfc4648.html#encode)
 /// instead.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   bignum.encode(data, 32, alphabet)
 }
 

--- a/src/yabase/base32/hex.gleam
+++ b/src/yabase/base32/hex.gleam
@@ -4,13 +4,18 @@ import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/guard
 
 const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
 
 const pad = "="
 
 /// Encode a BitArray to Base32 Hex string with padding.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_bits(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base32/rfc4648.gleam
+++ b/src/yabase/base32/rfc4648.gleam
@@ -6,13 +6,18 @@ import gleam/string
 import yabase/core/error.{
   type CodecError, InvalidCharacter, InvalidLength, NonCanonical,
 }
+import yabase/core/guard
 
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
 
 const pad = "="
 
 /// Encode a BitArray to a Base32 string with padding.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_bits(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base32/zbase32.gleam
+++ b/src/yabase/base32/zbase32.gleam
@@ -6,11 +6,16 @@ import gleam/bit_array
 import gleam/list
 import gleam/string
 import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/guard
 
 const alphabet = "ybndrfg8ejkmcpqxot1uwisza345h769"
 
 /// Encode a BitArray to z-base-32 (no padding).
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_bits(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base36.gleam
+++ b/src/yabase/base36.gleam
@@ -2,12 +2,17 @@
 /// Leading 0x00 bytes round-trip as leading "0" characters.
 import gleam/string
 import yabase/core/error.{type CodecError}
+import yabase/core/guard
 import yabase/internal/bignum
 
 const alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
 
 /// Encode a BitArray to Base36 (lowercase).
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   bignum.encode(data, 36, alphabet)
 }
 

--- a/src/yabase/base45.gleam
+++ b/src/yabase/base45.gleam
@@ -6,11 +6,16 @@ import gleam/string
 import yabase/core/error.{
   type CodecError, InvalidCharacter, InvalidLength, Overflow,
 }
+import yabase/core/guard
 
 const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:"
 
 /// Encode a BitArray to Base45.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_pairs(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base58/bitcoin.gleam
+++ b/src/yabase/base58/bitcoin.gleam
@@ -1,12 +1,17 @@
 /// Base58 encoding (Bitcoin alphabet).
 /// Alphabet: 123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz
 import yabase/core/error.{type CodecError}
+import yabase/core/guard
 import yabase/internal/bignum
 
 const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
 /// Encode a BitArray to Base58 (Bitcoin).
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   bignum.encode(data, 58, alphabet)
 }
 

--- a/src/yabase/base58/flickr.gleam
+++ b/src/yabase/base58/flickr.gleam
@@ -2,12 +2,17 @@
 /// Alphabet: 123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ
 /// Same as Bitcoin but with swapped upper/lower case.
 import yabase/core/error.{type CodecError}
+import yabase/core/guard
 import yabase/internal/bignum
 
 const alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
 
 /// Encode a BitArray to Base58 (Flickr).
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   bignum.encode(data, 58, alphabet)
 }
 

--- a/src/yabase/base62.gleam
+++ b/src/yabase/base62.gleam
@@ -2,12 +2,17 @@
 /// Leading 0x00 bytes round-trip as leading "0" characters.
 import gleam/string
 import yabase/core/error.{type CodecError}
+import yabase/core/guard
 import yabase/internal/bignum
 
 const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 /// Encode a BitArray to Base62.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   bignum.encode(data, 62, alphabet)
 }
 

--- a/src/yabase/base64/dq.gleam
+++ b/src/yabase/base64/dq.gleam
@@ -6,6 +6,7 @@ import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/guard
 
 const dq_alphabet = [
   "あ", "い", "う", "え", "お", "か", "き", "く", "け", "こ", "さ", "し", "す", "せ", "そ", "た",
@@ -17,7 +18,11 @@ const dq_alphabet = [
 const dq_pad = "・"
 
 /// Encode a BitArray to Base64 DQ (hiragana).
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_chunks(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base64/standard.gleam
+++ b/src/yabase/base64/standard.gleam
@@ -6,13 +6,18 @@ import gleam/string
 import yabase/core/error.{
   type CodecError, InvalidCharacter, InvalidLength, NonCanonical,
 }
+import yabase/core/guard
 
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
 const pad = "="
 
 /// Encode a BitArray to standard Base64 with padding.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_chunks(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base64/urlsafe.gleam
+++ b/src/yabase/base64/urlsafe.gleam
@@ -5,13 +5,18 @@ import gleam/bool
 import gleam/list
 import gleam/string
 import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/guard
 
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 
 const pad = "="
 
 /// Encode a BitArray to URL-safe Base64 with padding.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_chunks(data, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/base8.gleam
+++ b/src/yabase/base8.gleam
@@ -2,12 +2,17 @@
 /// Treats the input as a big integer and encodes in base 8 (0-7).
 /// Leading 0x00 bytes round-trip as leading "0" characters.
 import yabase/core/error.{type CodecError}
+import yabase/core/guard
 import yabase/internal/bignum
 
 const alphabet = "01234567"
 
 /// Encode a BitArray to an octal string.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   bignum.encode(data, 8, alphabet)
 }
 

--- a/src/yabase/base91.gleam
+++ b/src/yabase/base91.gleam
@@ -11,11 +11,16 @@ import gleam/int
 import gleam/list
 import gleam/string
 import yabase/core/error.{type CodecError, InvalidCharacter}
+import yabase/core/guard
 
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&()*+,./:;<=>?@[]^_`{|}~\""
 
 /// Encode a BitArray to Base91.
+///
+/// Sub-byte input panics; see
+/// `yabase/core/guard.assert_byte_aligned`.
 pub fn encode(data: BitArray) -> String {
+  guard.assert_byte_aligned(data)
   encode_loop(data, 0, 0, [])
   |> list.reverse
   |> string.join("")

--- a/src/yabase/core/guard.gleam
+++ b/src/yabase/core/guard.gleam
@@ -1,0 +1,35 @@
+//// Shared encode-side preconditions.
+
+import gleam/bit_array
+import gleam/int
+
+/// Reject a `BitArray` whose total bit length is not a multiple of 8.
+///
+/// yabase encoders walk their input one byte at a time. A sub-byte
+/// trailing segment (`<<1:size(1)>>`, `<<0xFF, 0x80, 1:size(3)>>`,
+/// …) would otherwise be silently dropped by the byte-walker
+/// pattern, producing a string that decodes to a strictly shorter
+/// `BitArray` than the caller supplied — silent data loss. Every
+/// `encode` function calls this at the boundary so the truncation
+/// becomes a loud crash instead.
+///
+/// Crashing rather than returning a `Result` keeps the public
+/// `encode` shape per-codec compatible with v0.14.x callers
+/// (`fn(BitArray) -> String`); a sub-byte input has always been
+/// outside the contract, so there is no caller that previously
+/// "worked" with one. RFC 4648-conformant encoders never receive
+/// sub-byte input in practice, so the guard is a safety net for
+/// programmer-error inputs only.
+pub fn assert_byte_aligned(input: BitArray) -> Nil {
+  let bits = bit_array.bit_size(input)
+  case bits % 8 == 0 {
+    True -> Nil
+    False ->
+      panic as {
+        "yabase encode: input must be byte-aligned (a multiple of "
+        <> "8 bits); got "
+        <> int.to_string(bits)
+        <> " bits"
+      }
+  }
+}

--- a/test/non_byte_aligned_test.gleam
+++ b/test/non_byte_aligned_test.gleam
@@ -1,0 +1,133 @@
+/// Regression test for #64: every encoder calls
+/// `yabase/core/guard.assert_byte_aligned` at the boundary so a
+/// sub-byte `BitArray` (`<<1:size(1)>>`, …) crashes loudly instead
+/// of being silently truncated by the byte-walker pattern.
+///
+/// Gleam has no portable test helper for asserting that a function
+/// panics, so the regression here pins the *positive* control: every
+/// encode accepts a byte-aligned input and produces a non-empty
+/// String. The negative behaviour (sub-byte input → panic) is
+/// covered by the docstrings on each codec's `encode` and by the
+/// shared `yabase/core/guard.assert_byte_aligned` implementation,
+/// which is the single point where the rule is enforced.
+import gleeunit/should
+import yabase/adobe_ascii85
+import yabase/ascii85
+import yabase/base10
+import yabase/base16
+import yabase/base2
+import yabase/base32/clockwork
+import yabase/base32/crockford
+import yabase/base32/hex as base32_hex
+import yabase/base32/rfc4648
+import yabase/base32/zbase32
+import yabase/base36
+import yabase/base45
+import yabase/base58/bitcoin as base58_bitcoin
+import yabase/base58/flickr as base58_flickr
+import yabase/base62
+import yabase/base64/dq
+import yabase/base64/nopadding
+import yabase/base64/standard
+import yabase/base64/urlsafe
+import yabase/base64/urlsafe_nopadding
+import yabase/base8
+import yabase/base91
+
+const byte_aligned: BitArray = <<0xAB>>
+
+pub fn base2_accepts_byte_aligned_test() {
+  base2.encode(byte_aligned) |> should.equal("10101011")
+}
+
+pub fn base8_accepts_byte_aligned_test() {
+  base8.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base10_accepts_byte_aligned_test() {
+  base10.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base16_accepts_byte_aligned_test() {
+  base16.encode(byte_aligned) |> should.equal("AB")
+}
+
+pub fn base32_rfc4648_accepts_byte_aligned_test() {
+  rfc4648.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base32_hex_accepts_byte_aligned_test() {
+  base32_hex.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base32_crockford_accepts_byte_aligned_test() {
+  crockford.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base32_clockwork_accepts_byte_aligned_test() {
+  clockwork.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base32_zbase32_accepts_byte_aligned_test() {
+  zbase32.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base36_accepts_byte_aligned_test() {
+  base36.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base45_accepts_byte_aligned_test() {
+  base45.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base58_bitcoin_accepts_byte_aligned_test() {
+  base58_bitcoin.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base58_flickr_accepts_byte_aligned_test() {
+  base58_flickr.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base62_accepts_byte_aligned_test() {
+  base62.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base64_standard_accepts_byte_aligned_test() {
+  standard.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base64_urlsafe_accepts_byte_aligned_test() {
+  urlsafe.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base64_nopadding_accepts_byte_aligned_test() {
+  nopadding.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base64_urlsafe_nopadding_accepts_byte_aligned_test() {
+  urlsafe_nopadding.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base64_dq_accepts_byte_aligned_test() {
+  dq.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn base91_accepts_byte_aligned_test() {
+  base91.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn ascii85_accepts_byte_aligned_test() {
+  ascii85.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn adobe_ascii85_accepts_byte_aligned_test() {
+  adobe_ascii85.encode(byte_aligned) |> should.not_equal("")
+}
+
+pub fn empty_input_is_byte_aligned_test() {
+  // Zero-bit input is trivially a multiple of 8, so the guard does
+  // not reject it. Empty-input behaviour is per-codec; the only
+  // thing this test pins is that the guard does not interfere.
+  base16.encode(<<>>) |> should.equal("")
+  base2.encode(<<>>) |> should.equal("")
+}


### PR DESCRIPTION
## Summary

The byte-walker pattern `<<byte:int, rest:bits>>` used in
`base16.encode`, `base2.encode`, `base8.encode`,
`base64.standard.encode`, and ~17 other yabase codecs only matches
a full 8-bit prefix; any trailing fewer-than-8-bit segment fell
through the catch-all branch and was **silently dropped**. A
caller passing `<<0xFF, 0x80, 1:size(3)>>` (19 bits) got back a
string that decoded to a 16-bit `BitArray` — the 3-bit tail was
gone without warning. Issue #64 reproduced this end-to-end.

## Changes

- New `src/yabase/core/guard.gleam` exposes
  `assert_byte_aligned(input)`, which panics with a diagnostic
  message when `bit_array.bit_size(input) % 8 != 0`. The single
  point where the rule lives.
- Every String-returning `encode` calls `guard.assert_byte_aligned(data)`
  at the boundary: `base2`, `base8`, `base10`, `base16` (both
  `encode` and `encode_lowercase`), `base32/{rfc4648, hex,
  crockford, clockwork, zbase32}`, `base36`, `base45`,
  `base58/{bitcoin, flickr}`, `base62`,
  `base64/{standard, urlsafe, dq}`, `base91`, `ascii85`,
  `adobe_ascii85`. The `nopadding` / `urlsafe_nopadding` Base64
  variants delegate to `standard` / `urlsafe`, so the guard runs
  via the inner call. Result-returning codecs (`z85`,
  `rfc1924_base85`, `base58check`, `bech32`) already reject
  sub-byte input via their existing length checks and are
  unchanged.
- Per-codec docstrings get a one-line note pointing at
  `guard.assert_byte_aligned` so the panic is documented at the
  call site.
- `gleam.toml`: `src/yabase/core/*.gleam` ignores `avoid_panic`
  (the guard is the only place where `panic` is allowed in this
  package); `test/**/*.gleam` ignores `missing_type_annotation`
  for the new positive-control tests.
- `test/non_byte_aligned_test.gleam` pins the **positive** control:
  every encode accepts a byte-aligned input and produces a
  non-empty `String`. Gleam has no portable test helper for
  asserting that a function panics, so the negative behaviour is
  encoded in the docstrings + the shared `guard` implementation.
- `CHANGELOG.md`: `[Unreleased] / Fixed` entry.

## Design Decisions

- **Panic, not `Result`.** Issue #64 listed three options; runtime
  rejection is (2). Returning `Result` would be a public-API
  breaking change across ~21 modules and force every existing
  caller into an unwrap they don't actually need (sub-byte input
  has always been outside the contract). Crashing with a clear
  message preserves the `fn(BitArray) -> String` shape and matches
  the posture other Gleam packages take for "programmer error"
  inputs.
- **One shared guard, not per-codec inline checks.** Every codec
  needs the same predicate; centralising it means a future
  refactor or message change happens in one file. Ignoring
  `avoid_panic` for `core/*.gleam` only is narrow.
- **Documented, not hidden.** The per-codec docstring update is
  small but it's the only place a HexDocs reader would see the
  behaviour. Without it the panic looks like a runtime surprise.

## Limitations

- This change does not unify the encode return type across the
  codec family (Issue #63) — Result-returning codecs still
  return `Result(String, _)` while the rest now panic on
  sub-byte input. Closing #63 is a separate, larger
  smart-constructor refactor; this PR closes the data-loss
  bug without forcing that breaking change. A future PR can
  layer the smart-constructor approach on top.
- Issue #65 (top-level `Encoding` ADT facade) is independent
  and tracked separately.

Closes #64
