### PR TITLE
chore(release): prepare v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-05-12
+
 ### Added
 
 - `intid.encode_int(encoding:, value:)`,

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.19.0"
+version = "0.20.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Added

- `intid.encode_int(encoding:, value:)`,
  `intid.decode_int(encoding:, value:)`, and
  `intid.decode_int_bounded(encoding:, value:, max:)`: the generic
  integer-side facade that mirrors `yabase.encode` / `yabase.decode`
  for runtime codec selection. Picks the right per-base helper from
  an `Encoding` value so callers writing their own dispatch
  (`case enc { Base58 -> intid.encode_int_base58(n); ... }`) can
  delete the boilerplate. Supports the same integer-domain codecs
  the per-base helpers already cover (Base10, Base16, Base32
  RFC4648 / Crockford / CrockfordCheck, Base36, Base58 Bitcoin /
  Flickr, Base58Check, Base62). Surfaces a new `UnsupportedForInt`
  error variant on `CodecError` for byte-only encodings (Base2,
  Base8, Base64 family, Base85 family, Base91, Bech32, the
  remaining Base32 variants). The per-base `encode_int_*` /
  `decode_int_*` / `decode_int_*_bounded` helpers stay for callers
  who pick the codec at compile time — no breaking change. (#93)
