### PR TITLE
feat: add base16.decode_strict for canonical-form hex verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`yabase/base16.decode_strict/1`**: canonical-form check for hex
+  digests, mirroring the existing `decode_strict` on `base32/rfc4648`
+  and `base64/standard`. Returns `Error(NonCanonical)` for input
+  that decodes successfully but is not byte-equal to `encode/1`'s
+  output — i.e. lowercase (`encode_lowercase/1`'s output), mixed
+  case, or any other deviation from the RFC 4648 §8 canonical
+  uppercase form. Useful for HMAC/TOTP/WebAuthn/content-addressable
+  storage workflows where the encoded string itself is part of the
+  contract. Other failure modes (`InvalidCharacter`,
+  `InvalidLength`) surface unchanged from `decode/1`. Closes #87.
+
 ### Documentation
 
 - **`yabase/intid` negative-input handling**: every `encode_int_*`

--- a/src/yabase/base16.gleam
+++ b/src/yabase/base16.gleam
@@ -8,7 +8,9 @@ import gleam/bit_array
 import gleam/int
 import gleam/list
 import gleam/string
-import yabase/core/error.{type CodecError, InvalidCharacter, InvalidLength}
+import yabase/core/error.{
+  type CodecError, InvalidCharacter, InvalidLength, NonCanonical,
+}
 import yabase/core/guard
 
 /// Encode a BitArray to an uppercase hexadecimal string per
@@ -58,6 +60,30 @@ pub fn decode(input: String) -> Result(BitArray, CodecError) {
   case len % 2 {
     0 -> decode_pairs(chars, <<>>, 0)
     _ -> Error(InvalidLength(len))
+  }
+}
+
+/// Decode `input` and additionally reject non-canonical encodings
+/// per RFC 4648 §8: the canonical Base 16 form is uppercase
+/// (`0-9 A-F`). Useful for HMAC / TOTP / WebAuthn / content-
+/// addressable storage and any signature-verification context where
+/// the encoded string itself is part of the contract — strict mode
+/// rejects the lowercase form (`encode_lowercase/1`'s output) as
+/// non-canonical even though it decodes to the same bytes through
+/// the lenient `decode/1`.
+///
+/// Returns `Error(NonCanonical)` when the input is not byte-equal
+/// to `encode(decode(input))`. Other failure modes
+/// (`InvalidCharacter`, `InvalidLength`) are surfaced unchanged from
+/// `decode/1`.
+pub fn decode_strict(input: String) -> Result(BitArray, CodecError) {
+  case decode(input) {
+    Error(e) -> Error(e)
+    Ok(bytes) ->
+      case encode(bytes) == input {
+        True -> Ok(bytes)
+        False -> Error(NonCanonical)
+      }
   }
 }
 

--- a/test/base16_test.gleam
+++ b/test/base16_test.gleam
@@ -1,5 +1,5 @@
 import yabase/base16
-import yabase/core/error.{InvalidCharacter, InvalidLength}
+import yabase/core/error.{InvalidCharacter, InvalidLength, NonCanonical}
 
 // --- Fixed vectors ---
 
@@ -112,4 +112,44 @@ pub fn roundtrip_leading_zeros_test() -> Nil {
 pub fn roundtrip_high_bits_test() -> Nil {
   let data = <<0xff, 0xfe, 0xfd, 0x80, 0x00>>
   assert base16.decode(base16.encode(data)) == Ok(data)
+}
+
+// ===== decode_strict (RFC 4648 §8 canonical-uppercase check) =====
+
+pub fn decode_strict_canonical_uppercase_passes_test() -> Nil {
+  // Canonical RFC 4648 §8 form is uppercase A-F.
+  assert base16.decode_strict("DEADBEEF") == Ok(<<0xde, 0xad, 0xbe, 0xef>>)
+}
+
+pub fn decode_strict_lowercase_rejected_test() -> Nil {
+  // Lowercase is the opt-in non-canonical form (encode_lowercase).
+  // The strict path rejects it even though decode/1 accepts it.
+  assert base16.decode_strict("deadbeef") == Error(NonCanonical)
+}
+
+pub fn decode_strict_mixed_case_rejected_test() -> Nil {
+  // Mixed case is non-canonical.
+  assert base16.decode_strict("DeAdBeEf") == Error(NonCanonical)
+}
+
+pub fn decode_strict_propagates_invalid_character_test() -> Nil {
+  // Non-hex characters surface unchanged from decode/1 — strict
+  // does not mask other failure modes.
+  assert case base16.decode_strict("Z0") {
+    Error(InvalidCharacter(_, _)) -> True
+    _ -> False
+  }
+}
+
+pub fn decode_strict_propagates_invalid_length_test() -> Nil {
+  // Odd-length input surfaces InvalidLength from decode/1.
+  assert case base16.decode_strict("ABC") {
+    Error(InvalidLength(_)) -> True
+    _ -> False
+  }
+}
+
+pub fn decode_strict_empty_passes_test() -> Nil {
+  // Empty input encodes to empty string — that is canonical.
+  assert base16.decode_strict("") == Ok(<<>>)
 }


### PR DESCRIPTION
## Summary

Adds \`base16.decode_strict/1\` to close the API symmetry gap with
\`base32/rfc4648\` and \`base64/standard\`, both of which already
expose \`decode_strict\`.

## Changes

- New \`pub fn decode_strict(input: String) -> Result(BitArray, CodecError)\`
  in \`src/yabase/base16.gleam\`.
- Imports \`NonCanonical\` from \`yabase/core/error\`.
- Adds 6 regression tests in \`test/base16_test.gleam\`.

## Design decisions

- **Canonical form is RFC 4648 §8 uppercase** (\`encode/1\`'s output).
  \`encode_lowercase/1\` is the documented opt-in non-canonical form,
  so \`decode_strict\` rejects its output even though the lenient
  \`decode/1\` accepts it. This matches the contract the package
  already advertises in \`encode/1\`'s docstring.
- **Same shape as \`base64/standard.decode_strict\` and (post-#86)
  \`base32/rfc4648.decode_strict\`**: the canonicality check is
  byte-equal (\`encode(bytes) == input\`). No \`string.uppercase\` or
  other normalization step — that is exactly the bug #86 closed,
  and reintroducing it here would defeat the purpose.
- **\`decode/1\` itself is unchanged**. The lenient read path still
  accepts both cases per the existing \"the decoder remains
  case-insensitive\" contract noted in the module-level docstring.

## Verification

- \`just check\` passes (799 tests, README snippets verified).

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict Base16 decoder to enforce canonical uppercase hexadecimal format validation.

* **Tests**
  * Added comprehensive test coverage for canonical form validation and error handling.

* **Documentation**
  * Updated changelog documenting strict decoding behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/yabase/pull/90)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->