### PR TITLE
chore(release): prepare v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-05-18
+
 ### Documentation
 
 - README's `decode_base64_strict("TR==")` example now annotates the result as `Error(NonCanonical)` instead of `Error(InvalidPadding)`. The `CodecError` type has no `InvalidPadding` constructor, so pattern-matching the README's snippet failed to compile. The strict decoders' own doc-strings already used the correct variant name; this fix aligns the README with both the type and the docstrings. (#96)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.20.0"
+version = "0.21.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Documentation

- README's `decode_base64_strict("TR==")` example now annotates the result as `Error(NonCanonical)` instead of `Error(InvalidPadding)`. The `CodecError` type has no `InvalidPadding` constructor, so pattern-matching the README's snippet failed to compile. The strict decoders' own doc-strings already used the correct variant name; this fix aligns the README with both the type and the docstrings. (#96)
