### PR TITLE
docs(readme): annotate decode_base64_strict result as Error(NonCanonical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- README's `decode_base64_strict("TR==")` example now annotates the result as `Error(NonCanonical)` instead of `Error(InvalidPadding)`. The `CodecError` type has no `InvalidPadding` constructor, so pattern-matching the README's snippet failed to compile. The strict decoders' own doc-strings already used the correct variant name; this fix aligns the README with both the type and the docstrings. (#96)
+
 ## [0.20.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ let _lenient = facade.decode_base64("TR==")
 
 // Strict — rejects non-canonical input per RFC 4648 §3.5:
 let _strict = facade.decode_base64_strict("TR==")
-// -> Error(InvalidPadding)
+// -> Error(NonCanonical)
 ```
 
 Available facade pairs:


### PR DESCRIPTION
## Summary

The README's strict-decode example annotated `facade.decode_base64_strict(\"TR==\")` as returning `Error(InvalidPadding)`, but the `CodecError` type has no `InvalidPadding` constructor — the strict decoders return `Error(NonCanonical)`. A reader who copied the README snippet into a `case` arm got a `Unknown constructor` compile error. The strict decoders' own doc-strings (in `src/yabase/facade.gleam:107` and `:238`) already use the correct variant name; only the README was wrong.

## Changes

- [README.md](README.md) Strict-decode example now annotates the result as `Error(NonCanonical)`, matching the actual `CodecError` constructor and the per-function docstring.
- [CHANGELOG.md](CHANGELOG.md) Unreleased Documentation entry.

Closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected README example to accurately reflect that strict base64 decoding of "TR==" returns a `NonCanonical` error variant instead of `InvalidPadding`, aligning documentation with actual codec behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/yabase/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->