### PR TITLE
docs(readme): document encode return-type asymmetry across codec modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **README**: new "Codec ergonomics" section spells out the
+  per-module `encode` return-type asymmetry (`String` vs
+  `Result(String, CodecError)`) that arises from genuine encode-
+  time preconditions in `z85`, `rfc1924_base85`, `base58check`,
+  and `bech32`. The section names every codec by category and
+  recommends the unified `yabase.encode` API for callers that
+  need a uniform `Result` shape (e.g. property-test tooling).
+  The asymmetry itself is unchanged — closing it would require
+  a smart-constructor refactor across every Result-returning
+  codec, which is a larger breaking change. (#63)
+
 ### Fixed
 
 - **Every encoder now rejects sub-byte input** at the boundary

--- a/README.md
+++ b/README.md
@@ -190,6 +190,43 @@ let encoded = facade.encode_base64(<<"Hello":utf8>>)
 let assert Ok(_decoded) = facade.decode_base64(encoded)
 ```
 
+## Codec ergonomics: `encode` return-type asymmetry
+
+The per-module `encode` family is **not uniform**:
+
+| Codec | `encode` signature |
+| --- | --- |
+| `base2`, `base8`, `base10`, `base16`, `base32/{rfc4648, hex, crockford, clockwork, zbase32}`, `base36`, `base45`, `base62`, `base64/{standard, urlsafe, nopadding, urlsafe_nopadding, dq}`, `base91`, `base58/{bitcoin, flickr}`, `ascii85`, `adobe_ascii85` | `fn(BitArray) -> String` |
+| **`z85`, `rfc1924_base85`** | **`fn(BitArray) -> Result(String, CodecError)`** |
+| **`base58check`** | **`fn(Int, BitArray) -> Result(String, CodecError)`** |
+| **`bech32`** | **`fn(String, BitArray, Bech32Variant) -> Result(String, CodecError)`** |
+
+The four `Result`-returning codecs have genuine encode-time
+preconditions:
+
+- `z85` / `rfc1924_base85` require the input length to be a
+  multiple of 4 bytes
+- `base58check` requires the version byte to be in `0..=255`
+- `bech32` validates the human-readable part (HRP) and the
+  variant
+- All four also reject sub-byte input via the same
+  precondition path used for the constraint above.
+
+Every other codec rejects sub-byte input (`bit_array.bit_size %
+8 != 0`) by panicking via
+`yabase/core/guard.assert_byte_aligned` (see #64) — a
+programmer-error path, not a runtime-input path. With that,
+sub-byte input is uniformly rejected across the codec family;
+only the *shape* of the rejection differs.
+
+If you need a uniform `Result(String, _)` shape across every
+codec — e.g. for property-test tooling like
+[`metamon`](https://github.com/nao1215/metamon)'s
+`forall_round_trip` — use the **unified API**
+(`yabase.encode`) at the top of this README. It always returns
+`Result(String, CodecError)` and absorbs the per-module
+asymmetry behind a single `Encoding` ADT dispatch.
+
 ### Multibase support
 
 Prefix-based encoding and auto-detection:


### PR DESCRIPTION
## Summary

Issue #63 noted that the per-module `encode` family is split
between two return shapes: most codecs return `String`, while
`z85`, `rfc1924_base85`, `base58check`, and `bech32` return
`Result(String, CodecError)` because they have genuine encode-
time preconditions (length-multiple-of-4, valid version byte,
valid HRP). The issue offered two paths: (1) smart-constructor
refactor to make every `encode` total on a wrapped input type,
or (2) a doc-only fallback that explains the asymmetry. This
PR takes (2) — closing the documentation gap so future users do
not re-discover the asymmetry by experiment, while leaving the
larger refactor for a future release.

## Changes

- `README.md`: new "Codec ergonomics: `encode` return-type
  asymmetry" section between "API layers" and the multibase
  documentation. Lists every codec by category, names the
  preconditions that justify the four `Result`-returning
  codecs, and recommends `yabase.encode` (the unified API) for
  callers who need a uniform `Result(String, _)` shape across
  every codec — e.g. property-test tooling like metamon's
  `forall_round_trip`.
- The section also cross-links the #64 fix: every other codec
  now uniformly rejects sub-byte input by panic, so the only
  per-codec difference left is the *shape* of the rejection.
- `CHANGELOG.md`: `[Unreleased] / Documentation` entry.

## Design Decisions

- **Doc-only, not smart-constructor.** Issue #63 explicitly
  presents the smart-constructor path as a separate (larger)
  option. Documenting the asymmetry in one place is enough to
  stop the "what does encode return?" discoverability bug
  without forcing the breaking change a constructor refactor
  would entail.
- **Recommend the unified API as the escape hatch.** `yabase.encode`
  already returns `Result(String, CodecError)` for every
  variant; pointing callers at it gives them a uniform shape
  without changing per-module signatures.
- **README, not per-module docstring duplication.** The
  per-module docstrings already describe each `encode`'s shape
  individually. The README ergonomics table is the place where
  a new user sees the codec catalogue at once and is the natural
  home for the cross-codec comparison.

## Limitations

- The asymmetry itself is unchanged. Callers who want a true
  total `encode` per codec still need either the unified API
  or a future smart-constructor refactor (which would be
  breaking and is tracked separately).

Closes #63
