### PR TITLE
fix: base32/rfc4648.decode_strict rejects non-canonical input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.18.0] - 2026-05-10
+### Fixed
+
+- **Security / Functional Suitability**: `base32/rfc4648.decode_strict`
+  was upper-casing the input before comparing to the canonical
+  re-encoding (`encode(bytes) == string.uppercase(input)`), which
+  silently accepted lowercase and mixed-case input — exactly the
+  axis the strict path exists to gate. The check is now byte-equal
+  (`encode(bytes) == input`), so lowercase, mixed-case, missing
+  padding, and any other deviation from `encode/1`'s output are
+  rejected with `Error(NonCanonical)`. This closes the replay-attack
+  surface where two distinct wire forms (e.g. `MZXW6===` and
+  `mzxw6===`) both validated as canonical for the same bytes —
+  important for HMAC / TOTP / WebAuthn / content-addressable-storage
+  use cases that were the entire reason for the strict path.
+  The docstring is updated to state the contract clearly. The
+  pre-existing test that asserted the buggy behaviour
+  (`rfc4648_decode_strict_lowercase_canonical_passes_test`) is
+  rewritten to assert the new contract, and two new regression tests
+  cover mixed case and missing-padding cases. Closes #86.
+
+
 
 ### Documentation
 

--- a/src/yabase/base32/rfc4648.gleam
+++ b/src/yabase/base32/rfc4648.gleam
@@ -63,23 +63,23 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
 }
 
 /// Decode `input` and additionally reject non-canonical encodings
-/// per RFC 4648 §3.5: the trailing pad bits in a final block of
-/// fewer than 5 bytes must be zero. Useful for signature
-/// verification and content-addressable storage, where the wire
+/// per RFC 4648 §3.5 / §6: the canonical form is the uppercase,
+/// padded shape produced by `encode/1`, and any deviation
+/// (lowercase, mixed case, missing padding, non-zero pad bits in a
+/// final partial block) is rejected with `Error(NonCanonical)`.
+/// Useful for signature verification, content-addressable storage,
+/// and replay-attack-resistant token handling, where the wire
 /// encoding's uniqueness is part of the contract.
 ///
-/// Returns `Error(NonCanonical)` when the input decodes to bytes
-/// whose canonical re-encoding (uppercase alphabet, padded) differs
-/// from the input. The check is case-insensitive and tolerates
-/// already-padded vs unpadded input — the canonical form is the
-/// uppercase, padded shape produced by `encode/1`. Other failure
-/// modes (`InvalidCharacter`, `InvalidLength`) are surfaced
-/// unchanged from `decode/1`.
+/// Returns `Error(NonCanonical)` when the input is not byte-equal
+/// to `encode(decode(input))`. Other failure modes
+/// (`InvalidCharacter`, `InvalidLength`) are surfaced unchanged from
+/// `decode/1`.
 pub fn decode_strict(input: String) -> Result(BitArray, CodecError) {
   case decode(input) {
     Error(e) -> Error(e)
     Ok(bytes) ->
-      case encode(bytes) == string.uppercase(input) {
+      case encode(bytes) == input {
         True -> Ok(bytes)
         False -> Error(NonCanonical)
       }

--- a/test/base32_test.gleam
+++ b/test/base32_test.gleam
@@ -419,8 +419,24 @@ pub fn rfc4648_decode_strict_full_block_passes_test() -> Nil {
   assert rfc4648.decode_strict("MZXW6YTBOI======") == Ok(<<"foobar":utf8>>)
 }
 
-pub fn rfc4648_decode_strict_lowercase_canonical_passes_test() -> Nil {
-  // Strict accepts case-insensitive input but compares against the
-  // uppercase canonical form.
-  assert rfc4648.decode_strict("my======") == Ok(<<"f":utf8>>)
+pub fn rfc4648_decode_strict_lowercase_rejected_test() -> Nil {
+  // Per RFC 4648 §3.5/§6, the canonical form is uppercase. A strict
+  // decoder MUST reject lowercase input, even though the lenient
+  // `decode/1` accepts it. Closes the security gap where two distinct
+  // wire forms ("MY======" and "my======") would both validate as
+  // canonical for the same bytes — exactly the replay-attack surface
+  // strict decoders exist to close.
+  assert rfc4648.decode_strict("my======") == Error(NonCanonical)
+}
+
+pub fn rfc4648_decode_strict_mixed_case_rejected_test() -> Nil {
+  // Mixed case is also non-canonical.
+  assert rfc4648.decode_strict("My======") == Error(NonCanonical)
+}
+
+pub fn rfc4648_decode_strict_missing_padding_rejected_test() -> Nil {
+  // Canonical form for "f" is "MY======" with full padding to 8
+  // chars. The unpadded form "MY" is accepted by lenient `decode/1`
+  // but is non-canonical for the strict path.
+  assert rfc4648.decode_strict("MY") == Error(NonCanonical)
 }


### PR DESCRIPTION
## Summary

Closes the security gap where \`base32/rfc4648.decode_strict\`
silently accepted lowercase and mixed-case input — the strict
path is meant to enforce RFC 4648 §3.5/§6 canonical form, which
this implementation was missing.

## Root cause

\`\`\`gleam
case encode(bytes) == string.uppercase(input) {
\`\`\`

The \`string.uppercase\` call upper-cased the input before comparing
it to the canonical re-encoding, so any input that decoded
successfully and whose uppercase form matched \`encode/1\`'s output
was treated as canonical. That made \`decode_strict\` indistinguishable
from \`decode\` along the case axis — exactly the axis it exists to
gate.

## Fix

Drop the \`string.uppercase\` call so the comparison is byte-equal:

\`\`\`gleam
case encode(bytes) == input {
\`\`\`

Lowercase, mixed-case, missing padding, and any other deviation
from \`encode/1\`'s output are now rejected with \`Error(NonCanonical)\`.

## Tests

- Pre-existing \`rfc4648_decode_strict_lowercase_canonical_passes_test\`
  asserted the buggy behaviour (lowercase passing). Renamed to
  \`rfc4648_decode_strict_lowercase_rejected_test\` and inverted to
  assert the correct contract.
- New \`rfc4648_decode_strict_mixed_case_rejected_test\` covers mixed
  case (\`My======\`).
- New \`rfc4648_decode_strict_missing_padding_rejected_test\` covers
  the unpadded-but-still-decodable case (\`MY\` → rejected because
  canonical is \`MY======\`).

## Why it matters (Security / ISO 25010)

- **Security — Integrity**: replay-attack surface. Two distinct wire
  forms (\`MZXW6===\` and \`mzxw6===\`) used to round-trip to the same
  bytes through the strict path. Any system using the encoded string
  as a cache / dedup / signature input got two valid representations
  of the same value when it asked for canonical form.
- **Security — Authenticity**: TOTP / HMAC / WebAuthn / replay-
  attack-resistant token workflows reach for the strict path
  precisely to reject non-canonical encodings.
- **Functional Suitability — Correctness**: the implementation
  diverged from the documented (and renamed) contract.

## Verification

- \`just check\` passes (793 tests, all encoding round-trips
  preserved, README snippets verified).
- The Gleam \`assert\` in the rewritten lowercase test confirms the
  new behaviour matches \`Error(NonCanonical)\`.

## Limitations

- This PR fixes only \`base32/rfc4648.decode_strict\`. The same
  pattern was previously surveyed in \`base64/standard.decode_strict\`
  and confirmed correct (uses \`encode(bytes) == input\` already).
  The remaining yabase-wide \`decode_strict\` cleanup (adding the
  function to \`base16\`, sweeping for asymmetries) lives in #87 and
  is intentionally out of scope here.

Closes #86