### PR TITLE
feat(intid): add encode_int_base10 / decode_int_base10[_bounded]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`yabase/intid`**: `encode_int_base10` /
+  `decode_int_base10` / `decode_int_base10_bounded` close the
+  decimal gap in the integer-id surface. Every other base
+  (base32 RFC 4648 / Crockford, base36, base58 Bitcoin /
+  Flickr, base62) had encode/decode/bounded-decode helpers; the
+  base10 omission broke switch-case bench harnesses (\"swap
+  base58 for base62 to compare ID lengths, hit a compile error
+  on `encode_int_base10`\") and forced callers to special-case
+  decimal with `int.to_string` / `int.parse` plus a hand-rolled
+  bounds check. The new helpers route through `yabase/base10`
+  for symmetry with the rest of the family. (#78)
 - Property-based round-trip tests using
   [metamon](https://github.com/nao1215/metamon) covering every
   encoding's `decode(encode(data)) == Ok(data)` invariant. Lives

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -49,6 +49,7 @@ import gleam/bool
 import gleam/int
 import gleam/result
 import gleam/string
+import yabase/base10
 import yabase/base32/crockford as base32_crockford
 import yabase/base32/rfc4648 as base32_rfc4648
 import yabase/base36
@@ -125,6 +126,35 @@ pub fn decode_int_base32_crockford_bounded(
   max max: Int,
 ) -> Result(Int, CodecError) {
   use value <- result.try(decode_int_base32_crockford(input))
+  bound_check(value, max)
+}
+
+/// Encode a non-negative `Int` as a Base10 (decimal) string.
+///
+/// Behaviour matches `int.to_string` for the typical case
+/// (positive integers) and the rest of the `intid` family for the
+/// switch-case bench harnesses described in #78. Routing through
+/// `base10.encode` keeps the contract uniform with the other
+/// `encode_int_*` functions: a non-negative `Int` in, a string
+/// in the alphabet out, no padding.
+pub fn encode_int_base10(value: Int) -> String {
+  base10.encode(int_to_bytes_be(value))
+}
+
+/// Decode a Base10 (decimal) string back to an `Int`.
+pub fn decode_int_base10(input: String) -> Result(Int, CodecError) {
+  use input <- result.try(reject_empty(input))
+  base10.decode(input)
+  |> result.map(bytes_to_int)
+}
+
+/// Decode a Base10 (decimal) string back to an `Int`, rejecting
+/// values greater than `max` with `Error(Overflow)`.
+pub fn decode_int_base10_bounded(
+  input input: String,
+  max max: Int,
+) -> Result(Int, CodecError) {
+  use value <- result.try(decode_int_base10(input))
   bound_check(value, max)
 }
 

--- a/test/intid_test.gleam
+++ b/test/intid_test.gleam
@@ -64,6 +64,58 @@ pub fn decode_int_base32_crockford_roundtrip_test() -> Nil {
   assert intid.decode_int_base32_crockford(encoded) == Ok(987_654)
 }
 
+// === encoding.base10() (#78) ===
+
+pub fn encode_int_base10_zero_test() -> Nil {
+  assert intid.encode_int_base10(0) == "0"
+}
+
+pub fn encode_int_base10_single_digit_test() -> Nil {
+  assert intid.encode_int_base10(7) == "7"
+}
+
+pub fn encode_int_base10_carry_test() -> Nil {
+  assert intid.encode_int_base10(10) == "10"
+}
+
+pub fn encode_int_base10_large_test() -> Nil {
+  assert intid.encode_int_base10(1_000_000_000) == "1000000000"
+}
+
+pub fn decode_int_base10_empty_test() -> Nil {
+  assert intid.decode_int_base10("") == Error(InvalidLength(0))
+}
+
+pub fn decode_int_base10_round_trip_test() -> Nil {
+  let encoded = intid.encode_int_base10(8_675_309)
+  assert intid.decode_int_base10(encoded) == Ok(8_675_309)
+}
+
+pub fn decode_int_base10_leading_zero_tolerant_test() -> Nil {
+  // The byte-roundtrip path treats leading zero characters as
+  // leading 0x00 bytes, which still decode to the same integer
+  // value — matching the behaviour of `decode_int_base36` for
+  // `"0042"` vs `"42"`.
+  assert intid.decode_int_base10("0042") == intid.decode_int_base10("42")
+}
+
+pub fn decode_int_base10_invalid_char_test() -> Nil {
+  assert intid.decode_int_base10("12a3") == Error(InvalidCharacter("a", 2))
+}
+
+pub fn decode_int_base10_bounded_within_max_test() -> Nil {
+  assert intid.decode_int_base10_bounded(input: "100", max: 1000) == Ok(100)
+}
+
+pub fn decode_int_base10_bounded_at_max_test() -> Nil {
+  assert intid.decode_int_base10_bounded(input: "1000", max: 1000) == Ok(1000)
+}
+
+pub fn decode_int_base10_bounded_overflow_test() -> Nil {
+  assert intid.decode_int_base10_bounded(input: "1001", max: 1000)
+    == Error(Overflow)
+}
+
 // === encoding.base36() ===
 
 pub fn encode_int_base36_zero_test() -> Nil {


### PR DESCRIPTION
## Summary

`yabase/intid` exposed encode/decode/bounded-decode helpers for
every other base (base32 RFC 4648 / Crockford, base36, base58
Bitcoin / Flickr, base62) but skipped decimal. The omission broke
switch-case bench harnesses (\"swap base58 for base62 to compare
ID lengths, hit a compile error on `encode_int_base10`\") and
forced callers to special-case decimal with `int.to_string` /
`int.parse` plus a hand-rolled bounds check. Add the missing
trio.

## Changes

### `src/yabase/intid.gleam`

- New imports: `yabase/base10`.
- `encode_int_base10(value: Int) -> String` — routes through
  `base10.encode(int_to_bytes_be(value))`.
- `decode_int_base10(input: String) -> Result(Int, CodecError)` —
  routes through `base10.decode(input) |> result.map(bytes_to_int)`
  with the same `reject_empty` guard as base36 / base58 / base62.
- `decode_int_base10_bounded(input:, max:) -> Result(Int, CodecError)`
  — wraps `decode_int_base10` with the existing `bound_check`.
- All three sit between the base32 Crockford block and the
  base36 block to keep the source ordering by base value.

### `test/intid_test.gleam`

- New `=== encoding.base10() (#78) ===` test block covering:
  - `encode`: zero, single-digit, two-digit carry, large value
    (1B).
  - `decode`: empty rejection, round-trip, leading-zero
    tolerance (`\"0042\" == \"42\"`), invalid character
    mid-string.
  - `_bounded`: under / at / over `max` boundary.

### `CHANGELOG.md`

- Added entry under `[Unreleased]`.

## Design Decisions

**Why route through `base10` rather than `int.to_string`.** The
issue's recommended approach was option 1 (\"add the helpers for
symmetry\"). Routing through `base10` keeps the implementation
byte-for-byte identical to the other `encode_int_*` functions,
so the contract — empty input rejection, leading-zero
tolerance, byte-roundtrip semantics — matches without
case-by-case behaviour. Using `int.to_string` / `int.parse`
directly would diverge on the leading-zero case
(`int.parse(\"0042\") == Ok(42)` doesn't preserve the
`\"0042\"` shape on round-trip the way the byte path does).

**Why no `_strict` variant.** Other intid functions don't have
a `_strict` form either — the `_bounded` family is the only
\"reject more inputs\" variant. Keeping the surface symmetric
with the rest of the family is the explicit goal of #78.

## Test plan

- [x] `gleam test` — 791 passed (was 780; +11 new tests)
- [x] `just check` — format-check + lint + check + build + test
- [x] Switch-case bench harnesses (the issue's repro shape) now
      compile cleanly with `intid.encode_int_base10(seq)` /
      `intid.encode_int_base58(seq)` / `intid.encode_int_base62(seq)`
      lined up.

Closes #78.