### PR TITLE
chore(release): prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-10
+
 ### Documentation
 
 - README gains a `## Strictness` section between `## Quick start`

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.17.0"
+version = "0.18.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Documentation

- README gains a `## Strictness` section between `## Quick start`
  and `## Integer IDs`. The new section names the lenient-by-
  default `decode_base32` / `decode_base64` posture, shows the
  `decode_base64("TR==")` repro for non-canonical pad bits (RFC
  4648 §3.5), points at the `_strict` siblings on the facade,
  cross-references the per-encoding strict variants for URL-safe
  / hex / nopadding, and gives the lenient-vs-strict default
  recommendation (strict for attacker-controlled input, lenient
  for friendly producers). Closes the discoverability gap from
  #79 — the strict variants shipped in #39 but the README never
  mentioned them. (#79)

### Added

- **`yabase/intid`**: `encode_int_base10` /
  `decode_int_base10` / `decode_int_base10_bounded` close the
  decimal gap in the integer-id surface. Every other base
  (base32 RFC 4648 / Crockford, base36, base58 Bitcoin /
  Flickr, base62) had encode/decode/bounded-decode helpers; the
  base10 omission broke switch-case bench harnesses ("swap
  base58 for base62 to compare ID lengths, hit a compile error
  on `encode_int_base10`") and forced callers to special-case
  decimal with `int.to_string` / `int.parse` plus a hand-rolled
  bounds check. The new helpers route through `yabase/base10`
  for symmetry with the rest of the family. (#78)
- Property-based round-trip tests using
  [metamon](https://github.com/nao1215/metamon) covering every
  encoding's `decode(encode(data)) == Ok(data)` invariant. Lives
  in `test/yabase_metamon_test.gleam` and pins the documented
  round-trip law for: base16 (upper / lowercase), base32 RFC 4648
  / hex / Crockford / Clockwork, base64 standard / urlsafe /
  nopadding, base10, base36, base45, base58 Bitcoin, base62,
  base91, ascii85 (4-byte-aligned inputs), z85 (4-byte-aligned
  inputs). The 4-byte-aligned generators stay inside ascii85 /
  z85's documented length contract; non-conforming length is
  rejected with `LengthNotMultipleOf4` per the existing strict
  variants and is exercised by the per-encoding test files.
