### PR TITLE
feat(intid): add generic encode_int / decode_int facade for runtime codec selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `intid.encode_int(encoding:, value:)`,
+  `intid.decode_int(encoding:, value:)`, and
+  `intid.decode_int_bounded(encoding:, value:, max:)`: the generic
+  integer-side facade that mirrors `yabase.encode` / `yabase.decode`
+  for runtime codec selection. Picks the right per-base helper from
+  an `Encoding` value so callers writing their own dispatch
+  (`case enc { Base58 -> intid.encode_int_base58(n); ... }`) can
+  delete the boilerplate. Supports the same integer-domain codecs
+  the per-base helpers already cover (Base10, Base16, Base32
+  RFC4648 / Crockford / CrockfordCheck, Base36, Base58 Bitcoin /
+  Flickr, Base58Check, Base62). Surfaces a new `UnsupportedForInt`
+  error variant on `CodecError` for byte-only encodings (Base2,
+  Base8, Base64 family, Base85 family, Base91, Bech32, the
+  remaining Base32 variants). The per-base `encode_int_*` /
+  `decode_int_*` / `decode_int_*_bounded` helpers stay for callers
+  who pick the codec at compile time — no breaking change. (#93)
+
 ## [0.19.0] - 2026-05-11
 
 ### Added

--- a/src/yabase/core/encoding.gleam
+++ b/src/yabase/core/encoding.gleam
@@ -335,6 +335,78 @@ pub fn supports_target(enc: Encoding, target: Target) -> Bool {
 }
 
 // ---------------------------------------------------------------------------
+// Integer codec dispatch tags.
+//
+// `Encoding` is opaque so callers cannot pattern-match its variants
+// from outside this module. The `intid` facade needs to branch on
+// the variant to dispatch `encode_int` / `decode_int` to the right
+// per-base helper without re-implementing the integer ↔ bytes shim
+// in this module (which would introduce an import cycle with the
+// per-base modules). `IntCodec` is the non-opaque tag the facade
+// reads via `int_codec/1`. The variants enumerate exactly the
+// encodings that `yabase/intid` currently supports; everything else
+// surfaces as `IntCodecUnsupported(name)` so the facade can return
+// `UnsupportedForInt(name)` without losing the encoding identity.
+// ---------------------------------------------------------------------------
+
+/// A tag describing which integer codec, if any, `yabase/intid`
+/// should dispatch to for a given `Encoding`. Used by the
+/// `intid.encode_int` / `intid.decode_int` facade; not interesting
+/// for callers that pick the codec at compile time and reach for
+/// the per-base `encode_int_*` / `decode_int_*` helpers directly.
+pub type IntCodec {
+  IntBase10
+  IntBase16
+  IntBase32Rfc4648
+  IntBase32Crockford
+  IntBase32CrockfordCheck
+  IntBase36
+  IntBase58Bitcoin
+  IntBase58Flickr
+  IntBase58Check(version: Int)
+  IntBase62
+  /// The `Encoding` has no integer codec wired up; the carried
+  /// name is the encoding's display identity for use in
+  /// `UnsupportedForInt(name)`.
+  IntCodecUnsupported(name: String)
+}
+
+/// Map an `Encoding` to the tag describing how `yabase/intid` should
+/// handle it. Internal to the package — exposed because `intid` lives
+/// in a separate module but needs to branch on the opaque variant.
+pub fn int_codec(enc: Encoding) -> IntCodec {
+  case enc {
+    Base10 -> IntBase10
+    Base16 -> IntBase16
+    Base32(RFC4648) -> IntBase32Rfc4648
+    Base32(Crockford) -> IntBase32Crockford
+    Base32(CrockfordCheck) -> IntBase32CrockfordCheck
+    Base36 -> IntBase36
+    Base58(Bitcoin) -> IntBase58Bitcoin
+    Base58(Flickr) -> IntBase58Flickr
+    Base58Check(version) -> IntBase58Check(version)
+    Base62 -> IntBase62
+    Base2 -> IntCodecUnsupported("Base2")
+    Base8 -> IntCodecUnsupported("Base8")
+    Base32(Hex) -> IntCodecUnsupported("Base32(Hex)")
+    Base32(Clockwork) -> IntCodecUnsupported("Base32(Clockwork)")
+    Base32(ZBase32) -> IntCodecUnsupported("Base32(ZBase32)")
+    Base45 -> IntCodecUnsupported("Base45")
+    Base64(Standard) -> IntCodecUnsupported("Base64(Standard)")
+    Base64(UrlSafe) -> IntCodecUnsupported("Base64(UrlSafe)")
+    Base64(NoPadding) -> IntCodecUnsupported("Base64(NoPadding)")
+    Base64(UrlSafeNoPadding) -> IntCodecUnsupported("Base64(UrlSafeNoPadding)")
+    Base64(DQ) -> IntCodecUnsupported("Base64(DQ)")
+    Base85(Btoa) -> IntCodecUnsupported("Base85(Btoa)")
+    Base85(Adobe) -> IntCodecUnsupported("Base85(Adobe)")
+    Base85(Rfc1924) -> IntCodecUnsupported("Base85(Rfc1924)")
+    Base85(Z85) -> IntCodecUnsupported("Base85(Z85)")
+    Base91 -> IntCodecUnsupported("Base91")
+    Bech32(_, _) -> IntCodecUnsupported("Bech32")
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Dispatch.
 // ---------------------------------------------------------------------------
 

--- a/src/yabase/core/error.gleam
+++ b/src/yabase/core/error.gleam
@@ -29,6 +29,14 @@ pub type CodecError {
   /// verification, content-addressable storage, audit comparisons)
   /// can opt into it.
   NonCanonical
+  /// The chosen `Encoding` has no integer-domain codec wired up in
+  /// `yabase/intid`. Surfaces from `intid.encode_int` /
+  /// `intid.decode_int` when the dispatch is asked to handle a
+  /// byte-only encoding (e.g. Base64, Base85, Bech32) for which an
+  /// `Int -> string` mapping would have no canonical form. Carries
+  /// the encoding's name so the caller can render an actionable
+  /// error.
+  UnsupportedForInt(encoding_name: String)
 }
 
 /// Bech32 encoding variant.

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -84,8 +84,10 @@ import yabase/base58/bitcoin as base58_bitcoin
 import yabase/base58/flickr as base58_flickr
 import yabase/base58check
 import yabase/base62
+import yabase/core/encoding
 import yabase/core/error.{
-  type CodecError as CoreCodecError, InvalidLength, Overflow,
+  type CodecError as CoreCodecError, InvalidChecksum, InvalidLength, Overflow,
+  UnsupportedForInt,
 }
 import yabase/internal/bignum
 
@@ -397,6 +399,106 @@ pub fn decode_int_base62_bounded(
 ) -> Result(Int, CodecError) {
   use value <- result.try(decode_int_base62(input))
   bound_check(value, max)
+}
+
+// ---------------------------------------------------------------------------
+// Generic Encoding -> Int facade (#93)
+//
+// The per-base helpers above are the right tool when the codec is
+// known at compile time. The facade is the right tool when the
+// codec is picked at runtime (multibase auto-detection, user
+// preference, config). The shape mirrors `yabase.encode` /
+// `yabase.decode` so a call site that already uses the byte facade
+// reads the integer-side call the same way.
+// ---------------------------------------------------------------------------
+
+/// Encode an `Int` to a string using the supplied `Encoding`,
+/// dispatching to the matching `encode_int_*` helper. Negative
+/// inputs are normalised to `int.absolute_value` exactly as the
+/// per-base helpers do; see the module note on "Negative inputs
+/// are silently absolutized" for the rationale and the
+/// boundary-check pattern.
+///
+/// Returns `Error(UnsupportedForInt(name))` for encodings that have
+/// no integer codec wired up (every byte-only codec: `Base2`,
+/// `Base8`, `Base32(Hex|Clockwork|ZBase32)`, `Base45`, every
+/// `Base64` / `Base85` variant, `Base91`, `Bech32`). For
+/// `Base58Check`, the existing `encode_int_base58check/1` helper
+/// uses the fixed version byte `0x00`; reach for the generic
+/// facade with `encoding.base58_check(version)` to pin a different
+/// version.
+pub fn encode_int(
+  encoding encoding: encoding.Encoding,
+  value value: Int,
+) -> Result(String, CodecError) {
+  case encoding.int_codec(encoding) {
+    encoding.IntBase10 -> Ok(encode_int_base10(value))
+    encoding.IntBase16 -> Ok(encode_int_base16(value))
+    encoding.IntBase32Rfc4648 -> Ok(encode_int_base32_rfc4648(value))
+    encoding.IntBase32Crockford -> Ok(encode_int_base32_crockford(value))
+    encoding.IntBase32CrockfordCheck ->
+      Ok(encode_int_base32_crockford_check(value))
+    encoding.IntBase36 -> Ok(encode_int_base36(value))
+    encoding.IntBase58Bitcoin -> Ok(encode_int_base58(value))
+    encoding.IntBase58Flickr -> Ok(encode_int_base58_flickr(value))
+    encoding.IntBase58Check(version) ->
+      base58check.encode(version, int_to_bytes_be(value))
+    encoding.IntBase62 -> Ok(encode_int_base62(value))
+    encoding.IntCodecUnsupported(name) -> Error(UnsupportedForInt(name))
+  }
+}
+
+/// Decode a string back to an `Int` using the supplied `Encoding`,
+/// dispatching to the matching `decode_int_*` helper.
+///
+/// Empty input returns `Error(InvalidLength(0))` so callers can
+/// distinguish "no ID was supplied" from "the ID is zero" — the
+/// same contract as the per-base helpers.
+///
+/// Returns `Error(UnsupportedForInt(name))` for encodings that have
+/// no integer codec wired up.
+pub fn decode_int(
+  encoding encoding: encoding.Encoding,
+  value value: String,
+) -> Result(Int, CodecError) {
+  case encoding.int_codec(encoding) {
+    encoding.IntBase10 -> decode_int_base10(value)
+    encoding.IntBase16 -> decode_int_base16(value)
+    encoding.IntBase32Rfc4648 -> decode_int_base32_rfc4648(value)
+    encoding.IntBase32Crockford -> decode_int_base32_crockford(value)
+    encoding.IntBase32CrockfordCheck -> decode_int_base32_crockford_check(value)
+    encoding.IntBase36 -> decode_int_base36(value)
+    encoding.IntBase58Bitcoin -> decode_int_base58(value)
+    encoding.IntBase58Flickr -> decode_int_base58_flickr(value)
+    encoding.IntBase58Check(version) ->
+      decode_int_base58check_with_version(value, version)
+    encoding.IntBase62 -> decode_int_base62(value)
+    encoding.IntCodecUnsupported(name) -> Error(UnsupportedForInt(name))
+  }
+}
+
+/// Decode a string back to an `Int` using the supplied `Encoding`,
+/// rejecting values greater than `max` with `Error(Overflow)`. The
+/// runtime sibling of the per-base `decode_int_*_bounded` helpers.
+pub fn decode_int_bounded(
+  encoding encoding: encoding.Encoding,
+  value value: String,
+  max max: Int,
+) -> Result(Int, CodecError) {
+  use decoded <- result.try(decode_int(encoding: encoding, value: value))
+  bound_check(decoded, max)
+}
+
+fn decode_int_base58check_with_version(
+  input: String,
+  version: Int,
+) -> Result(Int, CodecError) {
+  use input <- result.try(reject_empty(input))
+  use decoded <- result.try(base58check.decode(input))
+  case decoded.version == version {
+    True -> Ok(bytes_to_int(decoded.payload))
+    False -> Error(InvalidChecksum)
+  }
 }
 
 // `decode_int_*` rejects the empty string so callers can distinguish

--- a/test/intid_test.gleam
+++ b/test/intid_test.gleam
@@ -1,6 +1,7 @@
 import gleam/string
+import yabase/core/encoding
 import yabase/core/error.{
-  InvalidCharacter, InvalidChecksum, InvalidLength, Overflow,
+  InvalidCharacter, InvalidChecksum, InvalidLength, Overflow, UnsupportedForInt,
 }
 import yabase/intid
 
@@ -617,4 +618,102 @@ pub fn intid_codec_error_alias_propagates_through_wrapper_test() -> Nil {
 
 fn decode_job_id(s: String) -> Result(Int, intid.CodecError) {
   intid.decode_int_base58_bounded(input: s, max: intid.int53_max)
+}
+
+// === Issue #93: generic encode_int / decode_int facade ===
+
+pub fn encode_int_facade_matches_per_base_base58_test() -> Nil {
+  let direct = intid.encode_int_base58(42)
+  assert intid.encode_int(encoding: encoding.base58_bitcoin(), value: 42)
+    == Ok(direct)
+}
+
+pub fn encode_int_facade_matches_per_base_base32_crockford_test() -> Nil {
+  let direct = intid.encode_int_base32_crockford(31)
+  assert intid.encode_int(encoding: encoding.base32_crockford(), value: 31)
+    == Ok(direct)
+}
+
+pub fn encode_int_facade_matches_per_base_base62_test() -> Nil {
+  let direct = intid.encode_int_base62(123_456)
+  assert intid.encode_int(encoding: encoding.base62(), value: 123_456)
+    == Ok(direct)
+}
+
+pub fn encode_int_facade_matches_per_base_base16_test() -> Nil {
+  let direct = intid.encode_int_base16(255)
+  assert intid.encode_int(encoding: encoding.base16(), value: 255) == Ok(direct)
+}
+
+pub fn encode_int_facade_unsupported_base64_test() -> Nil {
+  // Base64 has no integer codec. The facade must surface
+  // UnsupportedForInt rather than fall back to byte encoding.
+  let result = intid.encode_int(encoding: encoding.base64_standard(), value: 42)
+  assert result == Error(UnsupportedForInt("Base64(Standard)"))
+}
+
+pub fn encode_int_facade_unsupported_bech32_test() -> Nil {
+  let result = intid.encode_int(encoding: encoding.bech32("bc"), value: 42)
+  assert result == Error(UnsupportedForInt("Bech32"))
+}
+
+pub fn decode_int_facade_matches_per_base_base58_test() -> Nil {
+  let encoded = intid.encode_int_base58(42)
+  assert intid.decode_int(encoding: encoding.base58_bitcoin(), value: encoded)
+    == Ok(42)
+}
+
+pub fn decode_int_facade_rejects_empty_input_test() -> Nil {
+  // Same contract as the per-base decoders: empty input is
+  // InvalidLength(0), not the integer zero.
+  assert intid.decode_int(encoding: encoding.base58_bitcoin(), value: "")
+    == Error(InvalidLength(0))
+}
+
+pub fn decode_int_facade_unsupported_test() -> Nil {
+  assert intid.decode_int(encoding: encoding.base85_z85(), value: "abc")
+    == Error(UnsupportedForInt("Base85(Z85)"))
+}
+
+pub fn encode_int_then_decode_int_round_trip_test() -> Nil {
+  let enc = encoding.base58_bitcoin()
+  let assert Ok(encoded) = intid.encode_int(encoding: enc, value: 1_234_567)
+  assert intid.decode_int(encoding: enc, value: encoded) == Ok(1_234_567)
+}
+
+pub fn decode_int_bounded_facade_overflow_test() -> Nil {
+  let enc = encoding.base58_bitcoin()
+  let assert Ok(encoded) = intid.encode_int(encoding: enc, value: 1_000_000)
+  // The encoded value (1_000_000) exceeds max=10, so the bounded
+  // facade returns Overflow — same shape as decode_int_*_bounded.
+  let result = intid.decode_int_bounded(encoding: enc, value: encoded, max: 10)
+  assert result == Error(Overflow)
+}
+
+pub fn decode_int_bounded_facade_within_range_test() -> Nil {
+  let enc = encoding.base32_crockford()
+  let assert Ok(encoded) = intid.encode_int(encoding: enc, value: 100)
+  let result =
+    intid.decode_int_bounded(encoding: enc, value: encoded, max: 1000)
+  assert result == Ok(100)
+}
+
+pub fn encode_int_facade_base58check_test() -> Nil {
+  // The version goes through the IntBase58Check carrier so a
+  // non-default version reaches the underlying codec.
+  let assert Ok(s) =
+    intid.encode_int(encoding: encoding.base58_check(5), value: 42)
+  // The decoded round trip is verified against the same version.
+  assert intid.decode_int(encoding: encoding.base58_check(5), value: s)
+    == Ok(42)
+}
+
+pub fn decode_int_facade_base58check_version_mismatch_test() -> Nil {
+  // Encode with version 5, decode with version 0 → InvalidChecksum,
+  // matching what `yabase.decode` does for Base58Check at the byte
+  // layer.
+  let assert Ok(s) =
+    intid.encode_int(encoding: encoding.base58_check(5), value: 42)
+  assert intid.decode_int(encoding: encoding.base58_check(0), value: s)
+    == Error(InvalidChecksum)
 }


### PR DESCRIPTION
## Summary

Fixes #93 — `yabase.encode` / `yabase.decode` already let callers pick the codec at runtime over `BitArray`, but the integer side (`intid.*`) had no parallel. Anyone writing dynamic dispatch had to maintain their own `case my_enum { Base58 -> intid.encode_int_base58(n); ... }` mapping at every call site.

## Approach

- New `intid.encode_int(encoding:, value:) -> Result(String, CodecError)`, `intid.decode_int(encoding:, value:) -> Result(Int, CodecError)`, and `intid.decode_int_bounded(encoding:, value:, max:) -> Result(Int, CodecError)` mirror the `yabase.encode` / `yabase.decode` shape.
- Dispatch goes through a new public `encoding.IntCodec` tag returned by `encoding.int_codec/1`. `Encoding` stays opaque externally; `IntCodec` is the non-opaque variant set `intid` matches against.
- Byte-only encodings (Base2, Base8, every Base64 / Base85 variant, Base91, Bech32, and the byte-only Base32 variants) surface the new `UnsupportedForInt(encoding_name: String)` `CodecError` variant with the encoding's display identity.
- The per-base `encode_int_*` / `decode_int_*` / `decode_int_*_bounded` helpers stay for callers who pick the codec at compile time. No breaking change.

## Changes

- `src/yabase/core/error.gleam`: add `UnsupportedForInt(encoding_name: String)`.
- `src/yabase/core/encoding.gleam`: add `IntCodec` enum + `int_codec/1` accessor for every `Encoding` variant.
- `src/yabase/intid.gleam`: add `encode_int` / `decode_int` / `decode_int_bounded` facades; new import of `encoding`.
- `test/intid_test.gleam`: facade-matches-per-base, unsupported-encoding, round-trip, bounded-overflow, and Base58Check version-mismatch tests.
- `CHANGELOG.md`: noted under `[Unreleased]`.

## Test plan

- `gleam test` — 823 passed, no failures.
- `gleam format`, `gleam check` clean.

Closes #93
