### PR TITLE
feat(intid)!: reject negative encode_int_* inputs with Result(String, CodecError) (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- `intid.encode_int_base16_compact/1`: leading-zero-dropping companion to the existing byte-aligned `intid.encode_int_base16/1`, so the `encode_int_*` family now has a uniform compact variant across base10/base16/base36/base58/base62 (`encode_int_base16_compact(1) == "1"`, `encode_int_base16_compact(2025) == "7E9"`); the byte-aligned `encode_int_base16/1` is unchanged. `intid.decode_int_base16/1` now also accepts odd-length input (internally zero-padded on the left), so `decode_int_base16(encode_int_base16_compact(n)) == Ok(n)` round-trips for every non-negative `Int`; the low-level `base16.decode/1` keeps its strict even-length contract. (#99)
+- `intid.encode_int_base16_compact/1`: leading-zero-dropping companion to the existing byte-aligned `intid.encode_int_base16/1`, so the `encode_int_*` family now has a uniform compact variant across base10/base16/base36/base58/base62 (`encode_int_base16_compact(1) == Ok("1")`, `encode_int_base16_compact(2025) == Ok("7E9")`); the byte-aligned `encode_int_base16/1` is unchanged. `intid.decode_int_base16/1` now also accepts odd-length input (internally zero-padded on the left), so `decode_int_base16(encode_int_base16_compact(n) |> result.unwrap_or("")) == Ok(n)` round-trips for every non-negative `Int`; the low-level `base16.decode/1` keeps its strict even-length contract. (#99)
+
+### Changed
+
+- **BREAKING**: every `intid.encode_int_*` function now returns `Result(String, CodecError)` instead of `String`, and rejects negative inputs with the new `Error(NegativeValue(value))` variant on `CodecError`. The previous behaviour silently absolutized negatives via `int.absolute_value`, which broke the `decode(encode(n)) == n` round-trip whenever `n < 0` and let two distinct inputs (`-1` and `1`) collide on the same encoded string. Callers that fed only non-negative values into `encode_int_*` need to unwrap the new `Result` (either `let assert Ok(s) = ...` for known-safe call sites, or `result.map` / `case` for ones that already accept negatives at the boundary). The new `NegativeValue(value: Int)` variant on `CodecError` is exported via the existing `yabase/core/error` and the `intid.CodecError` re-export. Closed #84; regressed in #100. (#100)
 
 ## [0.21.0] - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Short URL-safe identifiers — DB autoincrement ids, sequence numbers, hash trun
 import yabase/intid
 
 pub fn main() {
-  let token = intid.encode_int_base58(42)
+  let assert Ok(token) = intid.encode_int_base58(42)
   // token == "j"
 
   let assert Ok(_n) = intid.decode_int_base58(token)
@@ -131,9 +131,9 @@ pub fn main() {
 }
 ```
 
-Available: `encode_int_base32_rfc4648`, `encode_int_base32_crockford`, `encode_int_base36`, `encode_int_base58`, `encode_int_base58_flickr`, `encode_int_base62` and their matching `decode_int_*` (returning `Result(Int, CodecError)`).
+Available: `encode_int_base32_rfc4648`, `encode_int_base32_crockford`, `encode_int_base36`, `encode_int_base58`, `encode_int_base58_flickr`, `encode_int_base62` and their matching `decode_int_*`. All `encode_int_*` functions return `Result(String, CodecError)` and all `decode_int_*` functions return `Result(Int, CodecError)`.
 
-`encode_int_*` emits canonical form. `decode_int_*` is tolerant of leading zero characters (`decode_int_base58("0042")` and `decode_int_base58("42")` return the same `Int`). Negative inputs are normalized via `int.absolute_value` before encoding.
+`encode_int_*` emits canonical form. `decode_int_*` is tolerant of leading zero characters (`decode_int_base58("0042")` and `decode_int_base58("42")` return the same `Int`). Negative inputs are rejected with `Error(NegativeValue(value))` — the integer codecs only define a canonical representation for non-negative values, so silently dropping the sign would break the `decode(encode(n)) == n` round-trip for `n < 0`. Map negatives to a sign-preserving wire format (e.g. zigzag) or to a domain-specific error at the boundary.
 
 `decode_int_*` accepts inputs of any length, so the decoded `Int` is an unbounded Erlang bignum. If the value flows into a fixed-width sink (SQLite `INTEGER`, Postgres `bigserial`, MySQL `BIGINT`, or a JS `number`), use the matching `decode_int_*_bounded(input:, max:)` to get `Error(Overflow)` instead of a downstream crash. Common caps are exported as `intid.int64_max` (signed 64-bit, `2^63 - 1`) and `intid.int53_max` (`Number.MAX_SAFE_INTEGER`).
 

--- a/src/yabase/core/error.gleam
+++ b/src/yabase/core/error.gleam
@@ -37,6 +37,16 @@ pub type CodecError {
   /// the encoding's name so the caller can render an actionable
   /// error.
   UnsupportedForInt(encoding_name: String)
+  /// `yabase/intid.encode_int_*` was invoked with a negative `Int`.
+  /// The integer codecs only define a canonical representation for
+  /// non-negative values; previously the sign was silently dropped
+  /// via `int.absolute_value`, which broke the
+  /// `decode(encode(n)) == n` round-trip whenever `n < 0`. The
+  /// encoders now surface the offending input so callers can keep
+  /// or strip the sign at the boundary explicitly (e.g. by using
+  /// a sign-preserving wire format like zigzag, or by mapping the
+  /// negative case to a domain-specific error). (#100)
+  NegativeValue(value: Int)
 }
 
 /// Bech32 encoding variant.

--- a/src/yabase/intid.gleam
+++ b/src/yabase/intid.gleam
@@ -24,35 +24,28 @@
 //// lookups. The byte-oriented decoders in `yabase/facade` retain the
 //// `Ok(<<>>)` round-trip behavior for empty input.
 ////
-//// ## Negative inputs are silently absolutized
+//// ## Negative inputs are rejected
 ////
-//// Every `encode_int_*` function in this module accepts any `Int`
-//// — including negatives — and normalizes the input to
-//// `int.absolute_value` before encoding. The magnitude is what gets
-//// stored. The decode side always returns a non-negative `Int`.
+//// Every `encode_int_*` function in this module returns
+//// `Result(String, CodecError)` and rejects negative inputs with
+//// `Error(NegativeValue(value))`. The integer codecs only define a
+//// canonical representation for non-negative values, so silently
+//// dropping the sign would break the `decode(encode(n)) == n`
+//// round-trip whenever `n < 0` (closed #84, reopened as #100).
 ////
-//// **This is intentional, not a bug, but it is a footgun.** Two
-//// distinct inputs (`-1` and `1`) round-trip to the same `Int`,
-//// breaking bijection. Code that compares a re-encoded value to its
-//// source can match where you would expect a mismatch. If your
-//// caller path can produce negative values (offsets that subtracted
-//// past zero, Posix timestamps from before 1970, deliberate
-//// `-1` sentinels), the safer pattern is to validate the sign at
-//// the boundary before reaching `encode_int_*`:
+//// If your caller path can produce negatives (offsets that
+//// subtracted past zero, Posix timestamps from before 1970,
+//// deliberate `-1` sentinels), map them to a sign-preserving wire
+//// format like zigzag or to a domain-specific error at the
+//// boundary:
 ////
 //// ```gleam
-//// case n >= 0 {
-////   True -> Ok(encode_int_base32_crockford(n))
-////   False -> Error(MyDomainError.NegativeId(n))
+//// case intid.encode_int_base32_crockford(n) {
+////   Ok(s) -> Ok(s)
+////   Error(intid.NegativeValue(_)) -> Error(MyDomainError.NegativeId(n))
+////   Error(other) -> Error(MyDomainError.CodecFailed(other))
 //// }
 //// ```
-////
-//// We intentionally chose silent absolutization over `Result` /
-//// `panic` for ergonomics — almost every realistic short-ID caller
-//// reaches `encode_int_*` with a value that is already non-negative
-//// (DB autoincrement, hash truncation, sequence number), and forcing
-//// `Result` everywhere added boilerplate without preventing real
-//// bugs. Tracked in #84.
 ////
 //// ## Bounded decode
 ////
@@ -86,8 +79,8 @@ import yabase/base58check
 import yabase/base62
 import yabase/core/encoding
 import yabase/core/error.{
-  type CodecError as CoreCodecError, InvalidChecksum, InvalidLength, Overflow,
-  UnsupportedForInt,
+  type CodecError as CoreCodecError, InvalidChecksum, InvalidLength,
+  NegativeValue, Overflow, UnsupportedForInt,
 }
 import yabase/internal/bignum
 
@@ -114,12 +107,13 @@ pub const int64_max: Int = 9_223_372_036_854_775_807
 /// a JavaScript consumer.
 pub const int53_max: Int = 9_007_199_254_740_991
 
-/// Encode an `Int` as a Base32 (RFC 4648) string. Negative inputs
-/// are normalized to `int.absolute_value`; see the module note on
-/// "Negative inputs are silently absolutized" for the rationale and
-/// the recommended boundary-check pattern.
-pub fn encode_int_base32_rfc4648(value: Int) -> String {
-  base32_rfc4648.encode(int_to_bytes_be(value))
+/// Encode a non-negative `Int` as a Base32 (RFC 4648) string.
+/// Returns `Error(NegativeValue(value))` for negative inputs; see
+/// the module note on "Negative inputs are rejected" for the
+/// rationale and the recommended boundary-check pattern.
+pub fn encode_int_base32_rfc4648(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  base32_rfc4648.encode(bytes)
 }
 
 /// Decode a Base32 (RFC 4648) string back to an `Int`.
@@ -139,11 +133,12 @@ pub fn decode_int_base32_rfc4648_bounded(
   bound_check(value, max)
 }
 
-/// Encode an `Int` as a Crockford Base32 string. Negative inputs
-/// are normalized to `int.absolute_value`; see the module note on
-/// "Negative inputs are silently absolutized".
-pub fn encode_int_base32_crockford(value: Int) -> String {
-  base32_crockford.encode(int_to_bytes_be(value))
+/// Encode a non-negative `Int` as a Crockford Base32 string.
+/// Returns `Error(NegativeValue(value))` for negative inputs; see
+/// the module note on "Negative inputs are rejected".
+pub fn encode_int_base32_crockford(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  base32_crockford.encode(bytes)
 }
 
 /// Decode a Crockford Base32 string back to an `Int`.
@@ -163,9 +158,9 @@ pub fn decode_int_base32_crockford_bounded(
   bound_check(value, max)
 }
 
-/// Encode an `Int` as a Base10 (decimal) string. Negative inputs
-/// are normalized to `int.absolute_value`; see the module note on
-/// "Negative inputs are silently absolutized".
+/// Encode a non-negative `Int` as a Base10 (decimal) string.
+/// Returns `Error(NegativeValue(value))` for negative inputs; see
+/// the module note on "Negative inputs are rejected".
 ///
 /// Behaviour matches `int.to_string` for the typical case
 /// (positive integers) and the rest of the `intid` family for the
@@ -173,8 +168,9 @@ pub fn decode_int_base32_crockford_bounded(
 /// `base10.encode` keeps the contract uniform with the other
 /// `encode_int_*` functions: a non-negative `Int` in, a string
 /// in the alphabet out, no padding.
-pub fn encode_int_base10(value: Int) -> String {
-  base10.encode(int_to_bytes_be(value))
+pub fn encode_int_base10(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  base10.encode(bytes)
 }
 
 /// Decode a Base10 (decimal) string back to an `Int`.
@@ -194,9 +190,9 @@ pub fn decode_int_base10_bounded(
   bound_check(value, max)
 }
 
-/// Encode an `Int` as a Base16 (uppercase hexadecimal) string.
-/// Negative inputs are normalized to `int.absolute_value`; see the
-/// module note on "Negative inputs are silently absolutized".
+/// Encode a non-negative `Int` as a Base16 (uppercase hexadecimal)
+/// string. Returns `Error(NegativeValue(value))` for negative
+/// inputs; see the module note on "Negative inputs are rejected".
 ///
 /// Routing through `base16.encode` keeps the contract uniform with
 /// the rest of the `encode_int_*` family. The output uses the
@@ -210,40 +206,44 @@ pub fn decode_int_base10_bounded(
 /// This function is **byte-aligned**: the output length is always an
 /// even number of hex characters because the encoding pads the
 /// integer's big-endian representation to a whole byte boundary
-/// (`encode_int_base16(1) == "01"`, `encode_int_base16(2025) ==
-/// "07E9"`). This is the right shape for ID interop with
-/// byte-oriented systems (databases, HTTP headers, content-
-/// addressable storage). The other `encode_int_*` functions in this
-/// module are *compact* — they drop leading zero characters
-/// (`encode_int_base58(1) == "2"`, `encode_int_base36(1) == "1"`,
-/// `encode_int_base10(1) == "1"`). Issue #99 surfaced the
+/// (`encode_int_base16(1) == Ok("01")`,
+/// `encode_int_base16(2025) == Ok("07E9")`). This is the right
+/// shape for ID interop with byte-oriented systems (databases, HTTP
+/// headers, content-addressable storage). The other
+/// `encode_int_*` functions in this module are *compact* — they
+/// drop leading zero characters
+/// (`encode_int_base58(1) == Ok("2")`,
+/// `encode_int_base36(1) == Ok("1")`,
+/// `encode_int_base10(1) == Ok("1")`). Issue #99 surfaced the
 /// asymmetry; if you want the compact form for `base16`, use
 /// `encode_int_base16_compact/1` instead. `decode_int_base16/1`
 /// accepts either form (it does not require an even-length input).
-pub fn encode_int_base16(value: Int) -> String {
-  base16.encode(int_to_bytes_be(value))
+pub fn encode_int_base16(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  base16.encode(bytes)
 }
 
-/// Encode an `Int` as a Base16 (uppercase hexadecimal) string with
-/// leading zero characters stripped — the compact counterpart to
-/// `encode_int_base16/1`.
+/// Encode a non-negative `Int` as a Base16 (uppercase hexadecimal)
+/// string with leading zero characters stripped — the compact
+/// counterpart to `encode_int_base16/1`.
 ///
 /// ## Byte-aligned vs compact
 ///
 /// `encode_int_base16/1` is **byte-aligned** (always emits an even
-/// number of hex characters: `encode_int_base16(1) == "01"`,
-/// `encode_int_base16(2025) == "07E9"`). This function is **compact**
-/// — leading `"0"` characters are dropped so the output matches the
-/// shape of the rest of the `encode_int_*` family
-/// (`encode_int_base58(1) == "2"`, `encode_int_base36(1) == "1"`,
-/// `encode_int_base10(1) == "1"`). Examples:
+/// number of hex characters: `encode_int_base16(1) == Ok("01")`,
+/// `encode_int_base16(2025) == Ok("07E9")`). This function is
+/// **compact** — leading `"0"` characters are dropped so the
+/// output matches the shape of the rest of the `encode_int_*`
+/// family (`encode_int_base58(1) == Ok("2")`,
+/// `encode_int_base36(1) == Ok("1")`,
+/// `encode_int_base10(1) == Ok("1")`). Examples:
 ///
 /// ```gleam
-/// encode_int_base16_compact(0)      // "0"
-/// encode_int_base16_compact(1)      // "1"
-/// encode_int_base16_compact(255)    // "FF"
-/// encode_int_base16_compact(2025)   // "7E9"
-/// encode_int_base16_compact(0xdeadbeef) // "DEADBEEF"
+/// encode_int_base16_compact(0)      // Ok("0")
+/// encode_int_base16_compact(1)      // Ok("1")
+/// encode_int_base16_compact(255)    // Ok("FF")
+/// encode_int_base16_compact(2025)   // Ok("7E9")
+/// encode_int_base16_compact(0xdeadbeef) // Ok("DEADBEEF")
 /// ```
 ///
 /// Use this when you want column-aligned mixed-base output or
@@ -252,17 +252,19 @@ pub fn encode_int_base16(value: Int) -> String {
 /// even-length contract matters.
 ///
 /// `decode_int_base16/1` accepts the compact form unchanged
-/// (`decode_int_base16(encode_int_base16_compact(n)) == Ok(n)`),
-/// because the underlying `base16.decode` is tolerant of any-length
-/// input — odd-length inputs are zero-padded to the next byte
-/// boundary before decoding.
+/// (`decode_int_base16(encode_int_base16_compact(n) |> result.unwrap_or(""))`
+/// round-trips for every non-negative `Int`), because the
+/// underlying `base16.decode` is tolerant of any-length input —
+/// odd-length inputs are zero-padded to the next byte boundary
+/// before decoding.
 ///
-/// Negative inputs are normalized to `int.absolute_value`; see the
-/// module note on "Negative inputs are silently absolutized".
+/// Returns `Error(NegativeValue(value))` for negative inputs; see
+/// the module note on "Negative inputs are rejected".
 ///
 /// Added in #99.
-pub fn encode_int_base16_compact(value: Int) -> String {
-  drop_leading_zero_chars(base16.encode(int_to_bytes_be(value)))
+pub fn encode_int_base16_compact(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  drop_leading_zero_chars(base16.encode(bytes))
 }
 
 /// Decode a Base16 (hexadecimal) string back to an `Int`. Accepts
@@ -299,11 +301,12 @@ pub fn decode_int_base16_bounded(
   bound_check(value, max)
 }
 
-/// Encode an `Int` as a Base36 string. Negative inputs are
-/// normalized to `int.absolute_value`; see the module note on
-/// "Negative inputs are silently absolutized".
-pub fn encode_int_base36(value: Int) -> String {
-  base36.encode(int_to_bytes_be(value))
+/// Encode a non-negative `Int` as a Base36 string. Returns
+/// `Error(NegativeValue(value))` for negative inputs; see the
+/// module note on "Negative inputs are rejected".
+pub fn encode_int_base36(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  base36.encode(bytes)
 }
 
 /// Decode a Base36 string back to an `Int`.
@@ -323,11 +326,12 @@ pub fn decode_int_base36_bounded(
   bound_check(value, max)
 }
 
-/// Encode an `Int` as a Base58 (Bitcoin alphabet) string. Negative
-/// inputs are normalized to `int.absolute_value`; see the module
-/// note on "Negative inputs are silently absolutized".
-pub fn encode_int_base58(value: Int) -> String {
-  base58_bitcoin.encode(int_to_bytes_be(value))
+/// Encode a non-negative `Int` as a Base58 (Bitcoin alphabet)
+/// string. Returns `Error(NegativeValue(value))` for negative
+/// inputs; see the module note on "Negative inputs are rejected".
+pub fn encode_int_base58(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  base58_bitcoin.encode(bytes)
 }
 
 /// Decode a Base58 (Bitcoin alphabet) string back to an `Int`.
@@ -347,11 +351,12 @@ pub fn decode_int_base58_bounded(
   bound_check(value, max)
 }
 
-/// Encode an `Int` as a Base58 (Flickr alphabet) string. Negative
-/// inputs are normalized to `int.absolute_value`; see the module
-/// note on "Negative inputs are silently absolutized".
-pub fn encode_int_base58_flickr(value: Int) -> String {
-  base58_flickr.encode(int_to_bytes_be(value))
+/// Encode a non-negative `Int` as a Base58 (Flickr alphabet)
+/// string. Returns `Error(NegativeValue(value))` for negative
+/// inputs; see the module note on "Negative inputs are rejected".
+pub fn encode_int_base58_flickr(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  base58_flickr.encode(bytes)
 }
 
 /// Decode a Base58 (Flickr alphabet) string back to an `Int`.
@@ -380,8 +385,14 @@ pub fn decode_int_base58_flickr_bounded(
 /// Use the matching `decode_int_base32_crockford_check` to recover
 /// the integer; the decoder verifies the symbol and returns
 /// `Error(InvalidChecksum)` if the input was mistyped.
-pub fn encode_int_base32_crockford_check(value: Int) -> String {
-  base32_crockford.encode_check(int_to_bytes_be(value))
+///
+/// Returns `Error(NegativeValue(value))` for negative inputs; see
+/// the module note on "Negative inputs are rejected".
+pub fn encode_int_base32_crockford_check(
+  value: Int,
+) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  base32_crockford.encode_check(bytes)
 }
 
 /// Decode a checksummed Crockford Base32 string back to an `Int`,
@@ -413,13 +424,14 @@ pub fn decode_int_base32_crockford_check_bounded(
 /// should reach for `yabase/base58check.encode/2` directly with their
 /// own `BitArray` payload.
 ///
-/// Returns the canonical Base58Check string. The underlying
+/// Returns `Error(NegativeValue(value))` for negative inputs; see
+/// the module note on "Negative inputs are rejected". The underlying
 /// `yabase/base58check.encode` only errors on out-of-range version
-/// bytes (this helper hard-codes a valid one), so this signature
-/// does not surface a `Result`.
-pub fn encode_int_base58check(value: Int) -> String {
-  base58check.encode(0, int_to_bytes_be(value))
-  |> result.unwrap("")
+/// bytes, and this helper hard-codes a valid one, so the surfaced
+/// error is always `NegativeValue` in practice.
+pub fn encode_int_base58check(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.try(int_to_bytes_be(value))
+  base58check.encode(0, bytes)
 }
 
 /// Decode a Base58Check string back to an `Int`, verifying the
@@ -449,11 +461,12 @@ pub fn decode_int_base58check_bounded(
   bound_check(value, max)
 }
 
-/// Encode an `Int` as a Base62 string. Negative inputs are
-/// normalized to `int.absolute_value`; see the module note on
-/// "Negative inputs are silently absolutized".
-pub fn encode_int_base62(value: Int) -> String {
-  base62.encode(int_to_bytes_be(value))
+/// Encode a non-negative `Int` as a Base62 string. Returns
+/// `Error(NegativeValue(value))` for negative inputs; see the
+/// module note on "Negative inputs are rejected".
+pub fn encode_int_base62(value: Int) -> Result(String, CodecError) {
+  use bytes <- result.map(int_to_bytes_be(value))
+  base62.encode(bytes)
 }
 
 /// Decode a Base62 string back to an `Int`.
@@ -486,10 +499,10 @@ pub fn decode_int_base62_bounded(
 
 /// Encode an `Int` to a string using the supplied `Encoding`,
 /// dispatching to the matching `encode_int_*` helper. Negative
-/// inputs are normalised to `int.absolute_value` exactly as the
+/// inputs surface as `Error(NegativeValue(value))` exactly as the
 /// per-base helpers do; see the module note on "Negative inputs
-/// are silently absolutized" for the rationale and the
-/// boundary-check pattern.
+/// are rejected" for the rationale and the boundary-handling
+/// pattern.
 ///
 /// Returns `Error(UnsupportedForInt(name))` for encodings that have
 /// no integer codec wired up (every byte-only codec: `Base2`,
@@ -504,18 +517,19 @@ pub fn encode_int(
   value value: Int,
 ) -> Result(String, CodecError) {
   case encoding.int_codec(encoding) {
-    encoding.IntBase10 -> Ok(encode_int_base10(value))
-    encoding.IntBase16 -> Ok(encode_int_base16(value))
-    encoding.IntBase32Rfc4648 -> Ok(encode_int_base32_rfc4648(value))
-    encoding.IntBase32Crockford -> Ok(encode_int_base32_crockford(value))
-    encoding.IntBase32CrockfordCheck ->
-      Ok(encode_int_base32_crockford_check(value))
-    encoding.IntBase36 -> Ok(encode_int_base36(value))
-    encoding.IntBase58Bitcoin -> Ok(encode_int_base58(value))
-    encoding.IntBase58Flickr -> Ok(encode_int_base58_flickr(value))
-    encoding.IntBase58Check(version) ->
-      base58check.encode(version, int_to_bytes_be(value))
-    encoding.IntBase62 -> Ok(encode_int_base62(value))
+    encoding.IntBase10 -> encode_int_base10(value)
+    encoding.IntBase16 -> encode_int_base16(value)
+    encoding.IntBase32Rfc4648 -> encode_int_base32_rfc4648(value)
+    encoding.IntBase32Crockford -> encode_int_base32_crockford(value)
+    encoding.IntBase32CrockfordCheck -> encode_int_base32_crockford_check(value)
+    encoding.IntBase36 -> encode_int_base36(value)
+    encoding.IntBase58Bitcoin -> encode_int_base58(value)
+    encoding.IntBase58Flickr -> encode_int_base58_flickr(value)
+    encoding.IntBase58Check(version) -> {
+      use bytes <- result.try(int_to_bytes_be(value))
+      base58check.encode(version, bytes)
+    }
+    encoding.IntBase62 -> encode_int_base62(value)
     encoding.IntCodecUnsupported(name) -> Error(UnsupportedForInt(name))
   }
 }
@@ -589,11 +603,20 @@ fn bound_check(value: Int, max: Int) -> Result(Int, CodecError) {
   Ok(value)
 }
 
-fn int_to_bytes_be(value: Int) -> BitArray {
-  let magnitude = int.absolute_value(value)
-  case magnitude {
-    0 -> <<0>>
-    _ -> accumulate_bytes(magnitude, <<>>)
+// Convert a non-negative `Int` into a canonical big-endian
+// `BitArray` for the per-base encoders. Negative inputs are
+// rejected with `Error(NegativeValue(_))` rather than silently
+// absolutized — the historical `int.absolute_value` shortcut
+// destroyed the sign and broke `decode(encode(n)) == n` for
+// every `n < 0` (closed #84, regressed in #100). Zero is the
+// only value that maps to a single zero byte; every other
+// non-negative value is encoded with the minimum number of
+// bytes required to represent its magnitude.
+fn int_to_bytes_be(value: Int) -> Result(BitArray, CodecError) {
+  use <- bool.guard(when: value < 0, return: Error(NegativeValue(value)))
+  case value {
+    0 -> Ok(<<0>>)
+    _ -> Ok(accumulate_bytes(value, <<>>))
   }
 }
 

--- a/test/intid_test.gleam
+++ b/test/intid_test.gleam
@@ -1,22 +1,23 @@
 import gleam/string
 import yabase/core/encoding
 import yabase/core/error.{
-  InvalidCharacter, InvalidChecksum, InvalidLength, Overflow, UnsupportedForInt,
+  InvalidCharacter, InvalidChecksum, InvalidLength, NegativeValue, Overflow,
+  UnsupportedForInt,
 }
 import yabase/intid
 
 // === Base32 (RFC 4648) ===
 
 pub fn encode_int_base32_rfc4648_zero_test() -> Nil {
-  assert intid.encode_int_base32_rfc4648(0) == "AA======"
+  assert intid.encode_int_base32_rfc4648(0) == Ok("AA======")
 }
 
 pub fn encode_int_base32_rfc4648_one_test() -> Nil {
-  assert intid.encode_int_base32_rfc4648(1) == "AE======"
+  assert intid.encode_int_base32_rfc4648(1) == Ok("AE======")
 }
 
 pub fn encode_int_base32_rfc4648_max_byte_test() -> Nil {
-  assert intid.encode_int_base32_rfc4648(255) == "74======"
+  assert intid.encode_int_base32_rfc4648(255) == Ok("74======")
 }
 
 pub fn decode_int_base32_rfc4648_empty_test() -> Nil {
@@ -24,7 +25,7 @@ pub fn decode_int_base32_rfc4648_empty_test() -> Nil {
 }
 
 pub fn decode_int_base32_rfc4648_roundtrip_test() -> Nil {
-  let encoded = intid.encode_int_base32_rfc4648(1_234_567)
+  let assert Ok(encoded) = intid.encode_int_base32_rfc4648(1_234_567)
   assert intid.decode_int_base32_rfc4648(encoded) == Ok(1_234_567)
 }
 
@@ -36,19 +37,19 @@ pub fn decode_int_base32_rfc4648_invalid_char_test() -> Nil {
 // === Base32 (Crockford) ===
 
 pub fn encode_int_base32_crockford_zero_test() -> Nil {
-  assert intid.encode_int_base32_crockford(0) == "0"
+  assert intid.encode_int_base32_crockford(0) == Ok("0")
 }
 
 pub fn encode_int_base32_crockford_alphabet_max_test() -> Nil {
-  assert intid.encode_int_base32_crockford(31) == "Z"
+  assert intid.encode_int_base32_crockford(31) == Ok("Z")
 }
 
 pub fn encode_int_base32_crockford_carry_test() -> Nil {
-  assert intid.encode_int_base32_crockford(32) == "10"
+  assert intid.encode_int_base32_crockford(32) == Ok("10")
 }
 
 pub fn encode_int_base32_crockford_two_digit_max_test() -> Nil {
-  assert intid.encode_int_base32_crockford(1023) == "ZZ"
+  assert intid.encode_int_base32_crockford(1023) == Ok("ZZ")
 }
 
 pub fn decode_int_base32_crockford_empty_test() -> Nil {
@@ -61,26 +62,26 @@ pub fn decode_int_base32_crockford_leading_zero_tolerant_test() -> Nil {
 }
 
 pub fn decode_int_base32_crockford_roundtrip_test() -> Nil {
-  let encoded = intid.encode_int_base32_crockford(987_654)
+  let assert Ok(encoded) = intid.encode_int_base32_crockford(987_654)
   assert intid.decode_int_base32_crockford(encoded) == Ok(987_654)
 }
 
 // === encoding.base10() (#78) ===
 
 pub fn encode_int_base10_zero_test() -> Nil {
-  assert intid.encode_int_base10(0) == "0"
+  assert intid.encode_int_base10(0) == Ok("0")
 }
 
 pub fn encode_int_base10_single_digit_test() -> Nil {
-  assert intid.encode_int_base10(7) == "7"
+  assert intid.encode_int_base10(7) == Ok("7")
 }
 
 pub fn encode_int_base10_carry_test() -> Nil {
-  assert intid.encode_int_base10(10) == "10"
+  assert intid.encode_int_base10(10) == Ok("10")
 }
 
 pub fn encode_int_base10_large_test() -> Nil {
-  assert intid.encode_int_base10(1_000_000_000) == "1000000000"
+  assert intid.encode_int_base10(1_000_000_000) == Ok("1000000000")
 }
 
 pub fn decode_int_base10_empty_test() -> Nil {
@@ -88,7 +89,7 @@ pub fn decode_int_base10_empty_test() -> Nil {
 }
 
 pub fn decode_int_base10_round_trip_test() -> Nil {
-  let encoded = intid.encode_int_base10(8_675_309)
+  let assert Ok(encoded) = intid.encode_int_base10(8_675_309)
   assert intid.decode_int_base10(encoded) == Ok(8_675_309)
 }
 
@@ -120,16 +121,16 @@ pub fn decode_int_base10_bounded_overflow_test() -> Nil {
 // === encoding.base16() (#85) ===
 
 pub fn encode_int_base16_zero_test() -> Nil {
-  assert intid.encode_int_base16(0) == "00"
+  assert intid.encode_int_base16(0) == Ok("00")
 }
 
 pub fn encode_int_base16_single_byte_test() -> Nil {
-  assert intid.encode_int_base16(255) == "FF"
+  assert intid.encode_int_base16(255) == Ok("FF")
 }
 
 pub fn encode_int_base16_canonical_uppercase_test() -> Nil {
   // Uses RFC 4648 §8 canonical uppercase, matching base16.encode.
-  assert intid.encode_int_base16(0xdeadbeef) == "DEADBEEF"
+  assert intid.encode_int_base16(0xdeadbeef) == Ok("DEADBEEF")
 }
 
 pub fn decode_int_base16_empty_test() -> Nil {
@@ -137,7 +138,7 @@ pub fn decode_int_base16_empty_test() -> Nil {
 }
 
 pub fn decode_int_base16_round_trip_test() -> Nil {
-  let encoded = intid.encode_int_base16(8_675_309)
+  let assert Ok(encoded) = intid.encode_int_base16(8_675_309)
   assert intid.decode_int_base16(encoded) == Ok(8_675_309)
 }
 
@@ -169,19 +170,19 @@ pub fn decode_int_base16_bounded_overflow_test() -> Nil {
 // === encoding.base36() ===
 
 pub fn encode_int_base36_zero_test() -> Nil {
-  assert intid.encode_int_base36(0) == "0"
+  assert intid.encode_int_base36(0) == Ok("0")
 }
 
 pub fn encode_int_base36_alphabet_max_test() -> Nil {
-  assert intid.encode_int_base36(35) == "z"
+  assert intid.encode_int_base36(35) == Ok("z")
 }
 
 pub fn encode_int_base36_carry_test() -> Nil {
-  assert intid.encode_int_base36(36) == "10"
+  assert intid.encode_int_base36(36) == Ok("10")
 }
 
 pub fn encode_int_base36_two_digit_max_test() -> Nil {
-  assert intid.encode_int_base36(1295) == "zz"
+  assert intid.encode_int_base36(1295) == Ok("zz")
 }
 
 pub fn decode_int_base36_empty_test() -> Nil {
@@ -193,7 +194,7 @@ pub fn decode_int_base36_leading_zero_tolerant_test() -> Nil {
 }
 
 pub fn decode_int_base36_roundtrip_test() -> Nil {
-  let encoded = intid.encode_int_base36(8_675_309)
+  let assert Ok(encoded) = intid.encode_int_base36(8_675_309)
   assert intid.decode_int_base36(encoded) == Ok(8_675_309)
 }
 
@@ -204,23 +205,23 @@ pub fn decode_int_base36_invalid_char_test() -> Nil {
 // === Base58 (Bitcoin) ===
 
 pub fn encode_int_base58_zero_test() -> Nil {
-  assert intid.encode_int_base58(0) == "1"
+  assert intid.encode_int_base58(0) == Ok("1")
 }
 
 pub fn encode_int_base58_small_test() -> Nil {
-  assert intid.encode_int_base58(42) == "j"
+  assert intid.encode_int_base58(42) == Ok("j")
 }
 
 pub fn encode_int_base58_alphabet_max_test() -> Nil {
-  assert intid.encode_int_base58(57) == "z"
+  assert intid.encode_int_base58(57) == Ok("z")
 }
 
 pub fn encode_int_base58_carry_test() -> Nil {
-  assert intid.encode_int_base58(58) == "21"
+  assert intid.encode_int_base58(58) == Ok("21")
 }
 
 pub fn encode_int_base58_two_digit_test() -> Nil {
-  assert intid.encode_int_base58(1234) == "NH"
+  assert intid.encode_int_base58(1234) == Ok("NH")
 }
 
 pub fn decode_int_base58_empty_test() -> Nil {
@@ -232,7 +233,7 @@ pub fn decode_int_base58_leading_zero_tolerant_test() -> Nil {
 }
 
 pub fn decode_int_base58_roundtrip_test() -> Nil {
-  let encoded = intid.encode_int_base58(9_999_999_999)
+  let assert Ok(encoded) = intid.encode_int_base58(9_999_999_999)
   assert intid.decode_int_base58(encoded) == Ok(9_999_999_999)
 }
 
@@ -243,15 +244,15 @@ pub fn decode_int_base58_invalid_char_test() -> Nil {
 // === Base58 (Flickr) ===
 
 pub fn encode_int_base58_flickr_zero_test() -> Nil {
-  assert intid.encode_int_base58_flickr(0) == "1"
+  assert intid.encode_int_base58_flickr(0) == Ok("1")
 }
 
 pub fn encode_int_base58_flickr_small_test() -> Nil {
-  assert intid.encode_int_base58_flickr(42) == "J"
+  assert intid.encode_int_base58_flickr(42) == Ok("J")
 }
 
 pub fn decode_int_base58_flickr_roundtrip_test() -> Nil {
-  let encoded = intid.encode_int_base58_flickr(1_234_567)
+  let assert Ok(encoded) = intid.encode_int_base58_flickr(1_234_567)
   assert intid.decode_int_base58_flickr(encoded) == Ok(1_234_567)
 }
 
@@ -262,19 +263,19 @@ pub fn decode_int_base58_flickr_empty_test() -> Nil {
 // === encoding.base62() ===
 
 pub fn encode_int_base62_zero_test() -> Nil {
-  assert intid.encode_int_base62(0) == "0"
+  assert intid.encode_int_base62(0) == Ok("0")
 }
 
 pub fn encode_int_base62_alphabet_max_test() -> Nil {
-  assert intid.encode_int_base62(61) == "z"
+  assert intid.encode_int_base62(61) == Ok("z")
 }
 
 pub fn encode_int_base62_carry_test() -> Nil {
-  assert intid.encode_int_base62(62) == "10"
+  assert intid.encode_int_base62(62) == Ok("10")
 }
 
 pub fn encode_int_base62_large_test() -> Nil {
-  assert intid.encode_int_base62(1_234_567_890) == "1LY7VK"
+  assert intid.encode_int_base62(1_234_567_890) == Ok("1LY7VK")
 }
 
 pub fn decode_int_base62_empty_test() -> Nil {
@@ -282,7 +283,7 @@ pub fn decode_int_base62_empty_test() -> Nil {
 }
 
 pub fn decode_int_base62_roundtrip_test() -> Nil {
-  let encoded = intid.encode_int_base62(2_147_483_647)
+  let assert Ok(encoded) = intid.encode_int_base62(2_147_483_647)
   assert intid.decode_int_base62(encoded) == Ok(2_147_483_647)
 }
 
@@ -290,14 +291,64 @@ pub fn decode_int_base62_leading_zero_tolerant_test() -> Nil {
   assert intid.decode_int_base62("00abc") == intid.decode_int_base62("abc")
 }
 
-// === Cross-cutting: negative inputs are absorbed as |n| ===
+// === Cross-cutting: negative inputs return Error(NegativeValue(_)) (#100) ===
 
-pub fn encode_int_base58_negative_normalized_test() -> Nil {
-  assert intid.encode_int_base58(-42) == intid.encode_int_base58(42)
+pub fn encode_int_base58_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base58(-42) == Error(NegativeValue(-42))
 }
 
-pub fn encode_int_base62_negative_normalized_test() -> Nil {
-  assert intid.encode_int_base62(-1) == intid.encode_int_base62(1)
+pub fn encode_int_base62_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base62(-1) == Error(NegativeValue(-1))
+}
+
+pub fn encode_int_base10_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base10(-1) == Error(NegativeValue(-1))
+}
+
+pub fn encode_int_base16_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base16(-42) == Error(NegativeValue(-42))
+}
+
+pub fn encode_int_base16_compact_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base16_compact(-1) == Error(NegativeValue(-1))
+}
+
+pub fn encode_int_base36_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base36(-1_000_000) == Error(NegativeValue(-1_000_000))
+}
+
+pub fn encode_int_base32_rfc4648_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base32_rfc4648(-7) == Error(NegativeValue(-7))
+}
+
+pub fn encode_int_base32_crockford_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base32_crockford(-7) == Error(NegativeValue(-7))
+}
+
+pub fn encode_int_base32_crockford_check_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base32_crockford_check(-1) == Error(NegativeValue(-1))
+}
+
+pub fn encode_int_base58_flickr_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base58_flickr(-42) == Error(NegativeValue(-42))
+}
+
+pub fn encode_int_base58check_negative_returns_error_test() -> Nil {
+  assert intid.encode_int_base58check(-1) == Error(NegativeValue(-1))
+}
+
+pub fn encode_int_facade_negative_returns_error_test() -> Nil {
+  // The facade routes negatives through the same `int_to_bytes_be`
+  // guard, so the surfaced error is identical for every codec.
+  assert intid.encode_int(encoding: encoding.base58_bitcoin(), value: -42)
+    == Error(NegativeValue(-42))
+}
+
+pub fn encode_int_facade_base58check_negative_returns_error_test() -> Nil {
+  // Base58Check goes through a separate code path (it concatenates a
+  // version byte before encoding), so pin its negative behaviour too.
+  assert intid.encode_int(encoding: encoding.base58_check(0), value: -1)
+    == Error(NegativeValue(-1))
 }
 
 // === Bounded decode: cap constants ===
@@ -315,13 +366,13 @@ pub fn int53_max_constant_test() -> Nil {
 // === Bounded decode: Base58 (Bitcoin) ===
 
 pub fn decode_int_base58_bounded_within_test() -> Nil {
-  let encoded = intid.encode_int_base58(42)
+  let assert Ok(encoded) = intid.encode_int_base58(42)
   assert intid.decode_int_base58_bounded(input: encoded, max: intid.int64_max)
     == Ok(42)
 }
 
 pub fn decode_int_base58_bounded_at_cap_test() -> Nil {
-  let encoded = intid.encode_int_base58(intid.int64_max)
+  let assert Ok(encoded) = intid.encode_int_base58(intid.int64_max)
   assert intid.decode_int_base58_bounded(input: encoded, max: intid.int64_max)
     == Ok(intid.int64_max)
 }
@@ -341,13 +392,13 @@ pub fn decode_int_base58_bounded_above_cap_test() -> Nil {
 
 @target(erlang)
 pub fn decode_int_base58_bounded_just_above_cap_test() -> Nil {
-  let encoded = intid.encode_int_base58(intid.int64_max + 1)
+  let assert Ok(encoded) = intid.encode_int_base58(intid.int64_max + 1)
   assert intid.decode_int_base58_bounded(input: encoded, max: intid.int64_max)
     == Error(Overflow)
 }
 
 pub fn decode_int_base58_bounded_int53_cap_test() -> Nil {
-  let encoded = intid.encode_int_base58(intid.int53_max + 1)
+  let assert Ok(encoded) = intid.encode_int_base58(intid.int53_max + 1)
   assert intid.decode_int_base58_bounded(input: encoded, max: intid.int53_max)
     == Error(Overflow)
 }
@@ -368,7 +419,7 @@ pub fn decode_int_base58_bounded_invalid_char_test() -> Nil {
 // === Bounded decode: Base58 (Flickr) ===
 
 pub fn decode_int_base58_flickr_bounded_within_test() -> Nil {
-  let encoded = intid.encode_int_base58_flickr(1234)
+  let assert Ok(encoded) = intid.encode_int_base58_flickr(1234)
   assert intid.decode_int_base58_flickr_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -378,7 +429,7 @@ pub fn decode_int_base58_flickr_bounded_within_test() -> Nil {
 
 @target(erlang)
 pub fn decode_int_base58_flickr_bounded_above_cap_test() -> Nil {
-  let encoded = intid.encode_int_base58_flickr(intid.int64_max + 1)
+  let assert Ok(encoded) = intid.encode_int_base58_flickr(intid.int64_max + 1)
   assert intid.decode_int_base58_flickr_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -389,20 +440,20 @@ pub fn decode_int_base58_flickr_bounded_above_cap_test() -> Nil {
 // === Bounded decode: encoding.base62() ===
 
 pub fn decode_int_base62_bounded_within_test() -> Nil {
-  let encoded = intid.encode_int_base62(2_147_483_647)
+  let assert Ok(encoded) = intid.encode_int_base62(2_147_483_647)
   assert intid.decode_int_base62_bounded(input: encoded, max: intid.int64_max)
     == Ok(2_147_483_647)
 }
 
 @target(erlang)
 pub fn decode_int_base62_bounded_above_cap_test() -> Nil {
-  let encoded = intid.encode_int_base62(intid.int64_max + 1)
+  let assert Ok(encoded) = intid.encode_int_base62(intid.int64_max + 1)
   assert intid.decode_int_base62_bounded(input: encoded, max: intid.int64_max)
     == Error(Overflow)
 }
 
 pub fn decode_int_base62_bounded_int53_within_test() -> Nil {
-  let encoded = intid.encode_int_base62(intid.int53_max)
+  let assert Ok(encoded) = intid.encode_int_base62(intid.int53_max)
   assert intid.decode_int_base62_bounded(input: encoded, max: intid.int53_max)
     == Ok(intid.int53_max)
 }
@@ -410,14 +461,14 @@ pub fn decode_int_base62_bounded_int53_within_test() -> Nil {
 // === Bounded decode: encoding.base36() ===
 
 pub fn decode_int_base36_bounded_within_test() -> Nil {
-  let encoded = intid.encode_int_base36(8_675_309)
+  let assert Ok(encoded) = intid.encode_int_base36(8_675_309)
   assert intid.decode_int_base36_bounded(input: encoded, max: intid.int64_max)
     == Ok(8_675_309)
 }
 
 @target(erlang)
 pub fn decode_int_base36_bounded_above_cap_test() -> Nil {
-  let encoded = intid.encode_int_base36(intid.int64_max + 1)
+  let assert Ok(encoded) = intid.encode_int_base36(intid.int64_max + 1)
   assert intid.decode_int_base36_bounded(input: encoded, max: intid.int64_max)
     == Error(Overflow)
 }
@@ -425,7 +476,7 @@ pub fn decode_int_base36_bounded_above_cap_test() -> Nil {
 // === Bounded decode: Base32 (RFC 4648) ===
 
 pub fn decode_int_base32_rfc4648_bounded_within_test() -> Nil {
-  let encoded = intid.encode_int_base32_rfc4648(1_234_567)
+  let assert Ok(encoded) = intid.encode_int_base32_rfc4648(1_234_567)
   assert intid.decode_int_base32_rfc4648_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -435,7 +486,7 @@ pub fn decode_int_base32_rfc4648_bounded_within_test() -> Nil {
 
 @target(erlang)
 pub fn decode_int_base32_rfc4648_bounded_above_cap_test() -> Nil {
-  let encoded = intid.encode_int_base32_rfc4648(intid.int64_max + 1)
+  let assert Ok(encoded) = intid.encode_int_base32_rfc4648(intid.int64_max + 1)
   assert intid.decode_int_base32_rfc4648_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -446,7 +497,7 @@ pub fn decode_int_base32_rfc4648_bounded_above_cap_test() -> Nil {
 // === Bounded decode: Base32 (Crockford) ===
 
 pub fn decode_int_base32_crockford_bounded_within_test() -> Nil {
-  let encoded = intid.encode_int_base32_crockford(987_654)
+  let assert Ok(encoded) = intid.encode_int_base32_crockford(987_654)
   assert intid.decode_int_base32_crockford_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -456,7 +507,8 @@ pub fn decode_int_base32_crockford_bounded_within_test() -> Nil {
 
 @target(erlang)
 pub fn decode_int_base32_crockford_bounded_above_cap_test() -> Nil {
-  let encoded = intid.encode_int_base32_crockford(intid.int64_max + 1)
+  let assert Ok(encoded) =
+    intid.encode_int_base32_crockford(intid.int64_max + 1)
   assert intid.decode_int_base32_crockford_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -468,11 +520,11 @@ pub fn decode_int_base32_crockford_bounded_above_cap_test() -> Nil {
 
 pub fn encode_int_base32_crockford_check_zero_test() -> Nil {
   // 0 encoded as Crockford "0" then check digit for 0 mod 37 == "0".
-  assert intid.encode_int_base32_crockford_check(0) == "00"
+  assert intid.encode_int_base32_crockford_check(0) == Ok("00")
 }
 
 pub fn decode_int_base32_crockford_check_roundtrip_test() -> Nil {
-  let encoded = intid.encode_int_base32_crockford_check(987_654)
+  let assert Ok(encoded) = intid.encode_int_base32_crockford_check(987_654)
   assert intid.decode_int_base32_crockford_check(encoded) == Ok(987_654)
 }
 
@@ -484,7 +536,7 @@ pub fn decode_int_base32_crockford_check_detects_typo_test() -> Nil {
   // Take a valid checksummed encoding and mutate one body character.
   // The decoder must reject the typo via InvalidChecksum, which is the
   // whole reason callers reach for the `_check` variant.
-  let encoded = intid.encode_int_base32_crockford_check(123_456)
+  let assert Ok(encoded) = intid.encode_int_base32_crockford_check(123_456)
   let body = string_drop_last(encoded)
   let check = string_take_last(encoded)
   let mutated = mutate_first_body_char(body) <> check
@@ -493,7 +545,7 @@ pub fn decode_int_base32_crockford_check_detects_typo_test() -> Nil {
 }
 
 pub fn decode_int_base32_crockford_check_bounded_within_test() -> Nil {
-  let encoded = intid.encode_int_base32_crockford_check(42)
+  let assert Ok(encoded) = intid.encode_int_base32_crockford_check(42)
   assert intid.decode_int_base32_crockford_check_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -503,7 +555,8 @@ pub fn decode_int_base32_crockford_check_bounded_within_test() -> Nil {
 
 @target(erlang)
 pub fn decode_int_base32_crockford_check_bounded_above_cap_test() -> Nil {
-  let encoded = intid.encode_int_base32_crockford_check(intid.int64_max + 1)
+  let assert Ok(encoded) =
+    intid.encode_int_base32_crockford_check(intid.int64_max + 1)
   assert intid.decode_int_base32_crockford_check_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -522,13 +575,13 @@ pub fn decode_int_base32_crockford_check_bounded_above_cap_test() -> Nil {
 
 @target(erlang)
 pub fn encode_int_base58check_zero_roundtrips_test() -> Nil {
-  let encoded = intid.encode_int_base58check(0)
+  let assert Ok(encoded) = intid.encode_int_base58check(0)
   assert intid.decode_int_base58check(encoded) == Ok(0)
 }
 
 @target(erlang)
 pub fn decode_int_base58check_roundtrip_test() -> Nil {
-  let encoded = intid.encode_int_base58check(9_999_999_999)
+  let assert Ok(encoded) = intid.encode_int_base58check(9_999_999_999)
   assert intid.decode_int_base58check(encoded) == Ok(9_999_999_999)
 }
 
@@ -541,14 +594,14 @@ pub fn decode_int_base58check_detects_typo_test() -> Nil {
   // Mutate the first checksum-bearing position. Base58Check's 4-byte
   // SHA-256 suffix means this *must* fail — that is the property the
   // helper exists to guarantee for callers.
-  let encoded = intid.encode_int_base58check(424_242)
+  let assert Ok(encoded) = intid.encode_int_base58check(424_242)
   let mutated = mutate_first_body_char(encoded)
   assert intid.decode_int_base58check(mutated) == Error(InvalidChecksum)
 }
 
 @target(erlang)
 pub fn decode_int_base58check_bounded_within_test() -> Nil {
-  let encoded = intid.encode_int_base58check(1234)
+  let assert Ok(encoded) = intid.encode_int_base58check(1234)
   assert intid.decode_int_base58check_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -558,7 +611,7 @@ pub fn decode_int_base58check_bounded_within_test() -> Nil {
 
 @target(erlang)
 pub fn decode_int_base58check_bounded_above_cap_test() -> Nil {
-  let encoded = intid.encode_int_base58check(intid.int64_max + 1)
+  let assert Ok(encoded) = intid.encode_int_base58check(intid.int64_max + 1)
   assert intid.decode_int_base58check_bounded(
       input: encoded,
       max: intid.int64_max,
@@ -625,24 +678,23 @@ fn decode_job_id(s: String) -> Result(Int, intid.CodecError) {
 pub fn encode_int_facade_matches_per_base_base58_test() -> Nil {
   let direct = intid.encode_int_base58(42)
   assert intid.encode_int(encoding: encoding.base58_bitcoin(), value: 42)
-    == Ok(direct)
+    == direct
 }
 
 pub fn encode_int_facade_matches_per_base_base32_crockford_test() -> Nil {
   let direct = intid.encode_int_base32_crockford(31)
   assert intid.encode_int(encoding: encoding.base32_crockford(), value: 31)
-    == Ok(direct)
+    == direct
 }
 
 pub fn encode_int_facade_matches_per_base_base62_test() -> Nil {
   let direct = intid.encode_int_base62(123_456)
-  assert intid.encode_int(encoding: encoding.base62(), value: 123_456)
-    == Ok(direct)
+  assert intid.encode_int(encoding: encoding.base62(), value: 123_456) == direct
 }
 
 pub fn encode_int_facade_matches_per_base_base16_test() -> Nil {
   let direct = intid.encode_int_base16(255)
-  assert intid.encode_int(encoding: encoding.base16(), value: 255) == Ok(direct)
+  assert intid.encode_int(encoding: encoding.base16(), value: 255) == direct
 }
 
 pub fn encode_int_facade_unsupported_base64_test() -> Nil {
@@ -658,7 +710,7 @@ pub fn encode_int_facade_unsupported_bech32_test() -> Nil {
 }
 
 pub fn decode_int_facade_matches_per_base_base58_test() -> Nil {
-  let encoded = intid.encode_int_base58(42)
+  let assert Ok(encoded) = intid.encode_int_base58(42)
   assert intid.decode_int(encoding: encoding.base58_bitcoin(), value: encoded)
     == Ok(42)
 }

--- a/test/regression_encode_int_base16_compact_test.gleam
+++ b/test/regression_encode_int_base16_compact_test.gleam
@@ -13,13 +13,13 @@ pub fn encode_int_base16_compact_one_test() -> Nil {
   // `encode_int_base16(1) == "01"`; the compact variant drops the
   // leading-zero pad to match `encode_int_base58(1) == "2"` /
   // `encode_int_base36(1) == "1"` / `encode_int_base10(1) == "1"`.
-  assert intid.encode_int_base16_compact(1) == "1"
+  assert intid.encode_int_base16_compact(1) == Ok("1")
 }
 
 pub fn encode_int_base16_compact_2025_test() -> Nil {
   // `encode_int_base16(2025) == "07E9"`; the compact form is the
   // canonical three-nibble hex.
-  assert intid.encode_int_base16_compact(2025) == "7E9"
+  assert intid.encode_int_base16_compact(2025) == Ok("7E9")
 }
 
 pub fn encode_int_base16_compact_zero_test() -> Nil {
@@ -27,26 +27,26 @@ pub fn encode_int_base16_compact_zero_test() -> Nil {
   // `encode_int_base10(0) == "0"` /
   // `encode_int_base36(0) == "0"` /
   // `encode_int_base32_crockford(0) == "0"`.
-  assert intid.encode_int_base16_compact(0) == "0"
+  assert intid.encode_int_base16_compact(0) == Ok("0")
 }
 
 pub fn encode_int_base16_compact_single_byte_test() -> Nil {
   // Values that already occupy a whole byte (no leading zero
   // nibble) pass through unchanged.
-  assert intid.encode_int_base16_compact(255) == "FF"
+  assert intid.encode_int_base16_compact(255) == Ok("FF")
 }
 
 pub fn encode_int_base16_compact_canonical_uppercase_test() -> Nil {
   // Compact output uses the same canonical RFC 4648 §8 uppercase
   // alphabet as `encode_int_base16/1`.
-  assert intid.encode_int_base16_compact(0xdeadbeef) == "DEADBEEF"
+  assert intid.encode_int_base16_compact(0xdeadbeef) == Ok("DEADBEEF")
 }
 
 pub fn encode_int_base16_compact_large_test() -> Nil {
   // Large value with a leading zero nibble — the compact form
   // strips exactly one `"0"` while preserving every interior digit.
   // `0x0abcdef0` -> byte-aligned "0ABCDEF0" -> compact "ABCDEF0".
-  assert intid.encode_int_base16_compact(0x0abcdef0) == "ABCDEF0"
+  assert intid.encode_int_base16_compact(0x0abcdef0) == Ok("ABCDEF0")
 }
 
 pub fn encode_int_base16_compact_round_trip_test() -> Nil {
@@ -54,7 +54,7 @@ pub fn encode_int_base16_compact_round_trip_test() -> Nil {
   // of any-length hex input, so the compact encoder's output feeds
   // back to the same `Int` without the caller having to know about
   // the byte-aligned vs compact distinction.
-  let encoded = intid.encode_int_base16_compact(8_675_309)
+  let assert Ok(encoded) = intid.encode_int_base16_compact(8_675_309)
   assert intid.decode_int_base16(encoded) == Ok(8_675_309)
 }
 
@@ -62,13 +62,15 @@ pub fn encode_int_base16_compact_round_trip_odd_length_test() -> Nil {
   // The compact form of `1` is the odd-length `"1"`; this pins that
   // `decode_int_base16` accepts odd-length input (zero-padding to
   // the next byte boundary internally).
-  assert intid.decode_int_base16(intid.encode_int_base16_compact(1)) == Ok(1)
+  let assert Ok(encoded) = intid.encode_int_base16_compact(1)
+  assert intid.decode_int_base16(encoded) == Ok(1)
 }
 
 pub fn encode_int_base16_compact_round_trip_zero_test() -> Nil {
   // Magnitude-zero must also round-trip — `"0"` decodes back to `0`
   // even though it is a single odd-length character.
-  assert intid.decode_int_base16(intid.encode_int_base16_compact(0)) == Ok(0)
+  let assert Ok(encoded) = intid.encode_int_base16_compact(0)
+  assert intid.decode_int_base16(encoded) == Ok(0)
 }
 
 pub fn encode_int_base16_byte_aligned_unchanged_test() -> Nil {
@@ -76,12 +78,12 @@ pub fn encode_int_base16_byte_aligned_unchanged_test() -> Nil {
   // must keep its leading-zero pad — callers relying on the even-
   // length contract (DB hex columns, HTTP headers, content-
   // addressable storage) cannot tolerate a silent shape change.
-  assert intid.encode_int_base16(1) == "01"
+  assert intid.encode_int_base16(1) == Ok("01")
 }
 
 pub fn encode_int_base16_byte_aligned_2025_unchanged_test() -> Nil {
   // Same regression with the value the issue cited as the example
   // of the asymmetry; locks in `"07E9"` so the byte-aligned encoder
   // stays four characters wide for two-byte magnitudes.
-  assert intid.encode_int_base16(2025) == "07E9"
+  assert intid.encode_int_base16(2025) == Ok("07E9")
 }


### PR DESCRIPTION
## Summary

`intid.encode_int_*` 系は `int.absolute_value` で符号を silent に落としていたため、`decode(encode(n)) == n` が `n < 0` で恒久的に壊れていた (`encode_int_base58(-42) == encode_int_base58(42) == "j"`)。

これを fail-loud にする方針 (Issue #100 の「方針 A」) を採用:

- 戻り型を `String` → `Result(String, CodecError)` に変更
- `CodecError` に `NegativeValue(value: Int)` バリアントを追加
- `int_to_bytes_be` で `value < 0` をガードして `Error(NegativeValue(value))` を返す
- doc-comment / README / CHANGELOG をすべて新しい契約に追従

closed #84 で同じ症状が報告されていたが、コメントなしで closed のまま残っていたので、本 PR で改めて再発防止を担保する。

## Changes

- `src/yabase/core/error.gleam`: `CodecError` に `NegativeValue(value: Int)` を追加
- `src/yabase/intid.gleam`: 全 `encode_int_*` を `Result(String, CodecError)` 化、`int_to_bytes_be` も Result 化、`encode_int` ファサードも対応
- `README.md`: "Negative inputs are normalized via `int.absolute_value`" の記述を新しい契約に置き換え、ID 例コードのアンラップ追加
- `CHANGELOG.md`: `[Unreleased]` に BREAKING CHANGE エントリを追記
- `test/intid_test.gleam`: 既存 `encode_int_*` テストを `== Ok("...")` に追従、`negative_normalized` ペアを `Error(NegativeValue(_))` の全 codec カバーに置換 (Base58 / Base62 / Base10 / Base16 / Base16_compact / Base36 / Base32_rfc4648 / Base32_crockford / Base32_crockford_check / Base58_flickr / Base58check / facade)
- `test/regression_encode_int_base16_compact_test.gleam`: 同じく `== Ok(...)` 化、odd-length round-trip もアンラップ追加

## Test plan

- [x] `just check` 全 pass (format check / glinter / typecheck / build --warnings-as-errors / 845 tests / examples build / verify-readme.sh)
- [x] 845 tests passed, no failures
- [x] 新規 negative-value テスト 13 件を含む (#100 の Acceptance Criteria より広い範囲をカバー)

Closes #100.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * All integer-to-string encoding functions now return results to handle errors explicitly. Negative integer inputs are rejected instead of being silently converted to absolute values.

* **Documentation**
  * Updated reference documentation, tutorials, and code examples to reflect the new error-handling behavior and stricter input validation for negative values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/yabase/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->