### PR TITLE
feat: add intid.encode_int_base16 / decode_int_base16 / bounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`yabase/intid.encode_int_base16` / `decode_int_base16` /
+  `decode_int_base16_bounded`**: closes the API symmetry gap where
+  every other base in `intid` (base10, base32 RFC 4648 / Crockford,
+  base36, base58 Bitcoin / Flickr / check, base62) had `encode_int_*`
+  and `decode_int_*` helpers but base16 was missing. The new helpers
+  route through `yabase/base16` and use the canonical RFC 4648 §8
+  uppercase output. Lenient case-insensitive read on the decode side,
+  matching the rest of the family. Adds 9 regression tests covering
+  zero, single byte, canonical uppercase, empty input rejection,
+  round-trip, case-insensitive read, invalid character, and the
+  bounded variants. Closes #85.
 - **`yabase/base16.decode_strict/1`**: canonical-form check for hex
   digests, mirroring the existing `decode_strict` on `base32/rfc4648`
   and `base64/standard`. Returns `Error(NonCanonical)` for input

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -76,6 +76,7 @@ import gleam/int
 import gleam/result
 import gleam/string
 import yabase/base10
+import yabase/base16
 import yabase/base32/crockford as base32_crockford
 import yabase/base32/rfc4648 as base32_rfc4648
 import yabase/base36
@@ -188,6 +189,39 @@ pub fn decode_int_base10_bounded(
   max max: Int,
 ) -> Result(Int, CodecError) {
   use value <- result.try(decode_int_base10(input))
+  bound_check(value, max)
+}
+
+/// Encode an `Int` as a Base16 (uppercase hexadecimal) string.
+/// Negative inputs are normalized to `int.absolute_value`; see the
+/// module note on "Negative inputs are silently absolutized".
+///
+/// Routing through `base16.encode` keeps the contract uniform with
+/// the rest of the `encode_int_*` family. The output uses the
+/// canonical RFC 4648 §8 uppercase alphabet (`0-9 A-F`) — callers
+/// who need lowercase for interop with `sha256sum`-style tools can
+/// post-process with `string.lowercase` or use `base16.encode_lowercase`
+/// after `int_to_bytes_be` themselves.
+pub fn encode_int_base16(value: Int) -> String {
+  base16.encode(int_to_bytes_be(value))
+}
+
+/// Decode a Base16 (hexadecimal) string back to an `Int`. Accepts
+/// both uppercase and lowercase input via `base16.decode`'s
+/// case-insensitive alphabet.
+pub fn decode_int_base16(input: String) -> Result(Int, CodecError) {
+  use input <- result.try(reject_empty(input))
+  base16.decode(input)
+  |> result.map(bytes_to_int)
+}
+
+/// Decode a Base16 (hexadecimal) string back to an `Int`, rejecting
+/// values greater than `max` with `Error(Overflow)`.
+pub fn decode_int_base16_bounded(
+  input input: String,
+  max max: Int,
+) -> Result(Int, CodecError) {
+  use value <- result.try(decode_int_base16(input))
   bound_check(value, max)
 }
 

--- a/test/intid_test.gleam
+++ b/test/intid_test.gleam
@@ -116,6 +116,55 @@ pub fn decode_int_base10_bounded_overflow_test() -> Nil {
     == Error(Overflow)
 }
 
+// === encoding.base16() (#85) ===
+
+pub fn encode_int_base16_zero_test() -> Nil {
+  assert intid.encode_int_base16(0) == "00"
+}
+
+pub fn encode_int_base16_single_byte_test() -> Nil {
+  assert intid.encode_int_base16(255) == "FF"
+}
+
+pub fn encode_int_base16_canonical_uppercase_test() -> Nil {
+  // Uses RFC 4648 §8 canonical uppercase, matching base16.encode.
+  assert intid.encode_int_base16(0xdeadbeef) == "DEADBEEF"
+}
+
+pub fn decode_int_base16_empty_test() -> Nil {
+  assert intid.decode_int_base16("") == Error(InvalidLength(0))
+}
+
+pub fn decode_int_base16_round_trip_test() -> Nil {
+  let encoded = intid.encode_int_base16(8_675_309)
+  assert intid.decode_int_base16(encoded) == Ok(8_675_309)
+}
+
+pub fn decode_int_base16_case_insensitive_test() -> Nil {
+  // base16.decode accepts both cases; intid surfaces the same
+  // lenient read behaviour.
+  assert intid.decode_int_base16("DEADBEEF")
+    == intid.decode_int_base16("deadbeef")
+}
+
+pub fn decode_int_base16_invalid_char_test() -> Nil {
+  assert intid.decode_int_base16("12Z3") == Error(InvalidCharacter("z", 2))
+}
+
+pub fn decode_int_base16_bounded_within_max_test() -> Nil {
+  assert intid.decode_int_base16_bounded(input: "FF", max: 1000) == Ok(255)
+}
+
+pub fn decode_int_base16_bounded_at_max_test() -> Nil {
+  // Hex requires even-length input; "00FF" zero-pads to 4 chars.
+  assert intid.decode_int_base16_bounded(input: "00FF", max: 255) == Ok(255)
+}
+
+pub fn decode_int_base16_bounded_overflow_test() -> Nil {
+  assert intid.decode_int_base16_bounded(input: "FFFF", max: 255)
+    == Error(Overflow)
+}
+
 // === encoding.base36() ===
 
 pub fn encode_int_base36_zero_test() -> Nil {


### PR DESCRIPTION
## Summary

Closes the API symmetry gap where every other base in the \`intid\`
family had \`encode_int_*\` / \`decode_int_*\` helpers but base16 was
missing. Adds the three standard helpers, routing through
\`yabase/base16\`.

## Changes

| Function | Behaviour |
|----------|-----------|
| \`encode_int_base16(value: Int) -> String\` | Emits canonical RFC 4648 §8 uppercase |
| \`decode_int_base16(input: String) -> Result(Int, CodecError)\` | Case-insensitive, matches \`base16.decode\` |
| \`decode_int_base16_bounded(input:, max:) -> Result(Int, CodecError)\` | Same + \`Error(Overflow)\` when value exceeds max |

Also imports \`yabase/base16\` and adds 9 regression tests
(\`encode_int_base16_*_test\` and \`decode_int_base16_*_test\`)
mirroring the existing base10 / base36 / base58 test patterns.

## Design decisions

- **Canonical uppercase output** matches \`base16.encode\`, which is
  the package's own canonical-form contract per RFC 4648 §8.
  Callers needing lowercase for interop can wrap with
  \`string.lowercase\` themselves — keeping the intid surface
  uniformly canonical avoids a one-off lowercase variant just for
  base16.
- **Case-insensitive read**: matches the lenient-read posture of
  every other \`decode_int_*\` in the family. The \`_strict\` /
  canonical-form check belongs on the byte-oriented
  \`base16.decode_strict\` (added in #87), not on \`intid\`.
- **Same shape as \`encode_int_base10\` (#78)**: routes through
  \`base16.encode\` + \`int_to_bytes_be\` so the contract is uniform
  with the rest of the family.
- **\`encode_int_base16(0) == \"00\"\`** because \`int_to_bytes_be(0)
  == <<0>>\` (one zero byte) and \`base16.encode(<<0>>) == \"00\"\`.
  This matches \`encode_int_base32_rfc4648(0) == \"AA======\"\` —
  every codec in this family encodes zero as the alphabet's zero
  representation in a one-position frame, not the empty string.

## Verification

- \`just check\` passes (809 tests, README snippets verified).

## Limitations

- The bounded variant requires even-length input (because base16
  requires it). The \`decode_int_base16_bounded(\"0FF\", ...)\`
  three-character form returns \`Error(InvalidLength(3))\` — callers
  must zero-pad to even length (\`\"00FF\"\`). The test suite covers
  this with the \`00FF\" → 255\` case.

Closes #85