### PR TITLE
docs: surface intid negative-input handling more visibly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **`yabase/intid` negative-input handling**: every `encode_int_*`
+  function silently normalizes negative inputs to
+  `int.absolute_value`. The previous module docstring mentioned this
+  in passing — easy to miss because it was buried inside a long
+  paragraph and the per-function one-liners said "non-negative
+  `Int`" without noting what happens when callers pass a negative.
+  Move the negative-input note to a dedicated `## Negative inputs
+  are silently absolutized` subsection at the top of the module
+  doc, calling it out as an intentional but footgun-prone design
+  choice and showing the recommended boundary-check pattern. Update
+  every `encode_int_*` function's one-line docstring to read
+  "Negative inputs are normalized to `int.absolute_value`; see the
+  module note ..." so callers can't miss it. Behaviour itself is
+  unchanged — the contract is the same, just made more visible.
+  Closes #84.
+
 ### Fixed
 
 - **Security / Functional Suitability**: `base32/rfc4648.decode_strict`

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -24,9 +24,35 @@
 //// lookups. The byte-oriented decoders in `yabase/facade` retain the
 //// `Ok(<<>>)` round-trip behavior for empty input.
 ////
-//// Negative inputs are normalized to `int.absolute_value` before
-//// encoding — the magnitude is what gets stored. The decode side
-//// always returns a non-negative `Int`.
+//// ## Negative inputs are silently absolutized
+////
+//// Every `encode_int_*` function in this module accepts any `Int`
+//// — including negatives — and normalizes the input to
+//// `int.absolute_value` before encoding. The magnitude is what gets
+//// stored. The decode side always returns a non-negative `Int`.
+////
+//// **This is intentional, not a bug, but it is a footgun.** Two
+//// distinct inputs (`-1` and `1`) round-trip to the same `Int`,
+//// breaking bijection. Code that compares a re-encoded value to its
+//// source can match where you would expect a mismatch. If your
+//// caller path can produce negative values (offsets that subtracted
+//// past zero, Posix timestamps from before 1970, deliberate
+//// `-1` sentinels), the safer pattern is to validate the sign at
+//// the boundary before reaching `encode_int_*`:
+////
+//// ```gleam
+//// case n >= 0 {
+////   True -> Ok(encode_int_base32_crockford(n))
+////   False -> Error(MyDomainError.NegativeId(n))
+//// }
+//// ```
+////
+//// We intentionally chose silent absolutization over `Result` /
+//// `panic` for ergonomics — almost every realistic short-ID caller
+//// reaches `encode_int_*` with a value that is already non-negative
+//// (DB autoincrement, hash truncation, sequence number), and forcing
+//// `Result` everywhere added boilerplate without preventing real
+//// bugs. Tracked in #84.
 ////
 //// ## Bounded decode
 ////
@@ -85,7 +111,10 @@ pub const int64_max: Int = 9_223_372_036_854_775_807
 /// a JavaScript consumer.
 pub const int53_max: Int = 9_007_199_254_740_991
 
-/// Encode a non-negative `Int` as a Base32 (RFC 4648) string.
+/// Encode an `Int` as a Base32 (RFC 4648) string. Negative inputs
+/// are normalized to `int.absolute_value`; see the module note on
+/// "Negative inputs are silently absolutized" for the rationale and
+/// the recommended boundary-check pattern.
 pub fn encode_int_base32_rfc4648(value: Int) -> String {
   base32_rfc4648.encode(int_to_bytes_be(value))
 }
@@ -107,7 +136,9 @@ pub fn decode_int_base32_rfc4648_bounded(
   bound_check(value, max)
 }
 
-/// Encode a non-negative `Int` as a Crockford Base32 string.
+/// Encode an `Int` as a Crockford Base32 string. Negative inputs
+/// are normalized to `int.absolute_value`; see the module note on
+/// "Negative inputs are silently absolutized".
 pub fn encode_int_base32_crockford(value: Int) -> String {
   base32_crockford.encode(int_to_bytes_be(value))
 }
@@ -129,7 +160,9 @@ pub fn decode_int_base32_crockford_bounded(
   bound_check(value, max)
 }
 
-/// Encode a non-negative `Int` as a Base10 (decimal) string.
+/// Encode an `Int` as a Base10 (decimal) string. Negative inputs
+/// are normalized to `int.absolute_value`; see the module note on
+/// "Negative inputs are silently absolutized".
 ///
 /// Behaviour matches `int.to_string` for the typical case
 /// (positive integers) and the rest of the `intid` family for the
@@ -158,7 +191,9 @@ pub fn decode_int_base10_bounded(
   bound_check(value, max)
 }
 
-/// Encode a non-negative `Int` as a Base36 string.
+/// Encode an `Int` as a Base36 string. Negative inputs are
+/// normalized to `int.absolute_value`; see the module note on
+/// "Negative inputs are silently absolutized".
 pub fn encode_int_base36(value: Int) -> String {
   base36.encode(int_to_bytes_be(value))
 }
@@ -180,7 +215,9 @@ pub fn decode_int_base36_bounded(
   bound_check(value, max)
 }
 
-/// Encode a non-negative `Int` as a Base58 (Bitcoin alphabet) string.
+/// Encode an `Int` as a Base58 (Bitcoin alphabet) string. Negative
+/// inputs are normalized to `int.absolute_value`; see the module
+/// note on "Negative inputs are silently absolutized".
 pub fn encode_int_base58(value: Int) -> String {
   base58_bitcoin.encode(int_to_bytes_be(value))
 }
@@ -202,7 +239,9 @@ pub fn decode_int_base58_bounded(
   bound_check(value, max)
 }
 
-/// Encode a non-negative `Int` as a Base58 (Flickr alphabet) string.
+/// Encode an `Int` as a Base58 (Flickr alphabet) string. Negative
+/// inputs are normalized to `int.absolute_value`; see the module
+/// note on "Negative inputs are silently absolutized".
 pub fn encode_int_base58_flickr(value: Int) -> String {
   base58_flickr.encode(int_to_bytes_be(value))
 }
@@ -302,7 +341,9 @@ pub fn decode_int_base58check_bounded(
   bound_check(value, max)
 }
 
-/// Encode a non-negative `Int` as a Base62 string.
+/// Encode an `Int` as a Base62 string. Negative inputs are
+/// normalized to `int.absolute_value`; see the module note on
+/// "Negative inputs are silently absolutized".
 pub fn encode_int_base62(value: Int) -> String {
   base62.encode(int_to_bytes_be(value))
 }


### PR DESCRIPTION
## Summary

Resolves #84 with a docs-only change. The intid module silently
normalizes negative inputs to \`int.absolute_value\` — this is
intentional and was already documented, but the documentation
buried the note where callers reliably miss it.

## Changes

- **\`src/yabase/intid.gleam\` module docstring**: new dedicated
  \`## Negative inputs are silently absolutized\` subsection at the
  top of the module doc (right after the lead-in). Calls out the
  behaviour as **intentional but footgun-prone**, shows the
  recommended boundary-check pattern, and explains the rationale
  for choosing silent normalization over Result/panic.
- **All 7 \`encode_int_*\` one-line docstrings** changed from
  \"Encode a non-negative \`Int\` ...\" to \"Encode an \`Int\` ...
  Negative inputs are normalized to \`int.absolute_value\`; see the
  module note ...\". Affects: rfc4648, crockford, base10, base36,
  base58_bitcoin, base58_flickr, base62.
- **CHANGELOG entry** under Documentation describing the change.

## Design decisions

- **Behaviour intentionally unchanged.** The original contract
  (silent absolutization) was a deliberate ergonomics choice — most
  short-ID call sites (DB autoincrement, hash truncation, sequence
  number) reach \`encode_int_*\` with values that are already
  non-negative. Forcing \`Result\` everywhere would add boilerplate
  without preventing real bugs, and a \`panic\` would crash on input
  that the docs say is accepted. So the contract stays; the
  visibility increases.
- **Per-function note repeats the module note**. Repetition was the
  whole point — the original docstring did say it, but in a place
  where readers stopped reading before getting there. A short
  one-line note on every relevant function ensures the behaviour
  shows up in editor tooltips / hover docs / generated API docs.
- **Recommended pattern shown in the module note**:
  \`\`\`gleam
  case n >= 0 {
    True -> Ok(encode_int_base32_crockford(n))
    False -> Error(MyDomainError.NegativeId(n))
  }
  \`\`\`
  — the boundary check belongs in the caller's domain-error layer,
  not in yabase. yabase stays a small primitives library.
- **The \`_check\` variants** (\`encode_int_base32_crockford_check\`,
  \`encode_int_base58check\`) were not touched. Their docstrings
  already focus on the checksum behavior and reference base32 /
  base58 underneath, which transitively inherit the absolutization.

## Verification

- \`just check\` passes (793 tests, README snippets verified).
- No source code changes — only docstrings, CHANGELOG.

Closes #84