### PR TITLE
chore(release): prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-05-08
+
 ### Tests
 - New `test/empty_input_round_trip_test.gleam` pins the empty-input
   round-trip contract uniformly across all 32 facade pairs in

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.15.0"
+version = "0.16.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Tests
- New `test/empty_input_round_trip_test.gleam` pins the empty-input
  round-trip contract uniformly across all 32 facade pairs in
  `yabase/facade`. For every total `encode_*` function, the test
  asserts `decode(encode(<<>>)) == Ok(<<>>)`. For the two `Result`-
  returning encoders (Z85, RFC 1924 Base85) the same round-trip is
  pinned via `let assert Ok(encoded) = encode(<<>>)`. The RFC 4648
  family additionally pins `decode("") == Ok(<<>>)` directly. A future
  refactor that flips the rule for one codec now surfaces here as a
  single-test diff. metamon is not a dev-dep so the property is
  exercised exhaustively over the facade rather than via
  `forall_round_trip`. (#70)
