### PR TITLE
chore(release): prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-07
+
 ### Added
 
 - **Checksum-bearing encodings now fit the `Encoding` ADT.** New

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.14.0"
+version = "0.15.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Added

- **Checksum-bearing encodings now fit the `Encoding` ADT.** New
  smart constructors `encoding.base58_check(version: Int)`,
  `encoding.bech32(hrp: String)`, and `encoding.bech32m(hrp: String)`
  return `Encoding` values that the unified `yabase.encode` and
  `yabase.decode` family dispatches alongside the plain codecs.
  `yabase.decode` rejects any wire whose embedded checksum-bearing
  metadata (Base58Check version, Bech32 HRP / variant) does not
  match what the caller declared on the `Encoding` value.
  Property-test tooling that consumes `Encoding` (e.g. metamon's
  `forall_round_trip`) can now drive every codec — plain and
  checksum-bearing — through one ADT without forking by codec
  module. The README's "Checksum-bearing" section is rewritten to
  lead with the unified API while the per-module
  `yabase/base58check`, `yabase/bech32` decoders remain available
  for callers that need to inspect the embedded metadata
  directly. (#65)

### Documentation

- **README**: new "Codec ergonomics" section spells out the
  per-module `encode` return-type asymmetry (`String` vs
  `Result(String, CodecError)`) that arises from genuine encode-
  time preconditions in `z85`, `rfc1924_base85`, `base58check`,
  and `bech32`. The section names every codec by category and
  recommends the unified `yabase.encode` API for callers that
  need a uniform `Result` shape. (#63)

### Fixed

- **Every encoder now rejects sub-byte input** at the boundary
  via the new `yabase/core/guard.assert_byte_aligned` helper, which
  panics when the input `BitArray`'s total bit length is not a
  multiple of 8. Previously the byte-walker pattern
  `<<byte:int, rest:bits>>` used in `base16.encode`,
  `base2.encode`, `base8.encode`, `base64.standard.encode`, and
  most other codecs only matched a full 8-bit prefix; any trailing
  fewer-than-8-bit segment fell through the catch-all branch and
  was **silently dropped**. The new guard turns that data loss
  into a loud crash. Sub-byte input has always been outside the
  `encode` contract, so the change is API-compatible for every
  caller that was already passing byte-aligned `BitArray`s. (#64)
