### PR TITLE
chore(release): prepare v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-21
+
 ### Added
 
 - `intid.encode_int_base16_compact/1`: leading-zero-dropping companion to the existing byte-aligned `intid.encode_int_base16/1`, so the `encode_int_*` family now has a uniform compact variant across base10/base16/base36/base58/base62 (`encode_int_base16_compact(1) == Ok("1")`, `encode_int_base16_compact(2025) == Ok("7E9")`); the byte-aligned `encode_int_base16/1` is unchanged. `intid.decode_int_base16/1` now also accepts odd-length input (internally zero-padded on the left), so `decode_int_base16(encode_int_base16_compact(n) |> result.unwrap_or("")) == Ok(n)` round-trips for every non-negative `Int`; the low-level `base16.decode/1` keeps its strict even-length contract. (#99)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "yabase"
-version = "0.21.0"
+version = "0.22.0"
 description = "Unified binary-to-text encoding: base2, base8, base10, base16, base32, base36, base45, base58, base58check, base62, base64, base85, base91, ascii85, z85, bech32, bech32m, multibase"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "yabase" }


### PR DESCRIPTION
### Added

- `intid.encode_int_base16_compact/1`: leading-zero-dropping companion to the existing byte-aligned `intid.encode_int_base16/1`, so the `encode_int_*` family now has a uniform compact variant across base10/base16/base36/base58/base62 (`encode_int_base16_compact(1) == Ok("1")`, `encode_int_base16_compact(2025) == Ok("7E9")`); the byte-aligned `encode_int_base16/1` is unchanged. `intid.decode_int_base16/1` now also accepts odd-length input (internally zero-padded on the left), so `decode_int_base16(encode_int_base16_compact(n) |> result.unwrap_or("")) == Ok(n)` round-trips for every non-negative `Int`; the low-level `base16.decode/1` keeps its strict even-length contract. (#99)

### Changed

- **BREAKING**: every `intid.encode_int_*` function now returns `Result(String, CodecError)` instead of `String`, and rejects negative inputs with the new `Error(NegativeValue(value))` variant on `CodecError`. The previous behaviour silently absolutized negatives via `int.absolute_value`, which broke the `decode(encode(n)) == n` round-trip whenever `n < 0` and let two distinct inputs (`-1` and `1`) collide on the same encoded string. Callers that fed only non-negative values into `encode_int_*` need to unwrap the new `Result` (either `let assert Ok(s) = ...` for known-safe call sites, or `result.map` / `case` for ones that already accept negatives at the boundary). The new `NegativeValue(value: Int)` variant on `CodecError` is exported via the existing `yabase/core/error` and the `intid.CodecError` re-export. Closed #84; regressed in #100. (#100)
- **BREAKING**: `intid.decode_int_base58` (and `decode_int_base58_bounded`) now enforces canonical wire form. Inputs that decode to a value `n` but are not byte-equal to `encode_int_base58(n)` — the previously-tolerated leading-`"1"` aliases such as `"15Q"`, `"115Q"`, `"1115Q"` — return `Error(NonCanonical)` instead of `Ok(255)`. `"1"` alone remains the canonical encoding of `0` and decodes to `Ok(0)`; only **extra** leading `"1"` characters are rejected. This closes the silent-duplicate-ID surface for ID callers (URL shorteners, idempotency keys, database lookups, cache keys) where two distinct wire strings used to name the same row, breaking deduplication and cache invariants. The other `decode_int_*` codecs (base10 / base16 / base32 RFC 4648 / Crockford / Crockford-Check / base36 / base58 Flickr / base62) still accept leading zero characters leniently; applying the same canonical-form check to them consistently is tracked as a follow-up. The `NonCanonical` variant on `CodecError` is the existing one already used by `base16.decode_strict` / `base32/rfc4648.decode_strict` / `base64/standard.decode_strict`, so callers that already pattern-match `Error(NonCanonical)` for those strict decoders inherit the same shape here without a new variant to handle. Closes #101. (#101)
