### PR TITLE
feat(intid): re-export CodecError so single-module imports can type-annotate decode wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`yabase/intid` and the top-level `yabase` module now re-export
+  `CodecError`** as a public type alias, so callers who only
+  `import yabase/intid` (or only `import yabase`) can type-annotate a
+  wrapper around `decode_int_*` / `encode` / `decode` without reaching
+  into `yabase/core/error`. The alias preserves type identity (it
+  resolves to the same `CodecError` the underlying functions already
+  return), so existing code keeps working unchanged. (#74)
+
 ## [0.16.0] - 2026-05-08
 
 ### Tests

--- a/src/yabase.gleam
+++ b/src/yabase.gleam
@@ -1,8 +1,17 @@
 /// yabase - Yet Another Base encoding library.
 /// Provides a unified, type-safe interface for multiple binary-to-text encodings.
 import yabase/core/encoding.{type Decoded, type Encoding}
-import yabase/core/error.{type CodecError}
+import yabase/core/error.{type CodecError as CoreCodecError}
 import yabase/core/multibase
+
+/// Issue #74: re-export `CodecError` so callers who only
+/// `import yabase` can type-annotate around `encode` / `decode` /
+/// `encode_multibase` / `decode_multibase` without reaching into
+/// `yabase/core/error`. The alias keeps the type identity (same
+/// `CodecError` the underlying functions return), so error values
+/// flow through unchanged.
+pub type CodecError =
+  CoreCodecError
 
 /// Encode data using the specified encoding.
 /// Returns Result because some encodings (Base85 Z85/Rfc1924) have input

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -55,8 +55,20 @@ import yabase/base36
 import yabase/base58/bitcoin as base58_bitcoin
 import yabase/base58/flickr as base58_flickr
 import yabase/base62
-import yabase/core/error.{type CodecError, InvalidLength, Overflow}
+import yabase/core/error.{
+  type CodecError as CoreCodecError, InvalidLength, Overflow,
+}
 import yabase/internal/bignum
+
+/// Issue #74: every `decode_int_*` function in this module returns
+/// `Result(Int, CodecError)`. Without this re-export, callers who only
+/// `import yabase/intid` cannot type-annotate a wrapper around a
+/// decode call without reaching into `yabase/core/error` — a module
+/// the README does not mention. The alias keeps the type identity
+/// (it's the same `CodecError` the underlying codec functions
+/// already use) so error values flow through unchanged.
+pub type CodecError =
+  CoreCodecError
 
 /// Largest value that fits in a signed 64-bit integer (`2^63 - 1`).
 /// Use as the `max` argument to `decode_int_*_bounded` when the

--- a/test/intid_test.gleam
+++ b/test/intid_test.gleam
@@ -358,3 +358,32 @@ pub fn decode_int_base32_crockford_bounded_above_cap_test() -> Nil {
     )
     == Error(Overflow)
 }
+
+// Issue #74: a wrapper that only `import yabase/intid` must be able to
+// type-annotate the error returned by `decode_int_*` without reaching
+// into `yabase/core/error`. This test pins down that the re-exported
+// `intid.CodecError` works as a type annotation and that values of the
+// underlying error type round-trip through the alias unchanged.
+pub fn intid_codec_error_alias_round_trips_test() -> Nil {
+  // The alias is the literal type the decoder returns, so values match
+  // by structural equality. `InvalidLength` is one of the existing
+  // variants from `yabase/core/error`.
+  let result: Result(Int, intid.CodecError) =
+    intid.decode_int_base58_bounded(input: "", max: intid.int53_max)
+  assert result == Error(InvalidLength(0))
+}
+
+pub fn intid_codec_error_alias_propagates_through_wrapper_test() -> Nil {
+  // Demonstrates the wrapper shape from Issue #74's reproduction: a
+  // user function that takes only `yabase/intid` as an import and
+  // returns the codec error through a custom name.
+  let result = decode_job_id("0OIl")
+  // base58 alphabet excludes 0 / O / I / l → InvalidCharacter on the
+  // first offending position.
+  let assert Error(_) = result
+  Nil
+}
+
+fn decode_job_id(s: String) -> Result(Int, intid.CodecError) {
+  intid.decode_int_base58_bounded(input: s, max: intid.int53_max)
+}


### PR DESCRIPTION
## Summary

Issue #74: every `decode_int_*` function in `yabase/intid` returns `Result(Int, CodecError)`, but `CodecError` lives in `yabase/core/error` and is not re-exported from `yabase/intid`. A consumer who only `import yabase/intid` cannot type-annotate a wrapper around `decode_int_base58_bounded` (or any other `decode_int_*`) without discovering and importing a second module the README does not mention.

This PR adds `pub type CodecError = error.CodecError` to both `yabase/intid` and the top-level `yabase` module. The aliases preserve type identity (same underlying `CodecError`), so existing code that imports `yabase/core/error` directly keeps working — the new aliases just give single-module callers a complete surface.

## Changes

- `src/yabase/intid.gleam` — import the underlying type as `CoreCodecError` and add `pub type CodecError = CoreCodecError`. The alias is the type the existing public `decode_int_*` functions already return, so call-site behavior is unchanged.
- `src/yabase.gleam` — same alias at the top-level module so `import yabase` is also self-contained for `encode` / `decode` / `encode_multibase` / `decode_multibase` callers (all of which return `CodecError`).
- `test/intid_test.gleam` — two new tests:
  - `intid_codec_error_alias_round_trips_test` — pins down that an `intid.CodecError`-typed `Result` matches values constructed from the underlying `yabase/core/error` constructors (proves type identity).
  - `intid_codec_error_alias_propagates_through_wrapper_test` — exercises the issue's reproduction shape: a small `decode_job_id/1` wrapper typed `Result(Int, intid.CodecError)` that compiles and propagates errors.
- `CHANGELOG.md` — Unreleased entry under `### Added`.

## Design Decisions

- **Alias, not a re-defined sum type.** `pub type CodecError { ... }` would create a *different* type at `yabase/intid`, breaking interop with code that imports `yabase/core/error`. The alias keeps the type identity, which is what callers actually want.
- **Both `intid` and the top-level `yabase`.** The issue specifically calls out `intid` but the same gap applies to `yabase.encode/2`, `yabase.decode/2`, etc. Adding the alias in both places means "import the module that gives you the function" works uniformly.
- **`yabase/bech32` left alone.** The issue notes the same friction technically applies to bech32 but that bech32 already has its own per-codec types in scope, so the surprise is smaller. This PR leaves bech32 untouched — extending coverage there can be a separate, smaller follow-up if anyone hits it.

## Limitations

- The alias does not change the underlying `CodecError` shape. Callers that already destructure variants by importing `yabase/core/error` keep their existing imports.
- `yabase/core/error` itself is left as the canonical home of the type. The aliases are pure conveniences for the public surface; new variants still get added in one place.

Closes #74