### PR TITLE
chore(release): prepare v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-09
+
 ### Added
 - **`yabase/intid` gains checksum-bearing `_check` variants** for the
   Crockford Base32 and Base58Check codecs, removing the

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.16.0"
+version = "0.17.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Added
- **`yabase/intid` gains checksum-bearing `_check` variants** for the
  Crockford Base32 and Base58Check codecs, removing the
  `Int → BitArray → encode_check / decode_check → BitArray → Int`
  dance every caller previously reimplemented. New helpers:
  `encode_int_base32_crockford_check`,
  `decode_int_base32_crockford_check[_bounded]`,
  `encode_int_base58check`,
  `decode_int_base58check[_bounded]`. The decoders surface
  `Error(InvalidChecksum)` on a mistyped input — the whole reason
  callers reach for the checksummed variant. Base58Check is fixed at
  version byte `0` (Bitcoin mainnet P2PKH); callers who need a
  different version still drop to `yabase/base58check` directly. (#73)
- **`yabase/intid` and the top-level `yabase` module now re-export
  `CodecError`** as a public type alias, so callers who only
  `import yabase/intid` (or only `import yabase`) can type-annotate a
  wrapper around `decode_int_*` / `encode` / `decode` without reaching
  into `yabase/core/error`. The alias preserves type identity (it
  resolves to the same `CodecError` the underlying functions already
  return), so existing code keeps working unchanged. (#74)
