### PR TITLE
docs(readme): add Strictness section pointing at decode_*_strict variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- README gains a `## Strictness` section between `## Quick start`
+  and `## Integer IDs`. The new section names the lenient-by-
+  default `decode_base32` / `decode_base64` posture, shows the
+  `decode_base64("TR==")` repro for non-canonical pad bits (RFC
+  4648 §3.5), points at the `_strict` siblings on the facade,
+  cross-references the per-encoding strict variants for URL-safe
+  / hex / nopadding, and gives the lenient-vs-strict default
+  recommendation (strict for attacker-controlled input, lenient
+  for friendly producers). Closes the discoverability gap from
+  #79 — the strict variants shipped in #39 but the README never
+  mentioned them. (#79)
+
 ### Added
 
 - **`yabase/intid`**: `encode_int_base10` /

--- a/README.md
+++ b/README.md
@@ -73,6 +73,48 @@ pub fn main() {
 
 That covers the success path. See [Notes for production code](#notes-for-production-code) at the bottom for the lint-policy and error-propagation guidance.
 
+## Strictness
+
+The default `decode_base32` and `decode_base64` (and their
+URL-safe / no-padding cousins) are **lenient** — they accept
+non-canonical pad bits per the spec's MAY-relax clause. For
+interop with strict peers (JWT canonical-form check, signature
+verification, RFC-strict gateway), reach for the `_strict`
+siblings. They reject non-canonical pad bits per RFC 4648 §3.5
+with a typed error.
+
+```gleam
+import yabase/facade
+
+// Lenient default — accepts non-canonical trailing pad bits:
+let _lenient = facade.decode_base64("TR==")
+// -> Ok(<<...>>)
+
+// Strict — rejects non-canonical input per RFC 4648 §3.5:
+let _strict = facade.decode_base64_strict("TR==")
+// -> Error(InvalidPadding)
+```
+
+Available facade pairs:
+
+- `decode_base32` / `decode_base32_strict` (RFC 4648 §6 + §3.5)
+- `decode_base64` / `decode_base64_strict` (RFC 4648 §4 + §3.5)
+
+Reach into `yabase/base32/rfc4648` / `yabase/base64/standard`
+for the URL-safe / nopadding variants if you need their strict
+forms (`yabase/base64/urlsafe.decode_strict`,
+`yabase/base32/hex.decode_strict`, etc.). The strictness axis
+is independent of the padding axis: `_nopadding` already
+requires pad-free input, but its decoder is also lenient about
+non-canonical trailing bits — pair with `_strict` when both
+properties matter.
+
+Use the strict variants by default for any decoder fed with
+attacker-controlled input (auth tokens, signed payloads,
+multi-tenant API gateways). The lenient default is the right
+shape for friendly clients (config files, internal RPC) where
+the producer is trusted not to ship malformed pad bits.
+
 ## Integer IDs
 
 Short URL-safe identifiers — DB autoincrement ids, sequence numbers, hash truncations — usually want `Int -> compact string` rather than `BitArray -> String`. The `yabase/intid` module provides this directly so callers do not have to write the `Int -> big-endian bytes -> trim-leading-zero` shim themselves.


### PR DESCRIPTION
## Summary

The strict-mode decoders shipped in #39
(`decode_base32_strict`, `decode_base64_strict` on the facade,
plus the per-encoding `decode_strict` siblings) reject
non-canonical pad bits per RFC 4648 §3.5, but the README never
mentioned them. The default `decode_base*` is lenient, so a
caller writing a security-sensitive validator (auth tokens,
message signatures, RFC-strict interop) hits `decode_base64`
first and gets the lenient behaviour without ever discovering
the strict variant exists.

## Changes

### `README.md`

- New `## Strictness` section between `## Quick start` and
  `## Integer IDs`:
  - Names the lenient-by-default posture explicitly.
  - Shows the `decode_base64(\"TR==\")` repro from the issue
    body, comparing lenient (returns Ok) and strict (returns
    `Error(InvalidPadding)`).
  - Lists the facade's `_strict` pairs
    (`decode_base32_strict`, `decode_base64_strict`).
  - Cross-references per-encoding strict siblings for URL-safe
    / hex / nopadding cases (`yabase/base64/urlsafe.decode_strict`,
    etc.).
  - Recommends defaulting to strict for attacker-controlled
    input (auth tokens, signed payloads, multi-tenant API
    gateways) and lenient for friendly producers (config files,
    internal RPC).

### `CHANGELOG.md`

- Documentation entry under `[Unreleased]`.

## Design Decisions

**Why a dedicated section rather than inline notes on
`decode_base64`.** Strict-vs-lenient is a cross-cutting axis
that touches base32 + base64 + URL-safe + hex + nopadding. A
single section gives readers one place to look. Inline notes on
each `decode_base*` snippet would scatter the same content
across the rest of the README.

**Why no code change.** `decode_base*`'s lenient behaviour stays
as it is — matching the spec's MAY-relax clause. The
discoverability gap is purely a README issue.

**Why call out the audience split (attacker vs friendly).** The
issue noted the strict mode \"is the right default for auth/crypto
consumers; the discovery cost is the actual problem.\" Naming
the audience explicitly nudges the right caller toward the
right default without forcing every caller to switch.

## Test plan

- [x] `just check` (format-check + lint + check + build + test)
- [x] No code change; README only

Closes #79.