### PR TITLE
chore(release): prepare v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-05-11
+
 ### Added
 
 - **`yabase/intid.encode_int_base16` / `decode_int_base16` /

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.18.0"
+version = "0.19.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Added

- **`yabase/intid.encode_int_base16` / `decode_int_base16` /
  `decode_int_base16_bounded`**: closes the API symmetry gap where
  every other base in `intid` (base10, base32 RFC 4648 / Crockford,
  base36, base58 Bitcoin / Flickr / check, base62) had `encode_int_*`
  and `decode_int_*` helpers but base16 was missing. The new helpers
  route through `yabase/base16` and use the canonical RFC 4648 §8
  uppercase output. Lenient case-insensitive read on the decode side,
  matching the rest of the family. Closes #85.
- **`yabase/base16.decode_strict/1`**: canonical-form check for hex
  digests, mirroring the existing `decode_strict` on `base32/rfc4648`
  and `base64/standard`. Returns `Error(NonCanonical)` for input
  that decodes successfully but is not byte-equal to `encode/1`'s
  output — i.e. lowercase (`encode_lowercase/1`'s output), mixed
  case, or any other deviation from the RFC 4648 §8 canonical
  uppercase form. Useful for HMAC/TOTP/WebAuthn/content-addressable
  storage workflows where the encoded string itself is part of the
  contract. Closes #87.

### Documentation

- **`yabase/intid` negative-input handling**: every `encode_int_*`
  function silently normalizes negative inputs to
  `int.absolute_value`. Move the negative-input note to a dedicated
  `## Negative inputs are silently absolutized` subsection at the
  top of the module doc, calling it out as an intentional but
  footgun-prone design choice. Update every `encode_int_*`
  function's one-line docstring to read "Negative inputs are
  normalized to `int.absolute_value`; see the module note ..." so
  callers can't miss it. Behaviour itself is unchanged — the
  contract is the same, just made more visible. Closes #84.

### Fixed

- **Security / Functional Suitability**: `base32/rfc4648.decode_strict`
  was upper-casing the input before comparing to the canonical
  re-encoding (`encode(bytes) == string.uppercase(input)`), which
  silently accepted lowercase and mixed-case input — exactly the
  axis the strict path exists to gate. The check is now byte-equal
  (`encode(bytes) == input`), so lowercase, mixed-case, missing
  padding, and any other deviation from `encode/1`'s output are
  rejected with `Error(NonCanonical)`. Closes the replay-attack
  surface where two distinct wire forms validated as canonical for
  the same bytes — important for HMAC / TOTP / WebAuthn /
  content-addressable-storage use cases. Closes #86.
