### PR TITLE
feat(intid): add encode_int_base16_compact and odd-length decode_int_base16 (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `intid.encode_int_base16_compact/1`: leading-zero-dropping companion to the existing byte-aligned `intid.encode_int_base16/1`, so the `encode_int_*` family now has a uniform compact variant across base10/base16/base36/base58/base62 (`encode_int_base16_compact(1) == "1"`, `encode_int_base16_compact(2025) == "7E9"`); the byte-aligned `encode_int_base16/1` is unchanged. `intid.decode_int_base16/1` now also accepts odd-length input (internally zero-padded on the left), so `decode_int_base16(encode_int_base16_compact(n)) == Ok(n)` round-trips for every non-negative `Int`; the low-level `base16.decode/1` keeps its strict even-length contract. (#99)
+
 ## [0.21.0] - 2026-05-18
 
 ### Documentation

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -204,16 +204,88 @@ pub fn decode_int_base10_bounded(
 /// who need lowercase for interop with `sha256sum`-style tools can
 /// post-process with `string.lowercase` or use `base16.encode_lowercase`
 /// after `int_to_bytes_be` themselves.
+///
+/// ## Byte-aligned vs compact
+///
+/// This function is **byte-aligned**: the output length is always an
+/// even number of hex characters because the encoding pads the
+/// integer's big-endian representation to a whole byte boundary
+/// (`encode_int_base16(1) == "01"`, `encode_int_base16(2025) ==
+/// "07E9"`). This is the right shape for ID interop with
+/// byte-oriented systems (databases, HTTP headers, content-
+/// addressable storage). The other `encode_int_*` functions in this
+/// module are *compact* — they drop leading zero characters
+/// (`encode_int_base58(1) == "2"`, `encode_int_base36(1) == "1"`,
+/// `encode_int_base10(1) == "1"`). Issue #99 surfaced the
+/// asymmetry; if you want the compact form for `base16`, use
+/// `encode_int_base16_compact/1` instead. `decode_int_base16/1`
+/// accepts either form (it does not require an even-length input).
 pub fn encode_int_base16(value: Int) -> String {
   base16.encode(int_to_bytes_be(value))
+}
+
+/// Encode an `Int` as a Base16 (uppercase hexadecimal) string with
+/// leading zero characters stripped — the compact counterpart to
+/// `encode_int_base16/1`.
+///
+/// ## Byte-aligned vs compact
+///
+/// `encode_int_base16/1` is **byte-aligned** (always emits an even
+/// number of hex characters: `encode_int_base16(1) == "01"`,
+/// `encode_int_base16(2025) == "07E9"`). This function is **compact**
+/// — leading `"0"` characters are dropped so the output matches the
+/// shape of the rest of the `encode_int_*` family
+/// (`encode_int_base58(1) == "2"`, `encode_int_base36(1) == "1"`,
+/// `encode_int_base10(1) == "1"`). Examples:
+///
+/// ```gleam
+/// encode_int_base16_compact(0)      // "0"
+/// encode_int_base16_compact(1)      // "1"
+/// encode_int_base16_compact(255)    // "FF"
+/// encode_int_base16_compact(2025)   // "7E9"
+/// encode_int_base16_compact(0xdeadbeef) // "DEADBEEF"
+/// ```
+///
+/// Use this when you want column-aligned mixed-base output or
+/// round-trip-by-text comparisons across the `encode_int_*` family.
+/// Keep `encode_int_base16/1` for byte-oriented sinks where the
+/// even-length contract matters.
+///
+/// `decode_int_base16/1` accepts the compact form unchanged
+/// (`decode_int_base16(encode_int_base16_compact(n)) == Ok(n)`),
+/// because the underlying `base16.decode` is tolerant of any-length
+/// input — odd-length inputs are zero-padded to the next byte
+/// boundary before decoding.
+///
+/// Negative inputs are normalized to `int.absolute_value`; see the
+/// module note on "Negative inputs are silently absolutized".
+///
+/// Added in #99.
+pub fn encode_int_base16_compact(value: Int) -> String {
+  drop_leading_zero_chars(base16.encode(int_to_bytes_be(value)))
 }
 
 /// Decode a Base16 (hexadecimal) string back to an `Int`. Accepts
 /// both uppercase and lowercase input via `base16.decode`'s
 /// case-insensitive alphabet.
+///
+/// Odd-length inputs are accepted and internally zero-padded on the
+/// left to the next byte boundary before being passed to
+/// `base16.decode` (`"1"` is treated as `"01"`, `"7E9"` as
+/// `"07E9"`). This makes the function tolerant of either output
+/// shape from the `encode_int_base16*` family —
+/// `decode_int_base16(encode_int_base16(n)) == Ok(n)` *and*
+/// `decode_int_base16(encode_int_base16_compact(n)) == Ok(n)` both
+/// hold for every non-negative `Int`. The byte-oriented
+/// `base16.decode/1` keeps its strict even-length contract for
+/// callers reaching for the low-level codec directly. (#99)
 pub fn decode_int_base16(input: String) -> Result(Int, CodecError) {
   use input <- result.try(reject_empty(input))
-  base16.decode(input)
+  let padded = case int.is_odd(string.length(input)) {
+    True -> "0" <> input
+    False -> input
+  }
+  base16.decode(padded)
   |> result.map(bytes_to_int)
 }
 
@@ -537,4 +609,19 @@ fn accumulate_bytes(num: Int, acc: BitArray) -> BitArray {
 
 fn bytes_to_int(data: BitArray) -> Int {
   bignum.bytes_to_int(data, 0)
+}
+
+// Drop every leading `"0"` character from `s`. If the entire string
+// is composed of `"0"` characters (the magnitude-zero case), preserve
+// a single `"0"` so the compact form still has at least one digit —
+// matching `encode_int_base10(0) == "0"`,
+// `encode_int_base36(0) == "0"` etc. Used by
+// `encode_int_base16_compact/1` to turn the byte-aligned output of
+// `base16.encode` into the compact form expected by the rest of the
+// `encode_int_*` family. (#99)
+fn drop_leading_zero_chars(s: String) -> String {
+  use <- bool.guard(when: !string.starts_with(s, "0"), return: s)
+  let rest = string.drop_start(s, 1)
+  use <- bool.guard(when: string.is_empty(rest), return: "0")
+  drop_leading_zero_chars(rest)
 }

--- a/test/regression_encode_int_base16_compact_test.gleam
+++ b/test/regression_encode_int_base16_compact_test.gleam
@@ -1,0 +1,87 @@
+//// Regression tests for #99: `intid.encode_int_base16_compact/1`
+//// drops leading zero characters so the output shape matches the
+//// rest of the `encode_int_*` family
+//// (`encode_int_base58(1) == "2"`, `encode_int_base36(1) == "1"`,
+//// `encode_int_base10(1) == "1"`). The existing
+//// `encode_int_base16/1` keeps its byte-aligned (even-length)
+//// contract — this test file pins both behaviours side-by-side so
+//// the asymmetry follow-up cannot regress in either direction.
+
+import yabase/intid
+
+pub fn encode_int_base16_compact_one_test() -> Nil {
+  // `encode_int_base16(1) == "01"`; the compact variant drops the
+  // leading-zero pad to match `encode_int_base58(1) == "2"` /
+  // `encode_int_base36(1) == "1"` / `encode_int_base10(1) == "1"`.
+  assert intid.encode_int_base16_compact(1) == "1"
+}
+
+pub fn encode_int_base16_compact_2025_test() -> Nil {
+  // `encode_int_base16(2025) == "07E9"`; the compact form is the
+  // canonical three-nibble hex.
+  assert intid.encode_int_base16_compact(2025) == "7E9"
+}
+
+pub fn encode_int_base16_compact_zero_test() -> Nil {
+  // Magnitude-zero collapses to a single `"0"`, matching
+  // `encode_int_base10(0) == "0"` /
+  // `encode_int_base36(0) == "0"` /
+  // `encode_int_base32_crockford(0) == "0"`.
+  assert intid.encode_int_base16_compact(0) == "0"
+}
+
+pub fn encode_int_base16_compact_single_byte_test() -> Nil {
+  // Values that already occupy a whole byte (no leading zero
+  // nibble) pass through unchanged.
+  assert intid.encode_int_base16_compact(255) == "FF"
+}
+
+pub fn encode_int_base16_compact_canonical_uppercase_test() -> Nil {
+  // Compact output uses the same canonical RFC 4648 §8 uppercase
+  // alphabet as `encode_int_base16/1`.
+  assert intid.encode_int_base16_compact(0xdeadbeef) == "DEADBEEF"
+}
+
+pub fn encode_int_base16_compact_large_test() -> Nil {
+  // Large value with a leading zero nibble — the compact form
+  // strips exactly one `"0"` while preserving every interior digit.
+  // `0x0abcdef0` -> byte-aligned "0ABCDEF0" -> compact "ABCDEF0".
+  assert intid.encode_int_base16_compact(0x0abcdef0) == "ABCDEF0"
+}
+
+pub fn encode_int_base16_compact_round_trip_test() -> Nil {
+  // Issue #99 pins this round-trip: `decode_int_base16` is tolerant
+  // of any-length hex input, so the compact encoder's output feeds
+  // back to the same `Int` without the caller having to know about
+  // the byte-aligned vs compact distinction.
+  let encoded = intid.encode_int_base16_compact(8_675_309)
+  assert intid.decode_int_base16(encoded) == Ok(8_675_309)
+}
+
+pub fn encode_int_base16_compact_round_trip_odd_length_test() -> Nil {
+  // The compact form of `1` is the odd-length `"1"`; this pins that
+  // `decode_int_base16` accepts odd-length input (zero-padding to
+  // the next byte boundary internally).
+  assert intid.decode_int_base16(intid.encode_int_base16_compact(1)) == Ok(1)
+}
+
+pub fn encode_int_base16_compact_round_trip_zero_test() -> Nil {
+  // Magnitude-zero must also round-trip — `"0"` decodes back to `0`
+  // even though it is a single odd-length character.
+  assert intid.decode_int_base16(intid.encode_int_base16_compact(0)) == Ok(0)
+}
+
+pub fn encode_int_base16_byte_aligned_unchanged_test() -> Nil {
+  // Regression: the existing byte-aligned `encode_int_base16/1`
+  // must keep its leading-zero pad — callers relying on the even-
+  // length contract (DB hex columns, HTTP headers, content-
+  // addressable storage) cannot tolerate a silent shape change.
+  assert intid.encode_int_base16(1) == "01"
+}
+
+pub fn encode_int_base16_byte_aligned_2025_unchanged_test() -> Nil {
+  // Same regression with the value the issue cited as the example
+  // of the asymmetry; locks in `"07E9"` so the byte-aligned encoder
+  // stays four characters wide for two-byte magnitudes.
+  assert intid.encode_int_base16(2025) == "07E9"
+}


### PR DESCRIPTION
## Summary

- Adds `intid.encode_int_base16_compact/1` — the leading-zero-dropping companion to the existing byte-aligned `intid.encode_int_base16/1`. The `encode_int_*` family now has a uniform compact shape across base10/base16/base36/base58/base62 (`encode_int_base16_compact(1) == "1"`, `encode_int_base16_compact(2025) == "7E9"`, `encode_int_base16_compact(0) == "0"`). The byte-aligned `encode_int_base16/1` is **unchanged** so callers relying on the even-length contract (DB hex columns, HTTP headers, content-addressable storage) are not broken.
- Teaches `intid.decode_int_base16/1` to accept odd-length input by zero-padding on the left internally before delegating to `yabase/base16.decode`. This pins the round-trip invariant `decode_int_base16(encode_int_base16_compact(n)) == Ok(n)` for every non-negative `Int`. The low-level `yabase/base16.decode/1` keeps its strict even-length contract — only the `intid`-level decoder is lenient.
- Cross-references "byte-aligned vs compact" between the two `encode_int_base16*` docstrings so callers reading the function family side-by-side can pick the right variant.

Implementation:

- `src/yabase/intid.gleam`: new `encode_int_base16_compact/1`, expanded docstrings on both `encode_int_base16/1` and `decode_int_base16/1`, and a private `drop_leading_zero_chars/1` helper.
- `test/regression_encode_int_base16_compact_test.gleam`: 10 regression tests covering the values cited in the issue (`1` -> `"1"`, `2025` -> `"7E9"`), magnitude zero, the canonical uppercase alphabet, a large value with a leading-zero nibble, round-trip through `decode_int_base16` (including odd-length and zero), and two byte-aligned regression locks that pin `encode_int_base16(1) == "01"` and `encode_int_base16(2025) == "07E9"`.
- `CHANGELOG.md`: one bullet under `[Unreleased]` `### Added`.
- No new dependencies.

## Test plan

- [x] `just ci` green locally (834 passed, glinter clean, format check passes on gleam 1.15)
- [x] New `encode_int_base16_compact(1) == "1"` and `encode_int_base16_compact(2025) == "7E9"` pin the issue's expected values
- [x] `decode_int_base16(encode_int_base16_compact(n)) == Ok(n)` round-trip covered for `n` in {0, 1, 8_675_309}
- [x] `encode_int_base16(1) == "01"` and `encode_int_base16(2025) == "07E9"` regression-locked so the byte-aligned encoder stays byte-aligned

Closes #99